### PR TITLE
Test gcc-5, gcc-6 and gcc-7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,10 @@ jobs:
   build:
     strategy:
       matrix:
-        name: [ubuntu-gcc-8,
+        name: [ubuntu-gcc-5,
+               ubuntu-gcc-6,
+               ubuntu-gcc-7,
+               ubuntu-gcc-8,
                ubuntu-gcc-9,
                ubuntu-gcc-9-mpi,
                ubuntu-clang-8,
@@ -20,6 +23,24 @@ jobs:
                ]
 
         include:
+          - name: ubuntu-gcc-5
+            os: ubuntu-18.04
+            compiler: gcc
+            version: "5"
+            mpi: false
+
+          - name: ubuntu-gcc-6
+            os: ubuntu-18.04
+            compiler: gcc
+            version: "6"
+            mpi: false
+
+          - name: ubuntu-gcc-7
+            os: ubuntu-latest
+            compiler: gcc
+            version: "8"
+            mpi: false
+
           - name: ubuntu-gcc-8
             os: ubuntu-latest
             compiler: gcc


### PR DESCRIPTION
Since we have the computing power available, lets test older compilers.

The really interesting ones are probably 4.9 and maybe 4.8, which are installed on clusters, but for those I think I need to build boost with the old ABI.  This is the first step.