### PR TITLE
adds `make install` target

### DIFF
--- a/projects/cmake/regenerate.sh
+++ b/projects/cmake/regenerate.sh
@@ -176,12 +176,14 @@ if [ "$mpi" = "true" ]
 then
 echo '
 add_executable(rb-mpi ${PROJECT_SOURCE_DIR}/revlanguage/main.cpp)
+install(TARGETS rb-mpi DESTINATION bin)
 
 target_link_libraries(rb-mpi rb-parser rb-core libs ${Boost_LIBRARIES} ${MPI_LIBRARIES})
 ' >> $HERE/CMakeLists.txt
 else
 echo '
 add_executable(rb ${PROJECT_SOURCE_DIR}/revlanguage/main.cpp)
+install(TARGETS rb DESTINATION bin)
 
 target_link_libraries(rb rb-parser rb-core libs ${Boost_LIBRARIES})
 ' >> $HERE/CMakeLists.txt


### PR DESCRIPTION
When building with cmake, you now can automatically install.

This may not sound like much, considering there is only a single executable installed, either `rb` or `rb-mpi`. However, from the perspective of someone who maintains software for Linux distributions it is much more convenient to use the standard approach of:

```
cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release ...
make
make install
```

... rather than the manual workflow.
