### PR TITLE
Fix Ctrl-D/Ctrl-C entered in REPL from resulting in segfault

### DIFF
--- a/src/revlanguage/ui/RevClient.cpp
+++ b/src/revlanguage/ui/RevClient.cpp
@@ -328,29 +328,42 @@ void RevClient::startInterpretor( void )
         {
             line = linenoise(prompt);
             
-            linenoiseHistoryAdd(line);              /* Add to the history. */
-            linenoiseHistorySave("history.txt");    /* Save the history on disk. */
-        
-            cmd = line;
-            boost::trim(cmd);
-
-            if (cmd == "clr" || cmd == "clear")
+            if (!line) 
             {
-                linenoiseClearScreen();
+                // [JS, 2015-11-03]
+                // Null input, e.g. if the user entered CTRL-D or CTRL-C.
+                // If not handled here, segmentation fault results. Not a dealbreaker, but annoying.
+                // There might be a more elegant way to do this, but right now, until I get
+                // more familiar with the codebase or somebody else cares to improve it, we are
+                // just going to replace the input with the intention, i.e. to quit, and let
+                // the existing logic handle it.
+                commandLine = "q();";
             }
             else
             {
-                // interpret Rev statement
-                if (result == 0 || result == 2)
+                linenoiseHistoryAdd(line);              /* Add to the history. */
+                linenoiseHistorySave("history.txt");    /* Save the history on disk. */
+           
+                cmd = line;
+                boost::trim(cmd);
+
+                if (cmd == "clr" || cmd == "clear")
                 {
-                    commandLine = cmd;
+                    linenoiseClearScreen();
                 }
-                else //if (result == 1)
+                else
                 {
-                    commandLine += "; " + cmd;
+                    // interpret Rev statement
+                    if (result == 0 || result == 2)
+                    {
+                        commandLine = cmd;
+                    }
+                    else //if (result == 1)
+                    {
+                        commandLine += "; " + cmd;
+                    }
                 }
             }
-            
         }
         
         size_t bsz = commandLine.size();


### PR DESCRIPTION
The REPL when built using XCode correctly checks for null input. But it appears that when built in cmake a different code base is hit for the REPL? This one fails to handle null input, such as when the user enters CTRL-D or CTRL-C. 

This patch fixes it in a rather clumsy way: by injecting a 'q();' command into the processing pipeline. It ain't pretty, but it (seems to) work!