### PR TITLE
add option for linking static boost libraries

### DIFF
--- a/projects/cmake/build.sh
+++ b/projects/cmake/build.sh
@@ -14,6 +14,7 @@ help="false"
 jupyter="false"
 boost_root=""
 boost_lib=""
+static_boost="false"
 j=4
 
 cmake_args=""
@@ -31,6 +32,7 @@ while echo $1 | grep ^- > /dev/null; do
 -help           <true|false>    : update the help database and build the YAML help generator. Defaults to false.
 -boost_root     string          : specify directory containing Boost headers (e.g. `/usr/include`). Defaults to unset.
 -boost_lib      string          : specify directory containing Boost libraries. (e.g. `/usr/lib`). Defaults to unset.
+-static_boost	<true|false>    : link using static Boost libraries. Defaults to false.
 -j              integer         : the number of threads to use when compiling RevBayes. Defaults to 4.
 
 You can also specify cmake variables as -DCMAKE_VAR1=value1 -DCMAKE_VAR2=value2
@@ -105,6 +107,10 @@ fi
 
 if [ -n "$boost_lib" ] ; then
     cmake_args="-DBOOST_LIBRARYDIR=\"${boost_lib}\" $cmake_args"
+fi
+
+if [ "$static_boost" = "true" ] ; then
+    cmake_args="-DSTATIC_BOOST=ON $cmake_args"
 fi
 
 if [ "$help" = "true" ] ; then

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,6 +89,10 @@ if (BOOST_LIBRARYDIR)
 endif()
 
 set(Boost_USE_MULTITHREADED ON)
+if ("${STATIC_BOOST}" STREQUAL "ON")
+	MESSAGE("Static linking Boost")
+	set(Boost_USE_STATIC_LIBS ON)
+endif()
 
 MESSAGE("Searching for BOOST:")
 find_package(Boost


### PR DESCRIPTION
I added an option to the build script to activate static linking of Boost in the main `CMakeLists.txt` file. This is for building the Mac release.