### PR TITLE
Fix likelihood calculation for discrete characters

### DIFF
--- a/src/core/distributions/phylogenetics/substitution/PhyloCTMCSiteHomogeneous.h
+++ b/src/core/distributions/phylogenetics/substitution/PhyloCTMCSiteHomogeneous.h
@@ -398,7 +398,7 @@ void RevBayesCore::PhyloCTMCSiteHomogeneous<charType>::computeTipLikelihood(cons
 
                         double tmp = 0.0;
 
-                        for ( size_t i=0; i<val.size(); ++i )
+                        for ( size_t i=0; i<this->num_chars; ++i )
                         {
                             // check whether we observed this state
                             if ( val.isSet(i) == true )
@@ -428,7 +428,7 @@ void RevBayesCore::PhyloCTMCSiteHomogeneous<charType>::computeTipLikelihood(cons
 
                         double tmp = 0.0;
                         const std::vector< double >& weights = this->value->getCharacter(char_data_node_index, this_site_index).getWeights();
-                        for ( size_t i=0; i<val.size(); ++i )
+                        for ( size_t i=0; i<this->num_chars; ++i )
                         {
                             // check whether we observed this state
                             if ( val.isSet(i) == true )


### PR DESCRIPTION
When using ambiguous characters, and also partitioning standard data by state number, a bug caused the likelihood calculation to sum over the max state number instead of the number of states per partition.