### PR TITLE
Use correct number of sites in mnSiteMixtureAllocation

### DIFF
--- a/src/core/monitors/SiteMixtureAllocationMonitor.h
+++ b/src/core/monitors/SiteMixtureAllocationMonitor.h
@@ -128,7 +128,7 @@ void SiteMixtureAllocationMonitor<characterType>::monitorVariables(unsigned long
 	// TODO: come up with a way to do this that doesn't involve ancestral states
 	AbstractPhyloCTMCSiteHomogeneous<characterType> *dist_ctmc = static_cast<AbstractPhyloCTMCSiteHomogeneous<characterType>* >( &ctmc->getDistribution() );
 	const TypedDagNode<Tree> *tree = dist_ctmc->getTree();
-	size_t num_sites = dist_ctmc->getValue().getNumberOfCharacters();
+	size_t num_sites = dist_ctmc->getValue().getNumberOfIncludedCharacters();
 	size_t num_nodes = tree->getValue().getNumberOfNodes();
 	std::vector<std::vector<characterType> > startStates(num_nodes,std::vector<characterType>(num_sites));
 	std::vector<std::vector<characterType> > endStates(num_nodes,std::vector<characterType>(num_sites));


### PR DESCRIPTION
The SiteMixtureAllocation monitor was using the total number of characters, not the number of included characters, to report site matrix mixture allocations. This solves issue #147.