### PR TITLE
Fix cxx11 compile

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('RevBayes', ['cpp', 'c'],
         version: '1.0.12',
         default_options: [
           'buildtype=release',
-          'cpp_std=c++14'
+          'cpp_std=c++11'
         ],
         meson_version: '>= 0.47',
         license: 'GPLv2')

--- a/projects/cmake/regenerate.sh
+++ b/projects/cmake/regenerate.sh
@@ -101,7 +101,12 @@ project(RevBayes)
 #    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -Wall -g -pg")
 #endif ()
 
-set(CMAKE_CXX_STANDARD 11)
+# This is the RIGHT way, but requires cmake version >=3:
+#   set(CMAKE_CXX_STANDARD 11)
+# RHEL 7 compute clusters may have cmake 2.8.12
+#
+# So, we add the flag directly instead.
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
 ' > "$HERE/CMakeLists.txt"
 

--- a/projects/cmake/regenerate.sh
+++ b/projects/cmake/regenerate.sh
@@ -101,7 +101,7 @@ project(RevBayes)
 #    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -Wall -g -pg")
 #endif ()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_STANDARD 11)
 
 ' > "$HERE/CMakeLists.txt"
 

--- a/projects/cmake/regenerate.sh
+++ b/projects/cmake/regenerate.sh
@@ -101,6 +101,8 @@ project(RevBayes)
 #    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -Wall -g -pg")
 #endif ()
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+
 ' > "$HERE/CMakeLists.txt"
 
 if [ "$debug" = "true" ]
@@ -123,7 +125,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3")
 elif [ "$win" = "true" ]
 then
 echo '
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -msse -msse2 -msse3 -static -std=gnu++98")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -msse -msse2 -msse3 -static")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3 -static")
 '  >> "$HERE/CMakeLists.txt"
 else

--- a/src/core/monitors/Monitor.cpp
+++ b/src/core/monitors/Monitor.cpp
@@ -8,13 +8,13 @@ using namespace RevBayesCore;
 Monitor::Monitor(unsigned long g) :
     enabled( true ),
     printgen( g ),
-    model( NULL )
+    model( nullptr )
 {}
 
 Monitor::Monitor(unsigned long g, DagNode *n) :
     enabled( true ),
     printgen( g ),
-    model( NULL )
+    model( nullptr )
 {
     
     nodes.push_back( n );
@@ -31,7 +31,7 @@ Monitor::Monitor(unsigned long g, const std::vector<DagNode *> &n) :
     enabled( true ),
     printgen( g ),
     nodes( n ),
-    model( NULL )
+    model( nullptr )
 {
     
     for (std::vector<DagNode*>::iterator it = nodes.begin(); it != nodes.end(); it++)

--- a/src/core/moves/SliceSamplingMove.cpp
+++ b/src/core/moves/SliceSamplingMove.cpp
@@ -124,9 +124,8 @@ public:
         lnPrior += variable->getLnProbability();
 
         // 2. then we recompute the probability for all the affected nodes
-        for (RbOrderedSet<DagNode*>::iterator it = affectedNodes.begin(); it != affectedNodes.end(); ++it)
+        for (auto& node: affectedNodes)
         {
-            DagNode* node = *it;
             if ( node->isClamped() )
                 lnLikelihood += node->getLnProbability();
             else


### PR DESCRIPTION
Hi,

This should fix some compile issues with the current tree.  We currently have `auto` in a number of different places, which should fail with -std=c++98.

I tested this on the Duke cluster with the system gcc (4.8.5).  I put the `nullptr` changes back in to make sure that we are actually testing c++11, and it seems to work.

One unfortunate thing is that RHEL7 (which is what the Duke cluster is using) does not have cmake version 3.  Therefore I had to use the `-std` flag directly to make sure this works on older clusters, instead of using the more correct `set(CMAKE_CXX_STANDARD)` that appears in cmake version 3.  We can find a more beautiful solution later, but this one works for now.

-BenRI