### PR TITLE
Rename rbinomial, rnbinomial and rmultinomial argument names to size

### DIFF
--- a/src/revlanguage/distributions/math/Dist_binomial.cpp
+++ b/src/revlanguage/distributions/math/Dist_binomial.cpp
@@ -121,7 +121,7 @@ const MemberRules& Dist_binomial::getParameterRules(void) const
     if ( !rules_set ) 
     {
         dist_member_rules.push_back( new ArgumentRule( "p", Probability::getClassTypeSpec(), "Probability of success.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
-        dist_member_rules.push_back( new ArgumentRule( "n", Natural::getClassTypeSpec()    , "Number of trials.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        dist_member_rules.push_back( new ArgumentRule( "size", Natural::getClassTypeSpec()    , "Number of trials.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
         rules_set = true;
     }
     
@@ -150,7 +150,7 @@ void Dist_binomial::printValue(std::ostream& o) const
     {
         o << "?";
     }
-    o << ", n=";
+    o << ", size=";
     if ( n != NULL )
         o << n->getName();
     else
@@ -167,7 +167,7 @@ void Dist_binomial::setConstParameter(const std::string& name, const RevPtr<cons
     {
         p = var;
     }
-    else if ( name == "n" )
+    else if ( name == "size" )
     {
         n = var;
     }

--- a/src/revlanguage/distributions/math/Dist_multinomial.cpp
+++ b/src/revlanguage/distributions/math/Dist_multinomial.cpp
@@ -115,7 +115,7 @@ const MemberRules& Dist_multinomial::getParameterRules(void) const
     if ( !rules_set )
     {
         dist_member_rules.push_back( new ArgumentRule( "p", Simplex::getClassTypeSpec(), "The simplex of probabilities for the categories.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
-        dist_member_rules.push_back( new ArgumentRule( "n", Natural::getClassTypeSpec(), "The number of draws.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        dist_member_rules.push_back( new ArgumentRule( "size", Natural::getClassTypeSpec(), "The number of draws.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
         rules_set = true;
     }
     
@@ -140,7 +140,7 @@ void Dist_multinomial::printValue(std::ostream& o) const
         o << p->getName();
     else
         o << "?";
-    o << ", n=";
+    o << ", size=";
     if ( n != NULL )
         o << n->getName();
     else
@@ -157,7 +157,7 @@ void Dist_multinomial::setConstParameter(const std::string& name, const RevPtr<c
     {
         p = var;
     }
-    else if ( name == "n" )
+    else if ( name == "size" )
     {
         n = var;
     }

--- a/src/revlanguage/distributions/math/Dist_nbinomial.cpp
+++ b/src/revlanguage/distributions/math/Dist_nbinomial.cpp
@@ -120,7 +120,7 @@ const MemberRules& Dist_nbinomial::getParameterRules(void) const
     
     if ( !rules_set ) 
     {
-        dist_member_rules.push_back( new ArgumentRule( "r", Natural::getClassTypeSpec(), "Number of failures.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        dist_member_rules.push_back( new ArgumentRule( "size", Natural::getClassTypeSpec(), "Number of failures.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
         dist_member_rules.push_back( new ArgumentRule( "p", Probability::getClassTypeSpec()    , "Probability of success.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
         rules_set = true;
     }
@@ -141,7 +141,7 @@ const TypeSpec& Dist_nbinomial::getTypeSpec( void ) const
 void Dist_nbinomial::printValue(std::ostream& o) const
 {
     
-    o << "NegativeBinomial(r=";
+    o << "NegativeBinomial(size=";
     if ( r != NULL )
     {
         o << r->getName();
@@ -167,7 +167,7 @@ void Dist_nbinomial::setConstParameter(const std::string& name, const RevPtr<con
     {
         p = var;
     }
-    else if ( name == "r" )
+    else if ( name == "size" )
     {
         r = var;
     }

--- a/src/revlanguage/functions/DistributionFunctionRv.h
+++ b/src/revlanguage/functions/DistributionFunctionRv.h
@@ -76,7 +76,7 @@ RevLanguage::DistributionFunctionRv<valueType>::DistributionFunctionRv( TypedDis
     templateObject( d )
 {
     
-    argRules.push_back( new ArgumentRule("size", Natural::getClassTypeSpec(), "Number of random values to draw.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new Natural(1)));
+    argRules.push_back( new ArgumentRule("n", Natural::getClassTypeSpec(), "Number of random values to draw.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new Natural(1)));
     const ArgumentRules &memberRules = templateObject->getParameterRules();
     for (std::vector<ArgumentRule*>::const_iterator it = memberRules.begin(); it != memberRules.end(); ++it)
     {

--- a/src/revlanguage/functions/DistributionFunctionRv.h
+++ b/src/revlanguage/functions/DistributionFunctionRv.h
@@ -76,7 +76,7 @@ RevLanguage::DistributionFunctionRv<valueType>::DistributionFunctionRv( TypedDis
     templateObject( d )
 {
     
-    argRules.push_back( new ArgumentRule("n", Natural::getClassTypeSpec(), "Number of random values to draw.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new Natural(1)));
+    argRules.push_back( new ArgumentRule("size", Natural::getClassTypeSpec(), "Number of random values to draw.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new Natural(1)));
     const ArgumentRules &memberRules = templateObject->getParameterRules();
     for (std::vector<ArgumentRule*>::const_iterator it = memberRules.begin(); it != memberRules.end(); ++it)
     {


### PR DESCRIPTION
This solves issue #135 and brings the Rev syntax inline with R.