### PR TITLE
Documentation for math distributions, nucleotide rate matrix functions

### DIFF
--- a/src/core/distributions/math/LognormalDistribution.cpp
+++ b/src/core/distributions/math/LognormalDistribution.cpp
@@ -10,6 +10,11 @@ namespace RevBayesCore { class DagNode; }
 
 using namespace RevBayesCore;
 
+/** Lognormal distribution constructor
+ * @param m The mean of the natural logarithm of the variable
+ * @param s The standard deviation of the natural logarithm of the variable
+ */
+
 LognormalDistribution::LognormalDistribution(const TypedDagNode<double> *m, const TypedDagNode<double> *s) : ContinuousDistribution( new double( 1.0 ) ),
     mean( m ), 
     sd( s )

--- a/src/core/distributions/math/LognormalDistribution.h
+++ b/src/core/distributions/math/LognormalDistribution.h
@@ -31,7 +31,7 @@ template <class valueType> class TypedDagNode;
         double                                              computeLnProbability(void);
         double                                              getMax(void) const;
         double                                              getMin(void) const;
-        double                                              quantile(double p) const;                                                       //!< Qu
+        double                                              quantile(double p) const;                                                   
         void                                                redrawValue(void);
         const TypedDagNode<double>*                         getMean() const {return mean;}
         const TypedDagNode<double>*                         getStDev() const {return sd;}

