### PR TITLE
Also test with gcc-4.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,8 @@ jobs:
   build:
     strategy:
       matrix:
-        name: [ubuntu-gcc-5,
+        name: [ubuntu-gcc-4.9,
+               ubuntu-gcc-5,
                ubuntu-gcc-6,
                ubuntu-gcc-7,
                ubuntu-gcc-8,
@@ -23,6 +24,12 @@ jobs:
                ]
 
         include:
+          - name: ubuntu-gcc-4.9
+            os: ubuntu-16.04
+            compiler: gcc
+            version: "4.9"
+            mpi: false
+
           - name: ubuntu-gcc-5
             os: ubuntu-18.04
             compiler: gcc
@@ -82,8 +89,6 @@ jobs:
       if: runner.os == 'Linux'
       run: |
         sudo apt-get install -y pandoc libcairo2-dev ccache
-        sudo apt-get install -y libboost-dev libboost-program-options-dev libboost-date-time-dev libboost-filesystem-dev libboost-regex-dev libboost-serialization-dev libboost-system-dev libboost-thread-dev 
-        sudo rm -rf /usr/local/share/boost
         if [ "${{ matrix.compiler }}" = "gcc" ]; then
           sudo apt-get install -y g++-${{ matrix.version }}
           echo "::set-env name=C_COMPILER::gcc-${{ matrix.version }}"
@@ -126,6 +131,30 @@ jobs:
          key: ${{ matrix.name }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
          restore-keys: |
            ${{ matrix.name }}-ccache-
+
+    - name: Install BOOST (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        # Don't use weird boost version installed by github actions.
+        sudo rm -rf /usr/local/share/boost
+        # We have to build boost for gcc-4.9 because the prebuilt packages have the ABI from gcc-5+
+        if [ "${{ matrix.os }}" = ubuntu-16.04 ] ; then
+          # These exports are supposed to affect b2, but they seem not to, so use update-alternatives
+          export CC=gcc-4.9
+          export CXX=g++-4.9
+          sudo update-alternatives --install /usr/bin/gcc  gcc /usr/bin/gcc-4.9  90
+          sudo update-alternatives --install /usr/bin/g++  g++ /usr/bin/g++-4.9  90
+          curl -O -L https://dl.bintray.com/boostorg/release/1.71.0/source/boost_1_71_0.tar.gz
+          tar -xzf boost_1_71_0.tar.gz
+          cd boost_1_71_0
+          ./bootstrap.sh --with-libraries=atomic,chrono,filesystem,system,regex,thread,date_time,program_options,math,serialization
+          ./b2 link=static
+          echo "::set-env name=BOOST_ROOT::${GITHUB_WORKSPACE}/boost_1_71_0"
+          echo "::set-env name=BOOST_INCLUDE_DIR::${GITHUB_WORKSPACE}/boost_1_71_0"
+          echo "::set-env name=BOOST_LIBRARY_DIR::${GITHUB_WORKSPACE}/boost_1_71_0/stage/lib"
+        else
+          sudo apt-get install -y libboost-dev libboost-program-options-dev libboost-date-time-dev libboost-filesystem-dev libboost-regex-dev libboost-serialization-dev libboost-system-dev libboost-thread-dev
+        fi
 
     - name: Configure and build
       env:


### PR DESCRIPTION
This requires building boost with gcc-4.9, in order to get a boost with the right ABI that is also new enough.