### PR TITLE
Changed the call for matrix exponentiation method to the one 'owned' …

### DIFF
--- a/src/core/datatypes/phylogenetics/ratematrix/AbstractRateMatrix.cpp
+++ b/src/core/datatypes/phylogenetics/ratematrix/AbstractRateMatrix.cpp
@@ -364,8 +364,8 @@ bool AbstractRateMatrix::simulateStochasticMapping(double startAge, double endAg
 
     // transition probabilities
     TransitionProbabilityMatrix P(num_states);
-//    calculateTransitionProbabilities(startAge, endAge, rate, P);
-    exponentiateMatrixByScalingAndSquaring(branch_length * rate, P);
+    calculateTransitionProbabilities(startAge, endAge, rate, P);
+//    exponentiateMatrixByScalingAndSquaring(branch_length * rate, P);
     stochastic_matrix = std::vector<MatrixReal>();
 
     // dominating rate


### PR DESCRIPTION
I encountered stability issues with the stochastic mapping implementation that would result in segmentation fault (for "large FnFreeK matrix").

This small fix changes the matrix exponentiation method from exponentiateMatrixByScalingAndSquaring(...) to calculateTransitionProbabilities(...):

> calculateTransitionProbabilities(startAge, endAge, rate, P);
>//    exponentiateMatrixByScalingAndSquaring(branch_length * rate, P);

The forced use of the scaling and squaring implementation (i.e., exponentiateMatrixByScalingAndSquaring(...)) was unstable for some matrices, while the RateMatrix default method (e.g., tiProbsEigens(..) or tiProbsScalingAndSquaring(...) called by calculateTransitionProbabilities(...)) behaves well.

My understanding is that if the default exponentiation method (the one called by calculateTransitionProbabilities) is safe for likelihood evaluation, it should also be safe for stochastic mapping. 