--- a/src/core/distributions/math/LognormalDistribution.h
+++ b/src/core/distributions/math/LognormalDistribution.h
@@ -6,6 +6,18 @@
 namespace RevBayesCore {
 class DagNode;
 template <class valueType> class TypedDagNode;
+
+/**
+ * @brief Lognormal distribution class.
+ *
+ * The lognormal distribution represents a family of distributions
+ * defined on positive real numbers. The lognormal distribution has 2 parameters:
+ * @param m The mean of the natural logarithm of the variable
+ * @param s The standard deviation of the natural logarithm of the variable
+ *
+ * Instances of this class can be associated to stochastic variables.
+ *
+ */
     
     class LognormalDistribution : public ContinuousDistribution {
         

--- a/src/core/distributions/math/LognormalWithOffsetDistribution.cpp
+++ b/src/core/distributions/math/LognormalWithOffsetDistribution.cpp
@@ -10,6 +10,12 @@ namespace RevBayesCore { class DagNode; }
 
 using namespace RevBayesCore;
 
+/** LogNormalWithOffsetDistribution constructor
+ * @param m The mean of the natural logarithm of the variable
+ * @param s The standard deviation of the natural logarithm of the variable
+ * @param o Offset
+*/
+
 LognormalWithOffsetDistribution::LognormalWithOffsetDistribution(const TypedDagNode<double> *m, const TypedDagNode<double> *s, const TypedDagNode<double> *o) : ContinuousDistribution( new double( 1.0 ) ),
     mean( m ),
     sd( s ),

--- a/src/core/distributions/math/LognormalWithOffsetDistribution.h
+++ b/src/core/distributions/math/LognormalWithOffsetDistribution.h
@@ -27,6 +27,19 @@
 namespace RevBayesCore {
 class DagNode;
 template <class valueType> class TypedDagNode;
+
+/**
+ * @brief LognormalWithOffset distribution class.
+ *
+ * The LognormalWithOffset distribution represents a family of distributions defined on those positive real numbers
+ * that are greater than the value of the offset parameter. The LognormalWithOffset distribution has 3 parameters:
+ * @param m The mean of the natural logarithm of the variable
+ * @param s The standard deviation of the natural logarithm of the variable
+ * @param o Offset
+ *
+ * Instances of this class can be associated to stochastic variables.
+ *
+ */
     
     class LognormalWithOffsetDistribution : public ContinuousDistribution {
         

--- a/src/core/distributions/math/LognormalWithOffsetDistribution.h
+++ b/src/core/distributions/math/LognormalWithOffsetDistribution.h
@@ -29,7 +29,7 @@ class DagNode;
 template <class valueType> class TypedDagNode;
 
 /**
- * @brief LognormalWithOffset distribution class.
+ * @brief Lognormal distribution with offset.
  *
  * The LognormalWithOffset distribution represents a family of distributions defined on those positive real numbers
  * that are greater than the value of the offset parameter. The LognormalWithOffset distribution has 3 parameters:
@@ -53,7 +53,7 @@ template <class valueType> class TypedDagNode;
         double                                              computeLnProbability(void);
         double                                              getMax(void) const;
         double                                              getMin(void) const;
-        double                                              quantile(double p) const;                                                       //!< Qu
+        double                                              quantile(double p) const;                                                   
         void                                                redrawValue(void);
         
     protected:

--- a/src/core/distributions/math/NegativeBinomialDistribution.cpp
+++ b/src/core/distributions/math/NegativeBinomialDistribution.cpp
@@ -9,7 +9,7 @@ namespace RevBayesCore { class DagNode; }
 
 using namespace RevBayesCore;
 
-/** NegatvieBinomialDistribution Constructor
+/** NegativeBinomialDistribution Constructor
  * @param m the number of failures
  * @param q the probability of success
  *

--- a/src/core/distributions/math/NormalDistribution.h
+++ b/src/core/distributions/math/NormalDistribution.h
@@ -35,7 +35,7 @@ template <class valueType> class TypedDagNode;
         double                                              computeLnProbability(void);
         double                                              getMax(void) const;
         double                                              getMin(void) const;
-        double                                              quantile(double p) const;                                                       //!< Qu
+        double                                              quantile(double p) const;                                                   
         void                                                redrawValue(void);
         const TypedDagNode<double>*                         getMean() const {return mean;}
         const TypedDagNode<double>*                         getStDev() const {return stDev;}

--- a/src/core/distributions/math/NormalDistribution.h
+++ b/src/core/distributions/math/NormalDistribution.h
@@ -13,7 +13,7 @@ template <class valueType> class TypedDagNode;
      *@brief Normal distribution class.
      *
      *The Normal distribution represents a family of distributions
-     * on the set of rational numbers. The Normal distribution has 2 parameters:
+     * on the set of real numbers. The Normal distribution has 2 parameters:
      * @param m  the mean
      * @param s the standard deviation
      *

--- a/src/core/functions/phylogenetics/ratematrix/HkyRateMatrixFunction.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/HkyRateMatrixFunction.cpp
@@ -17,8 +17,6 @@ using namespace RevBayesCore;
  * This function takes two inputs:
  * @param k The transition-transversion ratio (kappa)
  * @param bf The simplex of base frequencies
- *
- * @return A HKY rate matrix object.
  */
 
 HkyRateMatrixFunction::HkyRateMatrixFunction(const TypedDagNode<double> *k, const TypedDagNode< Simplex > *bf) : TypedFunction<RateGenerator>( new RateMatrix_HKY() ),

--- a/src/core/functions/phylogenetics/ratematrix/HkyRateMatrixFunction.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/HkyRateMatrixFunction.cpp
@@ -11,6 +11,15 @@ namespace RevBayesCore { class DagNode; }
 
 using namespace RevBayesCore;
 
+/**
+ * Default constructor.
+ *
+ * This function takes two inputs:
+ * @param k The transition-transversion ratio (kappa)
+ * @param bf The simplex of base frequencies
+ *
+ * @return A HKY rate matrix object.
+ */
 
 HkyRateMatrixFunction::HkyRateMatrixFunction(const TypedDagNode<double> *k, const TypedDagNode< Simplex > *bf) : TypedFunction<RateGenerator>( new RateMatrix_HKY() ),
     base_frequencies( bf ),

--- a/src/core/functions/phylogenetics/ratematrix/HkyRateMatrixFunction.h
+++ b/src/core/functions/phylogenetics/ratematrix/HkyRateMatrixFunction.h
@@ -15,10 +15,8 @@ template <class valueType> class TypedDagNode;
      * This function creates the HKY rates matrix object by setting the transition-transversion parameter kappa
      * and the base frequencies. The rate matrix takes care of the setting of the actual rates and transition probabilities.
      *
-     *
-     * @copyright Copyright 2009-
-     * @author The RevBayes Development Core Team (Sebastian Hoehna)
-     * @since Version 1.0, 2014-07-04
+     * @param k The transition-transversion ratio (kappa)
+     * @param bf The simplex of base frequencies
      *
      */
     class HkyRateMatrixFunction : public TypedFunction<RateGenerator> {

--- a/src/core/functions/phylogenetics/ratematrix/JcRateMatrixFunction.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/JcRateMatrixFunction.cpp
@@ -12,8 +12,6 @@ using namespace RevBayesCore;
  *
  * This function takes a single input:
  * @param ns The number of states
- *
- * @return A JC rate matrix object.
  */
 
 JcRateMatrixFunction::JcRateMatrixFunction(size_t ns) : TypedFunction<RateGenerator>( new RateMatrix_JC(ns) ) {

--- a/src/core/functions/phylogenetics/ratematrix/JcRateMatrixFunction.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/JcRateMatrixFunction.cpp
@@ -7,6 +7,15 @@ namespace RevBayesCore { class DagNode; }
 
 using namespace RevBayesCore;
 
+/**
+ * Default constructor.
+ *
+ * This function takes a single input:
+ * @param ns The number of states
+ *
+ * @return A JC rate matrix object.
+ */
+
 JcRateMatrixFunction::JcRateMatrixFunction(size_t ns) : TypedFunction<RateGenerator>( new RateMatrix_JC(ns) ) {
     
     update();

--- a/src/core/functions/phylogenetics/ratematrix/JcRateMatrixFunction.h
+++ b/src/core/functions/phylogenetics/ratematrix/JcRateMatrixFunction.h
@@ -13,14 +13,11 @@ class DagNode;
     /**
      * @brief JC rate matrix function.
      *
-     * This function creates the JC rates matrix object by setting the number of states in the constructor.
+     * This function creates the JC rate matrix object by setting the number of states in the constructor.
      * The rate matrix takes care of the setting of the actual rates and transition probabilities.
      * In this case they are actually constant.
      *
-     *
-     * @copyright Copyright 2009-
-     * @author The RevBayes Development Core Team (Sebastian Hoehna)
-     * @since Version 1.0, 2014-07-04
+     * @param ns The number of states.
      *
      */
     class JcRateMatrixFunction : public TypedFunction<RateGenerator> {

--- a/src/core/functions/phylogenetics/ratematrix/K80RateMatrixFunction.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/K80RateMatrixFunction.cpp
@@ -8,6 +8,15 @@ namespace RevBayesCore { class DagNode; }
 
 using namespace RevBayesCore;
 
+/**
+ * Default constructor.
+ *
+ * This function takes a single input:
+ * @param k The transition-transversion ratio (kappa)
+ *
+ * @return A Kimura80 rate matrix object.
+ */
+
 K80RateMatrixFunction::K80RateMatrixFunction(const TypedDagNode<double> *k) : TypedFunction<RateGenerator>( new RateMatrix_Kimura80() ),
     kappa( k )
 {

--- a/src/core/functions/phylogenetics/ratematrix/K80RateMatrixFunction.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/K80RateMatrixFunction.cpp
@@ -13,8 +13,6 @@ using namespace RevBayesCore;
  *
  * This function takes a single input:
  * @param k The transition-transversion ratio (kappa)
- *
- * @return A Kimura80 rate matrix object.
  */
 
 K80RateMatrixFunction::K80RateMatrixFunction(const TypedDagNode<double> *k) : TypedFunction<RateGenerator>( new RateMatrix_Kimura80() ),

--- a/src/core/functions/phylogenetics/ratematrix/K80RateMatrixFunction.h
+++ b/src/core/functions/phylogenetics/ratematrix/K80RateMatrixFunction.h
@@ -11,15 +11,13 @@ template <class valueType> class TypedDagNode;
     /**
      * @brief K80 rate matrix function.
      *
-     * This function creates the K80 rates matrix object by setting the transition-transversion parameter kappa.
+     * This function creates the Kimura80 rate matrix object by setting the transition-transversion parameter kappa.
      * The rate matrix takes care of the setting of the actual rates and transition probabilities.
      *
-     *
-     * @copyright Copyright 2009-
-     * @author The RevBayes Development Core Team (Sebastian Hoehna)
-     * @since Version 1.0, 2014-11-18
+     * @param k The transition-transversion ratio (kappa)
      *
      */
+
     class K80RateMatrixFunction : public TypedFunction<RateGenerator> {
         
     public:

--- a/src/core/functions/phylogenetics/ratematrix/Kimura81RateMatrixFunction.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/Kimura81RateMatrixFunction.cpp
@@ -11,6 +11,17 @@ namespace RevBayesCore { class DagNode; }
 
 using namespace RevBayesCore;
 
+/**
+ * Default constructor.
+ *
+ * This function takes three inputs:
+ * @param k1 The ratio of transitions (A<->G, C<->T) to A<->C, G<->T transversions
+ * @param k2 The ratio of A<->T, C<->G transversions to A<->C, G<->T transversions
+ * @param bf The simplex of base frequencies
+ *
+ * @return A Kimura81 rate matrix object.
+ */
+
 Kimura81RateMatrixFunction::Kimura81RateMatrixFunction(const TypedDagNode<double> *k1, const TypedDagNode<double> *k2, const TypedDagNode< Simplex > *bf) : TypedFunction<RateGenerator>( new RateMatrix_Kimura81(bf->getValue().size()) ),
     kappa_1( k1 ),
     kappa_2( k2 ),

--- a/src/core/functions/phylogenetics/ratematrix/Kimura81RateMatrixFunction.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/Kimura81RateMatrixFunction.cpp
@@ -18,8 +18,6 @@ using namespace RevBayesCore;
  * @param k1 The ratio of transitions (A<->G, C<->T) to A<->C, G<->T transversions
  * @param k2 The ratio of A<->T, C<->G transversions to A<->C, G<->T transversions
  * @param bf The simplex of base frequencies
- *
- * @return A Kimura81 rate matrix object.
  */
 
 Kimura81RateMatrixFunction::Kimura81RateMatrixFunction(const TypedDagNode<double> *k1, const TypedDagNode<double> *k2, const TypedDagNode< Simplex > *bf) : TypedFunction<RateGenerator>( new RateMatrix_Kimura81(bf->getValue().size()) ),

--- a/src/core/functions/phylogenetics/ratematrix/Kimura81RateMatrixFunction.h
+++ b/src/core/functions/phylogenetics/ratematrix/Kimura81RateMatrixFunction.h
@@ -12,14 +12,12 @@ template <class valueType> class TypedDagNode;
     /**
      * @brief Kimura81 rate matrix function.
      *
-     * This function creates the Kimura81 rates matrix object by setting the exchangeability rates
+     * This function creates the Kimura81 rate matrix object by setting the exchangeability rates
      * and the base frequencies. The rate matrix takes care of the setting of the actual rates and transition probabilities.
      *
-     *
-     * @copyright Copyright 2009-
-     * @author The RevBayes Development Core Team (Sebastian Hoehna)
-     * @since Version 1.0, 2014-07-04
-     *
+     * @param k1 The ratio of transitions (A<->G, C<->T) to A<->C, G<->T transversions
+     * @param k2 The ratio of A<->T, C<->G transversions to A<->C, G<->T transversions
+     * @param bf The simplex of stationary base frequencies
      */
     class Kimura81RateMatrixFunction : public TypedFunction<RateGenerator> {
         


### PR DESCRIPTION
Added documentation for Lognormal, LognormalWithOffset distributions; JC, K80, Kimura81, and HKY rate matrix functions. Since the branch is based off of doxygen, I figured pull requesting here would be a better idea.