### PR TITLE
Make sure value is >= 1 when converting Real to IntegerPos

### DIFF
--- a/src/revlanguage/datatypes/basic/Real.cpp
+++ b/src/revlanguage/datatypes/basic/Real.cpp
@@ -307,11 +307,10 @@ double Real::isConvertibleTo(const TypeSpec& type, bool once) const
         return 0.3;
     }
     
-    if ( once && type == IntegerPos::getClassTypeSpec() && dag_node->getValue() == int(dag_node->getValue()) )
+    if ( once && type == IntegerPos::getClassTypeSpec() && dag_node->getValue() >= 1.0 && dag_node->getValue() == int(dag_node->getValue()) )
     {
         return 0.7;
     }
-    
 
     if ( once && type == Natural::getClassTypeSpec() && dag_node->getValue() >= 0.0 && dag_node->getValue() == int(dag_node->getValue()) )
     {


### PR DESCRIPTION
Following up on #96, conversion from `Real` to `IntegerPos` was allowed for values > 0. This fixes that.