### PR TITLE
Doxygen documentation for rate matrix functions

### DIFF
--- a/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_TIM.cpp
+++ b/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_TIM.cpp
@@ -16,7 +16,7 @@
 
 using namespace RevBayesCore;
 
-/** Construct rate matrix with n states */
+/** Construct rate matrix with 4 states and all four exchangeabilities set to 1 */
 RateMatrix_TIM::RateMatrix_TIM(void) : TimeReversibleRateMatrix( 4 ), rates(4,1)
 {
     

--- a/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_TIM.cpp
+++ b/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_TIM.cpp
@@ -17,7 +17,7 @@
 using namespace RevBayesCore;
 
 /** Construct rate matrix with n states */
-RateMatrix_TIM::RateMatrix_TIM(size_t n) : TimeReversibleRateMatrix( n ), rates(4,1)
+RateMatrix_TIM::RateMatrix_TIM(void) : TimeReversibleRateMatrix( 4 ), rates(4,1)
 {
     
     theEigenSystem       = new EigenSystem(the_rate_matrix);

--- a/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_TIM.h
+++ b/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_TIM.h
@@ -14,21 +14,17 @@ namespace RevBayesCore {
     /**
      * @brief TIM (transition model) rate matrix class.
      *
-     * This class implements the TIM rate matrix.
-     * The resulting rate matrix is computed by:
+     * This class implements the TIM rate matrix. The TIM matrix has four base frequency parameters
+     * and four exchangeability parameters. The resulting rate matrix is computed by:
      *
      *      |     -     pi_C*r_1  pi_G*r_2   pi_T*r_3 |
-     *      |                                         |
+     *      |                                                           |
      *      | pi_A*r_1      -     pi_G*r_3   pi_T*r_4 |
-     * Q =  |                                         |
+     * Q =     |                                                           |
      *      | pi_A*r_2  pi_C*r_3      -      pi_T*r_1 |
-     *      |                                         |
+     *      |                                                           |
      *      | pi_A*r_3  pi_C*r_4  pi_G*r_1       -    |
      *
-     *
-     * @copyright Copyright 2009-
-     * @author The RevBayes Development Core Team (Sebastian Hoehna)
-     * @since 2016-03-31, version 1.0
      */
     class RateMatrix_TIM : public TimeReversibleRateMatrix {
         

--- a/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_TIM.h
+++ b/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_TIM.h
@@ -29,7 +29,7 @@ namespace RevBayesCore {
     class RateMatrix_TIM : public TimeReversibleRateMatrix {
         
     public:
-        RateMatrix_TIM(size_t n);                                                                                               //!< Construct rate matrix with n states
+        RateMatrix_TIM(void);                                                                                                   //!< Default constructor
         RateMatrix_TIM(const RateMatrix_TIM& m);                                                                                //!< Copy constructor
         virtual                             ~RateMatrix_TIM(void);                                                              //!< Destructor
         

--- a/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_TVM.cpp
+++ b/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_TVM.cpp
@@ -16,7 +16,7 @@
 
 using namespace RevBayesCore;
 
-/** Construct rate matrix with n states */
+/** Construct rate matrix with 4 states and all five exchangeabilities set to 1 */
 RateMatrix_TVM::RateMatrix_TVM(void) : TimeReversibleRateMatrix( 4 ), rates(5,1)
 {
     

--- a/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_TVM.cpp
+++ b/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_TVM.cpp
@@ -17,7 +17,7 @@
 using namespace RevBayesCore;
 
 /** Construct rate matrix with n states */
-RateMatrix_TVM::RateMatrix_TVM(size_t n) : TimeReversibleRateMatrix( n ), rates(5,1)
+RateMatrix_TVM::RateMatrix_TVM(void) : TimeReversibleRateMatrix( 4 ), rates(5,1)
 {
     
     theEigenSystem       = new EigenSystem(the_rate_matrix);

--- a/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_TVM.h
+++ b/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_TVM.h
@@ -14,22 +14,17 @@ namespace RevBayesCore {
     /**
      * @brief TVM (transversion model) rate matrix class.
      *
-     * This class implements the special HKY rate matrix with the known analytical solution for the transition probabilities.
-     * The HKY matrix has a transition-transversion rate kappa and the four base frequency parameters.
-     * The resulting rate matrix is computed by:
+     * This class implements the TVM rate matrix. The TVM matrix has four base frequency parameters
+     * and five exchangeability parameters. The resulting rate matrix is computed by:
      *
-     *      |     -       pi_C     k*pi_G      pi_T   |
-     *      |                                         |
-     *      |   pi_A        -       pi_G      k*pi_T  |
-     * Q =  |                                         |
-     *      |  k*pi_A     pi_C        -        pi_T   |
-     *      |                                         |
-     *      |   pi_A     k*pi_C     pi_G         -    |
+     *      |     -       pi_C*r_1  pi_G*r_2   pi_T*r_3  |
+     *      |                                                              |
+     *      |   pi_A*r_1      -     pi_G*r_4   pi_T*r_2  |
+     * Q =     |                                                              |
+     *      |  pi_A*r_2   pi_C*r_4      -      pi_T*r_5  |
+     *      |                                                              |
+     *      |   pi_A*r_3  pi_C*r_2   pi_G*r_5       -    |
      *
-     *
-     * @copyright Copyright 2009-
-     * @author The RevBayes Development Core Team (Sebastian Hoehna)
-     * @since 2014-07-04, version 1.0
      */
     class RateMatrix_TVM : public TimeReversibleRateMatrix {
         

--- a/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_TVM.h
+++ b/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_TVM.h
@@ -29,7 +29,7 @@ namespace RevBayesCore {
     class RateMatrix_TVM : public TimeReversibleRateMatrix {
         
     public:
-        RateMatrix_TVM(size_t n);                                                                                               //!< Construct rate matrix with n states
+        RateMatrix_TVM(void);                                                                                                   //!< Default constructor
         RateMatrix_TVM(const RateMatrix_TVM& m);                                                                                //!< Copy constructor
         virtual                             ~RateMatrix_TVM(void);                                                              //!< Destructor
         

--- a/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_TamuraNei.cpp
+++ b/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_TamuraNei.cpp
@@ -16,8 +16,8 @@
 
 using namespace RevBayesCore;
 
-/** Construct rate matrix with n states */
-RateMatrix_TamuraNei::RateMatrix_TamuraNei(size_t n) : TimeReversibleRateMatrix( n )
+/** Construct rate matrix with 4 states */
+RateMatrix_TamuraNei::RateMatrix_TamuraNei(void) : TimeReversibleRateMatrix( 4 )
 {
     
     theEigenSystem       = new EigenSystem(the_rate_matrix);

--- a/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_TamuraNei.h
+++ b/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_TamuraNei.h
@@ -33,9 +33,9 @@ namespace RevBayesCore {
     class RateMatrix_TamuraNei : public TimeReversibleRateMatrix {
         
     public:
-        RateMatrix_TamuraNei(size_t n);                                                                                               //!< Construct rate matrix with n states
-        RateMatrix_TamuraNei(const RateMatrix_TamuraNei& m);                                                                                //!< Copy constructor
-        virtual                             ~RateMatrix_TamuraNei(void);                                                              //!< Destructor
+        RateMatrix_TamuraNei(void);                                                                                             //!< Construct rate matrix with n states
+        RateMatrix_TamuraNei(const RateMatrix_TamuraNei& m);                                                                    //!< Copy constructor
+        virtual                             ~RateMatrix_TamuraNei(void);                                                        //!< Destructor
         
         // overloaded operators
         RateMatrix_TamuraNei&                operator=(const RateMatrix_TamuraNei& r);

--- a/src/core/functions/phylogenetics/ratematrix/F81RateMatrixFunction.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/F81RateMatrixFunction.cpp
@@ -11,11 +11,16 @@ namespace RevBayesCore { class DagNode; }
 
 using namespace RevBayesCore;
 
+/**
+ * Default constructor.
+ *
+ * This function takes a single input:
+ * @param bf The simplex of base frequencies
+ */
 
 F81RateMatrixFunction::F81RateMatrixFunction(const TypedDagNode< Simplex > *bf) : TypedFunction<RateGenerator>( new RateMatrix_F81(bf->getValue().size()) ),
     base_frequencies( bf )
 {
-    // add the lambda parameter as a parent
     addParameter( base_frequencies );
     
     update();

--- a/src/core/functions/phylogenetics/ratematrix/F81RateMatrixFunction.h
+++ b/src/core/functions/phylogenetics/ratematrix/F81RateMatrixFunction.h
@@ -13,14 +13,10 @@ template <class valueType> class TypedDagNode;
     /**
      * @brief F81 rate matrix function.
      *
-     * This function creates the F81 rates matrix object by setting the base frequencies.
+     * This function creates the F81 rate matrix object by setting the base frequencies.
      * The rate matrix takes care of the setting of the actual rates and transition probabilities.
      *
-     *
-     * @copyright Copyright 2009-
-     * @author The RevBayes Development Core Team (Sebastian Hoehna)
-     * @since Version 1.0, 2014-07-04
-     *
+     * @param bf The simplex of stationary base frequencies.
      */
     class F81RateMatrixFunction : public TypedFunction<RateGenerator> {
         

--- a/src/core/functions/phylogenetics/ratematrix/FreeSymmetricRateMatrixFunction.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/FreeSymmetricRateMatrixFunction.cpp
@@ -13,6 +13,15 @@ namespace RevBayesCore { class DagNode; }
 
 using namespace RevBayesCore;
 
+/**
+ * Default constructor.
+ *
+ * This function takes three inputs:
+ * @param tr The vector of substitution rates, whose number of elements equals half the number of the off-diagonal entries of the rate matrix.
+ * @param r Should the rates be rescaled so that the average rate equals 1?
+ * @param method Matrix exponentiation method.
+ */
+
 FreeSymmetricRateMatrixFunction::FreeSymmetricRateMatrixFunction(const TypedDagNode< RbVector<double> > *tr, bool r, std::string method) : TypedFunction<RateGenerator>( NULL ),
     transition_rates( tr )
 {
@@ -44,10 +53,10 @@ FreeSymmetricRateMatrixFunction* FreeSymmetricRateMatrixFunction::clone( void ) 
 void FreeSymmetricRateMatrixFunction::update( void )
 {
     // get the information from the arguments for reading the file
-    const std::vector<double>& r = transition_rates->getValue();
+    const std::vector<double>& trr = transition_rates->getValue();
     
     // set the base frequencies
-    static_cast< RateMatrix_FreeSymmetric* >(value)->setTransitionRates(r);
+    static_cast< RateMatrix_FreeSymmetric* >(value)->setTransitionRates(trr);
     
     value->update();
 }

--- a/src/core/functions/phylogenetics/ratematrix/FreeSymmetricRateMatrixFunction.h
+++ b/src/core/functions/phylogenetics/ratematrix/FreeSymmetricRateMatrixFunction.h
@@ -14,14 +14,12 @@ template <class valueType> class TypedDagNode;
     /**
      * @brief Free symmetric rate matrix function.
      *
-     * This function creates the free (symmetric) rates matrix object by setting the substitution rates.
+     * This function creates the free (symmetric) rate matrix object by setting the substitution rates.
      * The rate matrix takes care of the setting of the actual rates and transition probabilities.
      *
-     *
-     * @copyright Copyright 2009-
-     * @author The RevBayes Development Core Team (Sebastian Hoehna)
-     * @since Version 1.0, 2015-09-29
-     *
+     * @param tr The vector of substitution rates, whose number of elements equals half the number of the off-diagonal entries of the rate matrix.
+     * @param r Should the rates be rescaled so that the average rate equals 1?
+     * @param method Matrix exponentiation method.
      */
     class FreeSymmetricRateMatrixFunction : public TypedFunction<RateGenerator> {
         

--- a/src/core/functions/phylogenetics/ratematrix/FreeSymmetricRateMatrixFunction.h
+++ b/src/core/functions/phylogenetics/ratematrix/FreeSymmetricRateMatrixFunction.h
@@ -37,7 +37,7 @@ template <class valueType> class TypedDagNode;
     private:
         
         // members
-        const TypedDagNode< RbVector<double> >*             transition_rates;
+        const TypedDagNode< RbVector<double> >*             transition_rates; //!< Vector of transition rates: of length (k-1)k/2 for a k-state model
         
     };
     

--- a/src/core/functions/phylogenetics/ratematrix/GtrRateMatrixFunction.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/GtrRateMatrixFunction.cpp
@@ -10,6 +10,13 @@
 namespace RevBayesCore { class DagNode; }
 
 using namespace RevBayesCore;
+/**
+ * Default constructor.
+ *
+ * This function takes two inputs:
+ * @param er The simplex of exchangeabilities
+ * @param bf The simplex of stationary base frequencies
+ */
 
 GtrRateMatrixFunction::GtrRateMatrixFunction(const TypedDagNode< Simplex > *er, const TypedDagNode< Simplex > *bf) : TypedFunction<RateGenerator>( new RateMatrix_GTR(bf->getValue().size()) ),
     exchangeability_rates( er ),

--- a/src/core/functions/phylogenetics/ratematrix/GtrRateMatrixFunction.h
+++ b/src/core/functions/phylogenetics/ratematrix/GtrRateMatrixFunction.h
@@ -10,16 +10,13 @@ class Simplex;
 template <class valueType> class TypedDagNode;
     
     /**
-     * @brief GTR rate matrix function.
+     * @brief General Time-Reversible rate matrix function.
      *
-     * This function creates the GTR rates matrix object by setting the exchangeability rates
+     * This function creates the GTR rate matrix object by setting the exchangeability rates
      * and the base frequencies. The rate matrix takes care of the setting of the actual rates and transition probabilities.
      *
-     *
-     * @copyright Copyright 2009-
-     * @author The RevBayes Development Core Team (Sebastian Hoehna)
-     * @since Version 1.0, 2014-07-04
-     *
+     * @param er The simplex of exchangeabilities
+     * @param bf The simplex of stationary base frequencies
      */
     class GtrRateMatrixFunction : public TypedFunction<RateGenerator> {
         

--- a/src/core/functions/phylogenetics/ratematrix/GtrRateMatrixFunction.h
+++ b/src/core/functions/phylogenetics/ratematrix/GtrRateMatrixFunction.h
@@ -34,7 +34,7 @@ template <class valueType> class TypedDagNode;
     private:
         
         // members
-        const TypedDagNode< Simplex >*                      exchangeability_rates;
+        const TypedDagNode< Simplex >*                      exchangeability_rates;  //!< A<->C, A<->G, A<->T, C<->G, C<->T, G<->T exchangeabilities
         const TypedDagNode< Simplex >*                      base_frequencies;
         
     };

--- a/src/core/functions/phylogenetics/ratematrix/HkyRateMatrixFunction.h
+++ b/src/core/functions/phylogenetics/ratematrix/HkyRateMatrixFunction.h
@@ -36,7 +36,7 @@ template <class valueType> class TypedDagNode;
         
         // members
         const TypedDagNode< Simplex >*                      base_frequencies;
-        const TypedDagNode<double>*                         kappa;
+        const TypedDagNode<double>*                         kappa;                                                                          //!< Transition-transversion ratio
         
     };
     

--- a/src/core/functions/phylogenetics/ratematrix/K80RateMatrixFunction.h
+++ b/src/core/functions/phylogenetics/ratematrix/K80RateMatrixFunction.h
@@ -34,7 +34,7 @@ template <class valueType> class TypedDagNode;
     private:
         
         // members
-        const TypedDagNode<double>*                         kappa;
+        const TypedDagNode<double>*                         kappa; //!< Transition-transversion ratio
         
     };
     

--- a/src/core/functions/phylogenetics/ratematrix/Kimura81RateMatrixFunction.h
+++ b/src/core/functions/phylogenetics/ratematrix/Kimura81RateMatrixFunction.h
@@ -36,8 +36,8 @@ template <class valueType> class TypedDagNode;
         
         // members
         
-        const TypedDagNode<double>*                         kappa_1;
-        const TypedDagNode<double>*                         kappa_2;
+        const TypedDagNode<double>*                         kappa_1; //!< The ratio of transitions (A<->G, C<->T) to A<->C, G<->T transversions
+        const TypedDagNode<double>*                         kappa_2; //!< The ratio of A<->T, C<->G transversions to A<->C, G<->T transversions
         const TypedDagNode< Simplex >*                      base_frequencies;
         
     };

--- a/src/core/functions/phylogenetics/ratematrix/T92RateMatrixFunction.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/T92RateMatrixFunction.cpp
@@ -8,6 +8,14 @@ namespace RevBayesCore { class DagNode; }
 
 using namespace RevBayesCore;
 
+/**
+ * Default constructor.
+ *
+ * This function takes two inputs:
+ * @param eqGc The compound equilibrium frequency of bases G and C
+ * @param tstv The transition-transversion ratio (kappa)
+ */
+
 T92RateMatrixFunction::T92RateMatrixFunction(const TypedDagNode< double > *eqGc, const TypedDagNode< double > *tstv) : TypedFunction<RateGenerator>( new RateMatrix_Tamura92( ) ),
     equilibriumGc( eqGc ),
     transitionTransversionRate( tstv )

--- a/src/core/functions/phylogenetics/ratematrix/T92RateMatrixFunction.h
+++ b/src/core/functions/phylogenetics/ratematrix/T92RateMatrixFunction.h
@@ -1,24 +1,3 @@
-/**
- * @file
- * This file contains the declaration of the GTR rate matrix function class.
- * This class is derived from the function class and is used to
- * compute the rate matrix of a general time reversible (GTR) Markov chain.
- *
- * @brief Declaration of the GTR rate matrix function.
- *
- * (c) Copyright 2009- under GPL version 3
- * @date Last modified: $Date$
- * @author The RevBayes Development Core Team
- * @license GPL version 3
- * @version 1.0
- * @since 2012-07-06, version 1.0
- * @interface Function
- *
- * $Id$
- */
-
-
-
 #ifndef T92RateMatrixFunction_H
 #define T92RateMatrixFunction_H
 
@@ -28,6 +7,16 @@
 namespace RevBayesCore {
 class DagNode;
 template <class valueType> class TypedDagNode;
+
+    /**
+     * @brief T92 rate matrix function.
+     *
+     * This function creates the T92 (Tamura 1992) rate matrix object by setting the compound frequency of G+C and the
+     * transition-transversion ratio. The rate matrix takes care of the setting of the actual rates and transition probabilities.
+     *
+     * @param eqGc The compound equilibrium frequency of bases G and C
+     * @param tstv The transition-transversion ratio (kappa)
+     */
     
     class T92RateMatrixFunction : public TypedFunction<RateGenerator> {
         

--- a/src/core/functions/phylogenetics/ratematrix/T92RateMatrixFunction.h
+++ b/src/core/functions/phylogenetics/ratematrix/T92RateMatrixFunction.h
@@ -34,7 +34,7 @@ template <class valueType> class TypedDagNode;
     private:
         
         // members
-        const TypedDagNode< double >*                       equilibriumGc;
+        const TypedDagNode< double >*                       equilibriumGc; //!< The compound equilibrium frequency of bases G and C
         const TypedDagNode< double >*                       transitionTransversionRate;
         
     };

--- a/src/core/functions/phylogenetics/ratematrix/TamuraNeiRateMatrixFunction.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/TamuraNeiRateMatrixFunction.cpp
@@ -12,6 +12,14 @@ namespace RevBayesCore { class DagNode; }
 
 using namespace RevBayesCore;
 
+/**
+ * Default constructor.
+ *
+ * This function takes three inputs:
+ * @param k1 The ratio of A<->G transitions to transversions
+ * @param k2 The ratio of C<->T transitions to transversions
+ * @param bf The simplex of base frequencies
+ */
 
 TamuraNeiRateMatrixFunction::TamuraNeiRateMatrixFunction(const TypedDagNode<double> *k1, const TypedDagNode<double> *k2, const TypedDagNode< Simplex > *bf) : TypedFunction<RateGenerator>( new RateMatrix_TamuraNei(bf->getValue().size()) ),
     kappa_1( k1 ),

--- a/src/core/functions/phylogenetics/ratematrix/TamuraNeiRateMatrixFunction.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/TamuraNeiRateMatrixFunction.cpp
@@ -21,7 +21,7 @@ using namespace RevBayesCore;
  * @param bf The simplex of base frequencies
  */
 
-TamuraNeiRateMatrixFunction::TamuraNeiRateMatrixFunction(const TypedDagNode<double> *k1, const TypedDagNode<double> *k2, const TypedDagNode< Simplex > *bf) : TypedFunction<RateGenerator>( new RateMatrix_TamuraNei(bf->getValue().size()) ),
+TamuraNeiRateMatrixFunction::TamuraNeiRateMatrixFunction(const TypedDagNode<double> *k1, const TypedDagNode<double> *k2, const TypedDagNode< Simplex > *bf) : TypedFunction<RateGenerator>( new RateMatrix_TamuraNei() ),
     kappa_1( k1 ),
     kappa_2( k2 ),
     base_frequencies( bf )

--- a/src/core/functions/phylogenetics/ratematrix/TamuraNeiRateMatrixFunction.h
+++ b/src/core/functions/phylogenetics/ratematrix/TamuraNeiRateMatrixFunction.h
@@ -14,13 +14,12 @@ namespace RevBayesCore {
     /**
      * @brief TamuraNei rate matrix function.
      *
-     * This function creates the TamuraNei rates matrix object by setting the exchangeability rates
+     * This function creates the Tamura-Nei rate matrix object by setting the exchangeability rates
      * and the base frequencies. The rate matrix takes care of the setting of the actual rates and transition probabilities.
      *
-     *
-     * @copyright Copyright 2009-
-     * @author The RevBayes Development Core Team (Sebastian Hoehna)
-     * @since Version 1.0, 2014-07-04
+     * @param k1 The ratio of A<->G transitions to transversions
+     * @param k2 The ratio of C<->T transitions to transversions
+     * @param bf The simplex of base frequencies
      *
      */
     class TamuraNeiRateMatrixFunction : public TypedFunction<RateGenerator> {

--- a/src/core/functions/phylogenetics/ratematrix/TamuraNeiRateMatrixFunction.h
+++ b/src/core/functions/phylogenetics/ratematrix/TamuraNeiRateMatrixFunction.h
@@ -40,8 +40,8 @@ namespace RevBayesCore {
         
         // members
         
-        const TypedDagNode<double>*                         kappa_1;
-        const TypedDagNode<double>*                         kappa_2;
+        const TypedDagNode<double>*                         kappa_1; //!< The ratio of A<->G transitions to transversions
+        const TypedDagNode<double>*                         kappa_2; //!< The ratio of C<->T transitions to transversions
         const TypedDagNode<Simplex>*                        base_frequencies;
         
     };

--- a/src/core/functions/phylogenetics/ratematrix/TimRateMatrixFunction.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/TimRateMatrixFunction.cpp
@@ -15,7 +15,7 @@ using namespace RevBayesCore;
  * Default constructor.
  *
  * This function takes two inputs:
- * @param er The simplex of exchangeabilities
+ * @param er The simplex of exchangeabilities (abccea): A<->C = G<->T, A<->G, A<->T = C<->G, C<->T
  * @param bf The simplex of base frequencies
  */
 

--- a/src/core/functions/phylogenetics/ratematrix/TimRateMatrixFunction.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/TimRateMatrixFunction.cpp
@@ -11,6 +11,14 @@ namespace RevBayesCore { class DagNode; }
 
 using namespace RevBayesCore;
 
+/**
+ * Default constructor.
+ *
+ * This function takes two inputs:
+ * @param er The simplex of exchangeabilities
+ * @param bf The simplex of base frequencies
+ */
+
 TimRateMatrixFunction::TimRateMatrixFunction(const TypedDagNode< Simplex > *er, const TypedDagNode< Simplex > *bf) : TypedFunction<RateGenerator>( new RateMatrix_TIM(bf->getValue().size()) ),
     exchangeability_rates( er ),
     base_frequencies( bf )

--- a/src/core/functions/phylogenetics/ratematrix/TimRateMatrixFunction.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/TimRateMatrixFunction.cpp
@@ -19,7 +19,7 @@ using namespace RevBayesCore;
  * @param bf The simplex of base frequencies
  */
 
-TimRateMatrixFunction::TimRateMatrixFunction(const TypedDagNode< Simplex > *er, const TypedDagNode< Simplex > *bf) : TypedFunction<RateGenerator>( new RateMatrix_TIM(bf->getValue().size()) ),
+TimRateMatrixFunction::TimRateMatrixFunction(const TypedDagNode< Simplex > *er, const TypedDagNode< Simplex > *bf) : TypedFunction<RateGenerator>( new RateMatrix_TIM() ),
     exchangeability_rates( er ),
     base_frequencies( bf )
 {

--- a/src/core/functions/phylogenetics/ratematrix/TimRateMatrixFunction.h
+++ b/src/core/functions/phylogenetics/ratematrix/TimRateMatrixFunction.h
@@ -12,14 +12,11 @@ template <class valueType> class TypedDagNode;
     /**
      * @brief Tim rate matrix function.
      *
-     * This function creates the Tim rates matrix object by setting the exchangeability rates
+     * This function creates the Tim (transition model) rate matrix object by setting the exchangeability rates
      * and the base frequencies. The rate matrix takes care of the setting of the actual rates and transition probabilities.
      *
-     *
-     * @copyright Copyright 2009-
-     * @author The RevBayes Development Core Team (Sebastian Hoehna)
-     * @since Version 1.0, 2014-07-04
-     *
+     * @param er The simplex of exchangeabilities
+     * @param bf The simplex of base frequencies
      */
     class TimRateMatrixFunction : public TypedFunction<RateGenerator> {
         

--- a/src/core/functions/phylogenetics/ratematrix/TimRateMatrixFunction.h
+++ b/src/core/functions/phylogenetics/ratematrix/TimRateMatrixFunction.h
@@ -35,7 +35,7 @@ template <class valueType> class TypedDagNode;
         
         // members
         
-        const TypedDagNode< Simplex >*                      exchangeability_rates;
+        const TypedDagNode< Simplex >*                      exchangeability_rates; //!< A<->C = G<->T, A<->G, A<->T = C<->G, C<->T exchangeabilities
         const TypedDagNode< Simplex >*                      base_frequencies;
         
     };

--- a/src/core/functions/phylogenetics/ratematrix/TimRateMatrixFunction.h
+++ b/src/core/functions/phylogenetics/ratematrix/TimRateMatrixFunction.h
@@ -15,7 +15,7 @@ template <class valueType> class TypedDagNode;
      * This function creates the Tim (transition model) rate matrix object by setting the exchangeability rates
      * and the base frequencies. The rate matrix takes care of the setting of the actual rates and transition probabilities.
      *
-     * @param er The simplex of exchangeabilities
+     * @param er The simplex of exchangeabilities (abccea): A<->C = G<->T, A<->G, A<->T = C<->G, C<->T
      * @param bf The simplex of base frequencies
      */
     class TimRateMatrixFunction : public TypedFunction<RateGenerator> {

--- a/src/core/functions/phylogenetics/ratematrix/TvmRateMatrixFunction.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/TvmRateMatrixFunction.cpp
@@ -11,6 +11,14 @@ namespace RevBayesCore { class DagNode; }
 
 using namespace RevBayesCore;
 
+/**
+ * Default constructor.
+ *
+ * This function takes two inputs:
+ * @param er The simplex of exchangeabilities
+ * @param bf The simplex of base frequencies
+ */
+
 TvmRateMatrixFunction::TvmRateMatrixFunction(const TypedDagNode< Simplex > *er, const TypedDagNode< Simplex > *bf) : TypedFunction<RateGenerator>( new RateMatrix_TVM(bf->getValue().size()) ),
     exchangeability_rates( er ),
     base_frequencies( bf )

--- a/src/core/functions/phylogenetics/ratematrix/TvmRateMatrixFunction.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/TvmRateMatrixFunction.cpp
@@ -15,7 +15,7 @@ using namespace RevBayesCore;
  * Default constructor.
  *
  * This function takes two inputs:
- * @param er The simplex of exchangeabilities
+ * @param er The simplex of exchangeabilities (abcdbe): A<->C, A<->G = C<->T, A<->T, C<->G, G<->T
  * @param bf The simplex of base frequencies
  */
 

--- a/src/core/functions/phylogenetics/ratematrix/TvmRateMatrixFunction.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/TvmRateMatrixFunction.cpp
@@ -19,7 +19,7 @@ using namespace RevBayesCore;
  * @param bf The simplex of base frequencies
  */
 
-TvmRateMatrixFunction::TvmRateMatrixFunction(const TypedDagNode< Simplex > *er, const TypedDagNode< Simplex > *bf) : TypedFunction<RateGenerator>( new RateMatrix_TVM(bf->getValue().size()) ),
+TvmRateMatrixFunction::TvmRateMatrixFunction(const TypedDagNode< Simplex > *er, const TypedDagNode< Simplex > *bf) : TypedFunction<RateGenerator>( new RateMatrix_TVM() ),
     exchangeability_rates( er ),
     base_frequencies( bf )
 {

--- a/src/core/functions/phylogenetics/ratematrix/TvmRateMatrixFunction.h
+++ b/src/core/functions/phylogenetics/ratematrix/TvmRateMatrixFunction.h
@@ -35,7 +35,7 @@ template <class valueType> class TypedDagNode;
         
         // members
         
-        const TypedDagNode< Simplex >*                      exchangeability_rates;
+        const TypedDagNode< Simplex >*                      exchangeability_rates; //!< A<->C, A<->G = C<->T, A<->T, C<->G, G<->T exchangeabilities
         const TypedDagNode< Simplex >*                      base_frequencies;
         
     };

--- a/src/core/functions/phylogenetics/ratematrix/TvmRateMatrixFunction.h
+++ b/src/core/functions/phylogenetics/ratematrix/TvmRateMatrixFunction.h
@@ -12,14 +12,11 @@ template <class valueType> class TypedDagNode;
     /**
      * @brief Tvm rate matrix function.
      *
-     * This function creates the Tvm rates matrix object by setting the exchangeability rates
+     * This function creates the Tvm (transversion model) rate matrix object by setting the exchangeability rates
      * and the base frequencies. The rate matrix takes care of the setting of the actual rates and transition probabilities.
      *
-     *
-     * @copyright Copyright 2009-
-     * @author The RevBayes Development Core Team (Sebastian Hoehna)
-     * @since Version 1.0, 2014-07-04
-     *
+     * @param er The simplex of exchangeabilities
+     * @param bf The simplex of base frequencies
      */
     class TvmRateMatrixFunction : public TypedFunction<RateGenerator> {
         

--- a/src/core/functions/phylogenetics/ratematrix/TvmRateMatrixFunction.h
+++ b/src/core/functions/phylogenetics/ratematrix/TvmRateMatrixFunction.h
@@ -15,7 +15,7 @@ template <class valueType> class TypedDagNode;
      * This function creates the Tvm (transversion model) rate matrix object by setting the exchangeability rates
      * and the base frequencies. The rate matrix takes care of the setting of the actual rates and transition probabilities.
      *
-     * @param er The simplex of exchangeabilities
+     * @param er The simplex of exchangeabilities (abcdbe): A<->C, A<->G = C<->T, A<->T, C<->G, G<->T
      * @param bf The simplex of base frequencies
      */
     class TvmRateMatrixFunction : public TypedFunction<RateGenerator> {


### PR DESCRIPTION
Added doxygen documentation to the functions creating rate matrices for the following models: F81, free symmetric, GTR, TN92, Tamura-Nei, Tim, Tvm.