### PR TITLE
Generalize the incomplete gamma function

### DIFF
--- a/src/core/distributions/phylogenetics/substitution/PhyloCTMCSiteHomogeneous.h
+++ b/src/core/distributions/phylogenetics/substitution/PhyloCTMCSiteHomogeneous.h
@@ -255,7 +255,7 @@ void RevBayesCore::PhyloCTMCSiteHomogeneous<charType>::computeInternalNodeLikeli
                 // store the likelihood for this starting state
                 p_site_mixture[c1] = sum;
                 
-                //assert(0.0 <= sum and sum <= 1.00000000001);
+                assert(0.0 <= sum and sum <= 1.00000000001);
 
                 // increment the pointers to the next starting state
                 tp_a+=this->num_chars;
@@ -316,7 +316,7 @@ void RevBayesCore::PhyloCTMCSiteHomogeneous<charType>::computeInternalNodeLikeli
 
                 } // end-for over all distination character
                 
-                //assert(0 <= sum and sum <= 1.00000000001);
+                assert(0 <= sum and sum <= 1.00000000001);
 
                 // store the likelihood for this starting state
                 p_site_mixture[c1] = sum;

--- a/src/core/distributions/phylogenetics/substitution/PhyloCTMCSiteHomogeneous.h
+++ b/src/core/distributions/phylogenetics/substitution/PhyloCTMCSiteHomogeneous.h
@@ -255,7 +255,7 @@ void RevBayesCore::PhyloCTMCSiteHomogeneous<charType>::computeInternalNodeLikeli
                 // store the likelihood for this starting state
                 p_site_mixture[c1] = sum;
                 
-                assert(0.0 <= sum and sum <= 1.00000000001);
+                //assert(0.0 <= sum and sum <= 1.00000000001);
 
                 // increment the pointers to the next starting state
                 tp_a+=this->num_chars;
@@ -316,7 +316,7 @@ void RevBayesCore::PhyloCTMCSiteHomogeneous<charType>::computeInternalNodeLikeli
 
                 } // end-for over all distination character
                 
-                assert(0 <= sum and sum <= 1.00000000001);
+                //assert(0 <= sum and sum <= 1.00000000001);
 
                 // store the likelihood for this starting state
                 p_site_mixture[c1] = sum;

