### PR TITLE
removing deprecated set-env

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,12 +100,12 @@ jobs:
         sudo apt-get install -y pandoc libcairo2-dev ccache
         if [ "${{ matrix.compiler }}" = "gcc" ]; then
           sudo apt-get install -y g++-${{ matrix.version }}
-          echo "::set-env name=C_COMPILER::gcc-${{ matrix.version }}"
-          echo "::set-env name=CXX_COMPILER::g++-${{ matrix.version }}"
+          echo "C_COMPILER=gcc-${{ matrix.version }}" >> $GITHUB_ENV
+          echo "CXX_COMPILER=g++-${{ matrix.version }}" >> $GITHUB_ENV
         else
           sudo apt-get install -y clang-${{ matrix.version }}
-          echo "::set-env name=C_COMPILER::clang-${{ matrix.version }}"
-          echo "::set-env name=CXX_COMPILER::clang++-${{ matrix.version }}"
+          echo "C_COMPILER=clang-${{ matrix.version }}" >> $GITHUB_ENV
+          echo "CXX_COMPILER=clang++-${{ matrix.version }}" >> $GITHUB_ENV
         fi
         if [ "${{ matrix.mpi }}" = true ] ; then
           sudo apt-get install libopenmpi-dev
@@ -166,9 +166,9 @@ jobs:
           cd boost_1_71_0
           ./bootstrap.sh --with-libraries=atomic,chrono,filesystem,system,regex,thread,date_time,program_options,math,serialization
           ./b2 link=static
-          echo "::set-env name=BOOST_ROOT::${GITHUB_WORKSPACE}/boost_1_71_0"
-          echo "::set-env name=BOOST_INCLUDE_DIR::${GITHUB_WORKSPACE}/boost_1_71_0"
-          echo "::set-env name=BOOST_LIBRARY_DIR::${GITHUB_WORKSPACE}/boost_1_71_0/stage/lib"
+          echo "BOOST_ROOT=${GITHUB_WORKSPACE}/boost_1_71_0" >> $GITHUB_ENV
+          echo "BOOST_INCLUDE_DIR=${GITHUB_WORKSPACE}/boost_1_71_0" >> $GITHUB_ENV
+          echo "BOOST_LIBRARY_DIR=${GITHUB_WORKSPACE}/boost_1_71_0/stage/lib" >> $GITHUB_ENV
         else
           sudo apt-get install -y libboost-dev libboost-program-options-dev libboost-date-time-dev libboost-filesystem-dev libboost-regex-dev libboost-serialization-dev libboost-system-dev libboost-thread-dev
         fi


### PR DESCRIPTION
set-env is deprecated and will be removed eventually (see https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)