### PR TITLE
setNumStates bug fix

### DIFF
--- a/src/revlanguage/datatypes/phylogenetics/characterdata/RlAbstractHomologousDiscreteCharacterData.cpp
+++ b/src/revlanguage/datatypes/phylogenetics/characterdata/RlAbstractHomologousDiscreteCharacterData.cpp
@@ -437,7 +437,7 @@ RevPtr<RevVariable> AbstractHomologousDiscreteCharacterData::executeMethod(std::
                         {
                             if (state.isSet(k) && k +1 > max)
                             {
-                                max = k+1;
+                                max = static_cast<int>(k)+1;
                             }
                         }
                     }

--- a/src/revlanguage/datatypes/phylogenetics/characterdata/RlAbstractHomologousDiscreteCharacterData.cpp
+++ b/src/revlanguage/datatypes/phylogenetics/characterdata/RlAbstractHomologousDiscreteCharacterData.cpp
@@ -437,7 +437,7 @@ RevPtr<RevVariable> AbstractHomologousDiscreteCharacterData::executeMethod(std::
                         {
                             if (state.isSet(k) && k +1 > max)
                             {
-                                max = (int)(k+1);
+                                max = k+1;
                             }
                         }
                     }


### PR DESCRIPTION
**Problem:** C-style cast was causing automated partitioning by number of character states for morphological data to fail. [These](https://github.com/graemetlloyd/ProjectWhalehead/tree/master/rb_scripts) two scripts, for example, fail with: 

```
> source("rb_scripts/mcmc_7states.Rev")
   Processing file "rb_scripts/mcmc_7states.Rev"
   Successfully read one character matrix from file 'Data/NEXUS/Dalla_Vecchia_2009a.nex'
   Processing file "rb_scripts/mk_7states.Rev"
   2

   Standard character matrix with 25 taxa and 121 characters
   =========================================================
   Origination:                   Dalla_Vecchia_2009a.nex
   Number of taxa:                25
   Number of included taxa:       25
   Number of characters:          121
   Number of included characters: 72
   Datatype:                      Standard

   [ [ -1.0000, 1.0000 ] ,
     [ 1.0000, -1.0000 ] ]
   Error:	The number of observed states (7) is greater than the dimension of the Q matrix (2)
   Error:	Problem processing line 54 in file "rb_scripts/mk_7states.Rev"
   Error:	Problem processing line 11 in file "rb_scripts/mcmc_7states.Rev
```

As the number of character states in the partition fails to reset, and remains set to the maximum number of states for any character in the matrix.

**Solution:** Move to C++ style cast.

