### PR TITLE
Fix boost location hints for cmake.

### DIFF
--- a/projects/cmake/build.sh
+++ b/projects/cmake/build.sh
@@ -31,8 +31,13 @@ while echo $1 | grep ^- > /dev/null; do
 -boost_root     string          : specify directory containing Boost headers (e.g. `/usr/include`). Defaults to unset.
 -boost_lib      string          : specify directory containing Boost libraries. (e.g. `/usr/lib`). Defaults to unset.
 
-Example:
-  ./build.sh -mpi true -help true'
+You can also specify cmake variables as -DCMAKE_VAR1=value1 -DCMAKE_VAR2=value2
+
+Examples:
+  ./build.sh -mpi true -help true
+  ./build.sh -boost_root /home/santa/boost_1.72
+  ./build.sh -DBOOST_ROOT=/home/santa/boost_1.72
+  ./build.sh -mpi true -DHELP=ON -DBOOST_ROOT=/home/santa/boost_1.72'
         exit
     fi
 
@@ -93,11 +98,11 @@ if [ "$travis" = "true" ] ; then
 fi
 
 if [ -n "$boost_root" ] ; then
-    cmake_args="-DLOCAL_BOOST_ROOT=\"${boost_root}\""
+    cmake_args="-DBOOST_ROOT=\"${boost_root}\" $cmake_args"
 fi
 
 if [ -n "$boost_lib" ] ; then
-    cmake_args="-DLOCAL_BOOST_LIBRARY=\"${boost_lib}\""
+    cmake_args="-DBOOST_LIBRARYDIR=\"${boost_lib}\" $cmake_args"
 fi
 
 if [ "$help" = "true" ] ; then
@@ -142,6 +147,8 @@ fi
     echo "Running './regenerate.sh $(pwd)/$BUILD_DIR"
     ./regenerate.sh $(pwd)/$BUILD_DIR
     cd ${BUILD_DIR}
+    echo
+    echo
     echo "Running 'cmake ../../../src $cmake_args' in $(pwd)"
     cmake ../../../src $cmake_args
     echo

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,21 +65,22 @@ if ("${CONTINUOUS_INTEGRATION}" STREQUAL "TRUE")
 endif()
 
 
-MESSAGE("My Boost information:")
-MESSAGE("  Boost_INCLUDE_DIRS: ${LOCAL_BOOST_ROOT}")
-MESSAGE("  Boost_LIBRARIES: ${LOCAL_BOOST_LIBRARY}")
+MESSAGE("Boost location hints:")
+if (BOOST_ROOT)
+  MESSAGE("  BOOST_ROOT: ${BOOST_ROOT}")
+else()
+  MESSAGE("  BOOST_ROOT not set")
+endif()
+if (BOOST_INCLUDEDIR)
+  MESSAGE("  BOOST_INCLUDEDIR: ${BOOST_INCLUDEDIR}")
+endif()
+if (BOOST_LIBRARYDIR)
+  MESSAGE("  BOOST_LIBRARYDIR: ${BOOST_LIBRARYDIR}")
+endif()
 
 set(Boost_USE_MULTITHREADED ON)
 
-if ( NOT "${LOCAL_BOOST_ROOT}" STREQUAL "" AND NOT "${LOCAL_BOOST_LIBRARY}" STREQUAL "" )
-   SET(BOOST_ROOT ${LOCAL_BOOST_ROOT})
-   SET(BOOST_LIBRARY ${LOCAL_BOOST_LIBRARY})
-   SET(Boost_REALPATH ON)
-#   SET(Boost_NO_SYSTEM_PATHS ON)
-#   SET(Boost_USE_STATIC_RUNTIME ON)
-#   SET(Boost_USE_STATIC_LIBS ON)
-endif()
-
+MESSAGE("Searching for BOOST:")
 find_package(Boost
 1.60.0
 COMPONENTS regex
@@ -89,10 +90,10 @@ system
 filesystem
 date_time
 serialization REQUIRED)
-MESSAGE("Boost information:")
+MESSAGE("Boost configuration results:")
 MESSAGE("  Boost_INCLUDE_DIRS: ${Boost_INCLUDE_DIR}")
-MESSAGE("  Boost_LIBRARIES: ${Boost_LIBRARIES}")
 MESSAGE("  Boost_LIBRARY_DIRS: ${Boost_LIBRARY_DIRS}")
+MESSAGE("  Boost_LIBRARIES: ${Boost_LIBRARIES}")
 LINK_DIRECTORIES(${Boost_LIBRARY_DIRS})
 
 # This will look for "generated_include_dirs.cmake" in the module path.


### PR DESCRIPTION
This branch fixes the fact that when using `build.sh` with `-boost_root` or `-boost_lib`, any previous options got erased.

It also:
* uses BOOST_LIBRARYDIR instead of BOOST_LIBRARY, which is not correct according to the docs
* cleans up and removes the variables LOCAL_BOOST_ROOT/LOCAL_BOOST_LIBRARY
* adds more examples to `build.sh -h` to show passing cmake variables directly.
* clarifies BOOST diagnostic messages printed by cmake.
