### PR TITLE
Removed default outgroup from consensus tree

### DIFF
--- a/src/core/analysis/mcmc/output/TreeSummary.cpp
+++ b/src/core/analysis/mcmc/output/TreeSummary.cpp
@@ -690,13 +690,6 @@ void TreeSummary::annotateTree( Tree &tree, AnnotationReport report, bool verbos
             {
                 tmp_tree->reroot( outgroup, true );
             }
-            else
-            {
-                std::vector<std::string> tip_names = traces.front()->objectAt(0).getTipNames();
-                std::sort(tip_names.begin(),tip_names.end());
-                std::string outgrp = tip_names[0];
-                tmp_tree->reroot( outgrp, true );
-            }
         }
         else if ( tmp_tree->isRooted() != rooted )
         {


### PR DESCRIPTION
Addresses issue #83 by removing the default outgroup from consensus tree building.
Default outgroup is still used to summarize clades, but the final tree is unrooted.