### PR TITLE
bug fix for segfault under DEC + stochastic mapping

### DIFF
--- a/src/core/datatypes/phylogenetics/ratematrix/AbstractRateMatrix.cpp
+++ b/src/core/datatypes/phylogenetics/ratematrix/AbstractRateMatrix.cpp
@@ -199,6 +199,16 @@ std::vector<double> AbstractRateMatrix::calculateStationaryFrequencies(void) con
     return pi;
 }
 
+/** This function computes the transition probability matrix that is used for
+ stochastic mapping. In general, we use the matrix uniformization method
+ for stochastic mapping, which requires P(t) = exp(Qt). This function may be
+ overridden if an alternative method is needed to compute P(t) for the model.
+ See RateMatrix_DECRateMatrix for an example.
+ */
+void AbstractRateMatrix::calculateTransitionProbabilitiesForStochasticMapping(double startAge, double endAge, double rate, TransitionProbabilityMatrix& P) const
+{
+    calculateTransitionProbabilities(startAge, endAge, rate, P);
+}
 
 
 /** This function checks that the rate matrix is time reversible. It takes as
@@ -364,7 +374,7 @@ bool AbstractRateMatrix::simulateStochasticMapping(double startAge, double endAg
 
     // transition probabilities
     TransitionProbabilityMatrix P(num_states);
-    calculateTransitionProbabilities(startAge, endAge, rate, P);
+    calculateTransitionProbabilitiesForStochasticMapping(startAge, endAge, rate, P);
 //    exponentiateMatrixByScalingAndSquaring(branch_length * rate, P);
     stochastic_matrix = std::vector<MatrixReal>();
 

--- a/src/core/datatypes/phylogenetics/ratematrix/AbstractRateMatrix.h
+++ b/src/core/datatypes/phylogenetics/ratematrix/AbstractRateMatrix.h
@@ -51,6 +51,7 @@ namespace RevBayesCore {
         // pure virtual methods you have to overwrite
         virtual double                      averageRate(void) const = 0;                                                                //!< Calculate the average rate
         virtual void                        calculateTransitionProbabilities(double startAge, double endAge, double rate, TransitionProbabilityMatrix& P) const = 0;   //!< Calculate the transition matrix
+        virtual void                        calculateTransitionProbabilitiesForStochasticMapping(double startAge, double endAge, double rate, TransitionProbabilityMatrix& P) const;   //!< Calculate the transition matrix
         virtual AbstractRateMatrix*         clone(void) const = 0;
         virtual std::vector<double>         getStationaryFrequencies(void) const = 0;                                                   //!< Return the stationary frequencies
         MatrixReal                          getRateMatrix(void) const;

--- a/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_DECRateMatrix.cpp
+++ b/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_DECRateMatrix.cpp
@@ -412,6 +412,25 @@ void RateMatrix_DECRateMatrix::calculateTransitionProbabilities(double startAge,
     return;
 }
 
+
+/**
+ Stochastic mapping under matrix uniformization requires P(t)=exp(Qt). This
+ relationship does not hold when the DEC rate matrix conditions on survival,
+ P'(t)_ij = P(t)_ij / (1-P(t)_i0). Instead, using the standard P(t) with
+ uniformization guarantees the condition on survival is satisfied, since
+ state 0 is an absorbing state, meaning it cannot be sampled as a possible
+ end state.
+ */
+void RateMatrix_DECRateMatrix::calculateTransitionProbabilitiesForStochasticMapping(double startAge, double endAge, double rate, TransitionProbabilityMatrix& P) const
+{
+    double t = scalingFactor * rate * (startAge - endAge);
+    
+    //We use repeated squaring to quickly obtain exponentials, as in Poujol and Lartillot, Bioinformatics 2014.
+    exponentiateMatrixByScalingAndSquaring(t, P);
+    
+}
+
+
 RateMatrix_DECRateMatrix* RateMatrix_DECRateMatrix::clone( void ) const
 {
     return new RateMatrix_DECRateMatrix( *this );

--- a/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_DECRateMatrix.h
+++ b/src/core/datatypes/phylogenetics/ratematrix/RateMatrix_DECRateMatrix.h
@@ -27,6 +27,7 @@ namespace RevBayesCore {
         // RateMatrix functions
         double                              averageRate(void) const;
         void                                calculateTransitionProbabilities(double startAge, double endAge, double rate, TransitionProbabilityMatrix& P) const;   //!< Calculate the transition matrix
+        void                                calculateTransitionProbabilitiesForStochasticMapping(double startAge, double endAge, double rate, TransitionProbabilityMatrix& P) const;   //!< Calculate the transition matrix
         RateMatrix_DECRateMatrix*           clone(void) const;
         void                                fillRateMatrix(void);
         const RbVector<RbVector<double> >&  getDispersalRates(void) const;


### PR DESCRIPTION
Some time recently the stochastic mapping code was changed to always use calculateTransitionProbabilities(). This was apparently not an issue for most rate matrices, but it caused stochastic mapping under DEC to segfault (invalid index access).

Context: DEC has an option to condition on survival (i.e. not entering the "null range") which is used when computing calculateTransitionProbabilities(). Using method for stochastic mapping causes the algorithm to fail, because the algorithm requires P(t)=exp(Qt) to work. Stochastic mapping under uniformization fails when using P that conditions on survival because P(t|survival) != exp(Qt).

To restore the original functionality, I added a virtual function for calculateTransitionProbabilitiesForStochasticMapping() that by default calls calculateTransitionProbabilities(). RateMatrix_DECRateMatrix::calculateTransitionProbabilitiesForStochasticMapping() computes the unconditional form of P(t)=exp(Qt).