### PR TITLE
fixing bug described in issue #101

### DIFF
--- a/src/revlanguage/functions/argumentrules/ArgumentRule.cpp
+++ b/src/revlanguage/functions/argumentrules/ArgumentRule.cpp
@@ -226,15 +226,15 @@ Argument ArgumentRule::fitArgument( Argument& arg, bool once ) const
         {
             if ( the_var->getRevObject().isType( *it ) )
             {
-                RevPtr<RevVariable> valueVar = RevPtr<RevVariable>( new RevVariable(the_var->getRevObject().clone(),arg.getLabel()) );
+                RevPtr<RevVariable> valueVar = RevPtr<RevVariable>( new RevVariable(the_var->getRevObject().clone(),the_var->getName() ) );
                 return Argument( valueVar, arg.getLabel(), false );
             }
-            else if ( the_var->getRevObject().isConvertibleTo( *it, once ) != -1)
+            else if ( the_var->getRevObject().isConvertibleTo( *it, once ) != -1 )
             {
                 // Fit by type conversion. For now, we also modify the type of the incoming variable wrapper.
                 RevObject* convertedObject = the_var->getRevObject().convertTo( *it );
 
-                RevPtr<RevVariable> valueVar = RevPtr<RevVariable>( new RevVariable(convertedObject,arg.getLabel()) );
+                RevPtr<RevVariable> valueVar = RevPtr<RevVariable>( new RevVariable(convertedObject,the_var->getName() ) );
                 return Argument( valueVar, arg.getLabel(), false );
                 
             }
@@ -259,16 +259,27 @@ Argument ArgumentRule::fitArgument( Argument& arg, bool once ) const
             else if ( the_var->getRevObject().isConvertibleTo( *it, once ) != -1  && (*it).isDerivedOf( the_var->getRequiredTypeSpec() ) )
             {
                 // Fit by type conversion. For now, we also modify the type of the incoming variable wrapper.
-                RevObject* convertedObject = the_var->getRevObject().convertTo( *it );
-                the_var->replaceRevObject( convertedObject );
-                the_var->setRequiredTypeSpec( *it );
-                if ( !isEllipsis() )
+                RevObject* converted_object = the_var->getRevObject().convertTo( *it );
+                
+                RevPtr<RevVariable> the_new_var = NULL;
+                if ( the_var->getRevObject().isConstant() == true )
                 {
-                    return Argument( the_var, arg.getLabel(), false );
+                    the_new_var = the_var;
+                    the_new_var->replaceRevObject( converted_object );
+                    the_new_var->setRequiredTypeSpec( *it );
                 }
                 else
                 {
-                    return Argument( the_var, arg.getLabel(), false );
+                    the_new_var = RevPtr<RevVariable>( new RevVariable(converted_object, the_var->getName() ) );
+                }
+                
+                if ( !isEllipsis() )
+                {
+                    return Argument( the_new_var, arg.getLabel(), false );
+                }
+                else
+                {
+                    return Argument( the_new_var, arg.getLabel(), false );
                 }
             }
             else
@@ -423,7 +434,13 @@ double ArgumentRule::isArgumentValid( Argument &arg, bool once) const
             return 0.0;
         }
         
-        double penalty = the_var->getRevObject().isConvertibleTo( *it, once );
+        double penalty = -1;
+        // make sure that we only perform type casting when the variable will not be part of a model graph
+        if ( once == true || the_var->getRevObject().isConstant() == true )
+        {
+            penalty = the_var->getRevObject().isConvertibleTo( *it, once );
+        }
+        
         if ( penalty != -1 && (*it).isDerivedOf( the_var->getRequiredTypeSpec() ) )
         {
             return penalty;


### PR DESCRIPTION
I have done a minor rewrite of how arguments are converted. Specifically, instead of replacing the value of the original argument, we now create a new variable with the converted type if the function is only executed once.

Note, I did a minor clean-up where we mistakingly set the variable name to the argument name. This now cases a problem with the tests because the test_CBDP has a different header name for one column in the log file. No one had noticed this bug before. We should simply replace the current test result delta -> shift_rate.