--- a/src/core/distributions/phylogenetics/tree/MultispeciesCoalescentUniformPrior.cpp
+++ b/src/core/distributions/phylogenetics/tree/MultispeciesCoalescentUniformPrior.cpp
@@ -81,7 +81,7 @@ double MultispeciesCoalescentUniformPrior::computeLnCoalescentProbability(size_t
 //    double gamma = RbMath::gamma(shape);
     
 //    Gamma(n-2,2*fn/theta_max)
-    double lower_incomplete_gamma = RbMath::incompleteGamma( 2*fn/theta_max, n-1, RbMath::lnGamma(n-1) );
+    double lower_incomplete_gamma = RbMath::incompleteGamma( 2*fn/theta_max, n-1 );
     
     double gamma = RbMath::lnGamma(n-1);
     gamma = 0.0;

--- a/src/core/distributions/phylogenetics/tree/MultispeciesCoalescentUniformPrior.cpp
+++ b/src/core/distributions/phylogenetics/tree/MultispeciesCoalescentUniformPrior.cpp
@@ -76,19 +76,9 @@ double MultispeciesCoalescentUniformPrior::computeLnCoalescentProbability(size_t
     
     double ln_prob_coal = RbConstants::LN2 - log( fn ) * (n-1) - log( theta_max );
     
-//    shape, rate/x
-//    double lowerIncompleteGamma = RbMath::incompleteGamma( rate/x, shape, RbMath::lnGamma(shape) );
-//    double gamma = RbMath::gamma(shape);
-    
-//    Gamma(n-2,2*fn/theta_max)
     double lower_incomplete_gamma = RbMath::incompleteGamma( 2*fn/theta_max, n-1 );
     
-    double gamma = RbMath::lnGamma(n-1);
-    gamma = 0.0;
-
-    ln_prob_coal -= log( lower_incomplete_gamma ) - gamma;
-    
-    return ln_prob_coal;
+    return ln_prob_coal - log( lower_incomplete_gamma );
 }
 
 

--- a/src/core/functions/distribution/DiscretizeGammaFromBetaQuantilesFunction.cpp
+++ b/src/core/functions/distribution/DiscretizeGammaFromBetaQuantilesFunction.cpp
@@ -108,14 +108,13 @@ void RevBayesCore::DiscretizeGammaFromBetaQuantilesFunction::update( void )
         /* the mean value for each category is used to represent all of the values
         in that category */
         /* calculate the cumulative values */
-        double lnGammaValue = RbMath::lnGamma(s + 1.0);
         for (size_t i=0; i<nCats-1; i++)
         {
             (*value)[i] = RbStatistics::Gamma::quantile(s,r,beta_quants[i+1]);
       }
         for (size_t i=0; i<nCats-1; i++)
         {
-            (*value)[i] = RbMath::incompleteGamma((*value)[i] * r, s + 1.0, lnGammaValue);
+            (*value)[i] = RbMath::incompleteGamma((*value)[i] * r, s + 1.0);
         }
         (*value)[nCats-1] = 1.0;
 

--- a/src/core/functions/distribution/DiscretizeGammaFunction.cpp
+++ b/src/core/functions/distribution/DiscretizeGammaFunction.cpp
@@ -86,9 +86,8 @@ void RevBayesCore::DiscretizeGammaFunction::update( void )
         for (int i=0; i<nCats-1; i++) 
             (*value)[i] = RbStatistics::ChiSquare::quantile((i + 1.0) / nCats, 2.0 * a) / (2.0 * b);
         /* calculate the cumulative values */
-        double lnGammaValue = RbMath::lnGamma(a + 1.0);
         for (int i=0; i<nCats-1; i++) 
-            (*value)[i] = RbMath::incompleteGamma((*value)[i] * b, a + 1.0, lnGammaValue);
+            (*value)[i] = RbMath::incompleteGamma((*value)[i] * b, a + 1.0);
         (*value)[nCats-1] = 1.0;
         /* calculate the relative values and rescale */
         for (int i=nCats-1; i>0; i--){

--- a/src/core/math/RbMathFunctions.cpp
+++ b/src/core/math/RbMathFunctions.cpp
@@ -630,7 +630,7 @@ double RbMath::incompleteBeta(double a, double b, double x) {
  */
 
 
-double RbMath::incompleteGamma(double x, double alpha, double scale) {
+double RbMath::incompleteGamma(double x, double alpha) {
 
     // (1) series expansion     if (alpha>x || x<=1)
     // (2) continued fraction   otherwise
@@ -648,11 +648,11 @@ double RbMath::incompleteGamma(double x, double alpha, double scale) {
     if (x < 0.0 || alpha <= 0.0) 
     {
         std::ostringstream s;
-        s << "Cannot compute incomplete gamma function for x = " << x << ", alpha = " << alpha << "and scale = " << scale;
+        s << "Cannot compute incomplete gamma function for x = " << x << ", alpha = " << alpha;
         throw RbException(s.str());
     }
     
-    factor = exp(alpha * log(x) - x - scale);
+    factor = exp(alpha * log(x) - x - RbMath::lnGamma(alpha));
     
     if (x > 1 && x >= alpha) {
         // continued fraction
@@ -711,73 +711,6 @@ double RbMath::incompleteGamma(double x, double alpha, double scale) {
     }
     return gin;
 
-}
-
-
-double RbMath::incompleteGamma_old(double x, double alpha, double scale) {
-    
-	double			p = alpha, g = scale,
-    accurate = 1e-8, overflow = 1e30,
-    rn = 0.0, a = 0.0, b = 0.0, an = 0.0, 
-    gin, dif = 0.0, term = 0.0, pn[6];
-    
-	if (x == 0.0) 
-		return (0.0);
-	if (x < 0 || p <= 0) 
-		return (-1.0);
-    
-	double factor = exp(p*log(x)-x-g);   
-	if (x > 1 && x >= p) 
-		goto l30;
-	gin = 1.0;  
-	term = 1.0;  
-	rn = p;
-l20:
-    rn++;
-    term *= x/rn;   
-    gin += term;
-    if (term > accurate) 
-        goto l20;
-    gin *= factor/p;
-    goto l50;
-l30:
-    a = 1.0-p;   
-    b = a+x+1.0;  
-    term = 0.0;
-    pn[0] = 1.0;  
-    pn[1] = x;  
-    pn[2] = x+1;  
-    pn[3] = x*b;
-    gin = pn[2]/pn[3];
-l32:
-    a++;  
-    b += 2.0;  
-    term++;   
-    an = a*term;
-    for (int i=0; i<2; i++) 
-        pn[i+4] = b*pn[i+2]-an*pn[i];
-    if (pn[5] == 0) 
-        goto l35;
-    rn = pn[4]/pn[5];   
-    dif = fabs(gin-rn);
-    if (dif>accurate) 
-        goto l34;
-    if (dif<=accurate*rn) 
-        goto l42;
-l34:
-    gin = rn;
-l35:
-    for (int i=0; i<4; i++) 
-        pn[i] = pn[i+2];
-    if (fabs(pn[4]) < overflow) 
-        goto l32;
-    for (int i=0; i<4; i++) 
-        pn[i] /= overflow;
-    goto l32;
-l42:
-    gin = 1.0-factor*gin;
-l50:
-    return (gin);
 }
 
 

--- a/src/core/math/RbMathFunctions.cpp
+++ b/src/core/math/RbMathFunctions.cpp
@@ -616,27 +616,32 @@ double RbMath::incompleteBeta(double a, double b, double x) {
 	return value;
 }
 
+
 /*!
- * This function returns the incomplete gamma ratio I(x,alpha) where x is
- * the upper limit of the integration and alpha is the shape parameter.
+* This function returns the incomplete gamma function
+ * where x is the upper or lower limit of the integration
+ * and alpha is the shape parameter.
  *
  * \brief Incomplete gamma function.
  * \param alpha is the shape parameter of the gamma. 
  * \param x is the upper limit of integration. 
- * \return Returns -1 if in error and the incomplete gamma ratio otherwise. 
- * \throws Does not throw an error.
+ * \param regularized indicates the regularized incomplete gamma
+ * \param lower indicates x is the lower limit of integration, upper otherwise
+ * \return Returns the incomplete gamma function.
+ * \throws RbException on error
  * \see Bhattacharjee, G. P. 1970. The incomplete gamma integral. Applied 
  *      Statistics, 19:285-287.
  */
 
 
-double RbMath::incompleteGamma(double x, double alpha) {
+double RbMath::incompleteGamma(double x, double alpha, bool regularized, bool lower)
+{
 
     // (1) series expansion     if (alpha>x || x<=1)
     // (2) continued fraction   otherwise
     // RATNEST FORTRAN by
     // Bhattacharjee GP (1970) The incomplete gamma integral.  Applied Statistics,
-    // 19: 285-287 (AS32)
+    // 19: 285-287 (ASA032)
     
     double accurate = 1e-8, overflow = 1e30;
     double factor, gin, rn, a, b, an, dif, term;
@@ -652,7 +657,8 @@ double RbMath::incompleteGamma(double x, double alpha) {
         throw RbException(s.str());
     }
     
-    factor = exp(alpha * log(x) - x - RbMath::lnGamma(alpha));
+    double scale = regularized ? RbMath::lnGamma(alpha) : 0.0;
+    factor = exp(alpha * log(x) - x - scale );
     
     if (x > 1 && x >= alpha) {
         // continued fraction
@@ -709,7 +715,7 @@ double RbMath::incompleteGamma(double x, double alpha) {
         while (term > accurate);
         gin *= factor / alpha;
     }
-    return gin;
+    return lower ? gin : 1.0 - gin;
 
 }
 

--- a/src/core/math/RbMathFunctions.cpp
+++ b/src/core/math/RbMathFunctions.cpp
@@ -648,7 +648,7 @@ double RbMath::incompleteGamma(double x, double alpha, bool regularized, bool lo
     double pn0, pn1, pn2, pn3, pn4, pn5;
     
     if (x == 0.0) {
-        return 0.0;
+        return lower ? 0.0 : RbMath::gamma(alpha);
     }
     if (x < 0.0 || alpha <= 0.0) 
     {

--- a/src/core/math/RbMathFunctions.h
+++ b/src/core/math/RbMathFunctions.h
@@ -32,8 +32,7 @@ namespace RevBayesCore {
         double                      gamma(double x);                                                                //!< Calculate the Gamma function 
         double                      gamma_old(double x);                                                            //!< Calculate the Gamma function 
         double                      incompleteBeta(double a, double b, double x);                                   //!< Xxx 
-        double                      incompleteGamma(double x, double alpha, double scale);                          //!< Xxx 
-        double                      incompleteGamma_old(double x, double alpha, double scale);                      //!< Xxx 
+        double                      incompleteGamma(double x, double alpha);                                        //!< Xxx
         double                      lnGamma_sign(double a, int *sgn);                                               //!< Calculate the log of the Gamma function
         double                      lnGamma(double a);                                                              //!< Calculate the log of the Gamma function
         double                      lnGamma_old(double a);                                                          //!< Calculate the log of the Gamma function

--- a/src/core/math/RbMathFunctions.h
+++ b/src/core/math/RbMathFunctions.h
@@ -32,7 +32,7 @@ namespace RevBayesCore {
         double                      gamma(double x);                                                                //!< Calculate the Gamma function 
         double                      gamma_old(double x);                                                            //!< Calculate the Gamma function 
         double                      incompleteBeta(double a, double b, double x);                                   //!< Xxx 
-        double                      incompleteGamma(double x, double alpha);                                        //!< Xxx
+        double                      incompleteGamma(double x, double alpha, bool regularized=true, bool lower=true);//!< Xxx
         double                      lnGamma_sign(double a, int *sgn);                                               //!< Calculate the log of the Gamma function
         double                      lnGamma(double a);                                                              //!< Calculate the log of the Gamma function
         double                      lnGamma_old(double a);                                                          //!< Calculate the log of the Gamma function

--- a/src/core/math/RbStatisticsHelper.cpp
+++ b/src/core/math/RbStatisticsHelper.cpp
@@ -158,7 +158,7 @@ double RbStatistics::Helper::pointChi2(double prob, double v) {
     do {
         q = ch;
         p1 = 0.5 * ch;
-        if ((t = RbMath::incompleteGamma(p1, xx, g)) < 0) {
+        if ((t = RbMath::incompleteGamma(p1, xx)) < 0) {
             throw new RbException("Arguments out of range: t < 0");
         }
         p2 = p - t;

--- a/src/core/math/distributions/DistributionChisq.cpp
+++ b/src/core/math/distributions/DistributionChisq.cpp
@@ -146,7 +146,7 @@ double RbStatistics::ChiSquare::quantile(double prob, double df)
         double last_improv = q - ch;
 		q = ch; 
 		p1 = 0.5*ch;
-		if ((t = RbMath::incompleteGamma(p1, xx, g)) < 0.0)
+		if ((t = RbMath::incompleteGamma(p1, xx)) < 0.0)
         {
             std::cerr<<"\nerr IncompleteGamma";
 			return (-1.0);

--- a/src/core/math/distributions/DistributionGamma.cpp
+++ b/src/core/math/distributions/DistributionGamma.cpp
@@ -104,7 +104,7 @@ double RbStatistics::Gamma::lnPdf(double shape, double rate, double x)
 double RbStatistics::Gamma::cdf(double shape, double rate, double x)
 {
     
-	return RbMath::incompleteGamma( rate*x, shape, RbMath::lnGamma(shape) );
+	return RbMath::incompleteGamma( rate*x, shape );
 }
 
 /*!

--- a/src/core/math/distributions/DistributionInverseGamma.cpp
+++ b/src/core/math/distributions/DistributionInverseGamma.cpp
@@ -111,7 +111,7 @@ double RbStatistics::InverseGamma::lnPdf(double shape, double rate, double x)
 double RbStatistics::InverseGamma::cdf(double shape, double rate, double x)
 {
 
-    double lower_incomplete_gamma = RbMath::incompleteGamma( rate/x, shape, RbMath::lnGamma(shape) );
+    double lower_incomplete_gamma = RbMath::incompleteGamma( rate/x, shape );
     
     return 1 - lower_incomplete_gamma;
 }

--- a/src/core/math/distributions/DistributionInverseGamma.cpp
+++ b/src/core/math/distributions/DistributionInverseGamma.cpp
@@ -110,10 +110,7 @@ double RbStatistics::InverseGamma::lnPdf(double shape, double rate, double x)
  */
 double RbStatistics::InverseGamma::cdf(double shape, double rate, double x)
 {
-
-    double lower_incomplete_gamma = RbMath::incompleteGamma( rate/x, shape );
-    
-    return 1 - lower_incomplete_gamma;
+    return RbMath::incompleteGamma( rate/x, shape, true, false );
 }
 
 /*!


### PR DESCRIPTION
The internal RevBayes function for the incomplete gamma integral was implemented using [this algorithm](https://people.sc.fsu.edu/~jburkardt/cpp_src/asa032/asa032.html) for the regularized lower incomplete gamma function. I've generalized the function so now you can choose whether it should be regularized, and whether to use the upper or lower limits of integration.

The previous function had an extra argument `scale` that determined the scale over which the function should be regularized.
I didn't see any need for this since it is always just &Gamma;(&alpha;). The only reason I can think this was included was for some small optimization from eliminating repeated calls to the gamma function, or simply for hidden testing purposes. I went ahead and removed it.