### PR TITLE
fixes std::setprecision errors

### DIFF
--- a/src/core/moves/compound/ConjugateInverseWishartBrownianMove.cpp
+++ b/src/core/moves/compound/ConjugateInverseWishartBrownianMove.cpp
@@ -6,6 +6,7 @@
 #include "ConjugateInverseWishartBrownianMove.h"
 
 #include <cmath>
+#include <iomanip>
 
 using namespace RevBayesCore;
 

--- a/src/core/moves/compound/RateAgeBetaShift.cpp
+++ b/src/core/moves/compound/RateAgeBetaShift.cpp
@@ -6,6 +6,7 @@
 #include "TreeUtilities.h"
 
 #include <cmath>
+#include <iomanip>
 
 using namespace RevBayesCore;
 


### PR DESCRIPTION
I tried to build the latest merge into master from develop on a recent Arch Linux, however I got two compile errors regarding `std::setprecision` not being found. This PR fixes these problems.