### PR TITLE
Allow passing -Darg to cmake.

### DIFF
--- a/projects/cmake/build.sh
+++ b/projects/cmake/build.sh
@@ -4,6 +4,7 @@ set -e
 all_args="$@"
 mpi="false"
 travis="false"
+cmake_args=""
 # parse command line arguments
 while echo $1 | grep ^- > /dev/null; do
     # intercept help while parsing "-key value" pairs
@@ -15,6 +16,13 @@ Command line options are:
 '
         exit
     fi
+
+    case "$1" in -D*)
+                     cmake_args="$cmake_args $1"
+                     shift
+                     continue
+                     ;;
+    esac
 
     # parse pairs
     eval $( echo $1 | sed 's/-//g' | tr -d '\012')=$2
@@ -59,7 +67,10 @@ fi
 
 	./regenerate.sh ${all_args}
 	cd ${BUILD_DIR}
-	cmake .
+        echo "Running 'cmake . $cmake_args' in $(pwd)"
+	cmake . $cmake_args
+        echo
+        echo "Running 'make -j4' in $(pwd)"
 	make -j 4
 	cd ..
 

--- a/projects/cmake/regenerate.sh
+++ b/projects/cmake/regenerate.sh
@@ -37,6 +37,13 @@ Command line options are:
         exit
     fi
 
+    # skip cmake args
+    case "$1" in -D*)
+                     shift
+                     continue
+                     ;;
+    esac
+
     # parse pairs
     eval $( echo $1 | sed 's/-//g' | tr -d '\012')=$2
     shift


### PR DESCRIPTION
This removes arguments that start with `-D` from the current argument handling, and passes them to  cmake.  It also prints how and where cmake is called.

Passing args to cmake allows doing things like 
* `./build.sh -DBoost_DEBUG=ON`
* `./build.sh -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_COMPILER=clang`
and many other things.  We then have the option of making future options to `./build.sh` be cmake options instead of options to generate different scripts.