### PR TITLE
Check for _WIN32 instead of RB_WIN when checking for windows.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -49,7 +49,6 @@ add_project_arguments([# These just add noise:
 # Handle file too large error when cross-compiling to windows
 if host_machine.system() == 'windows'
   add_project_arguments(['-Wa,-mbig-obj'], language : 'cpp')
-  add_project_arguments(['-DRB_WIN'], language : 'cpp')
 endif
 
 boost_modules = [ 'regex',

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -61,10 +61,6 @@ if ("${MPI}" STREQUAL "ON")
    set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} ${MPI_LINK_FLAGS}")
 endif()
 
-if (WIN32)
-   add_definitions(-DRB_WIN)
-endif()
-
 if ("${JUPYTER}" STREQUAL "ON")
    add_definitions(-DRB_XCODE)
 endif()

--- a/src/cmd/RbGTKGui.cpp
+++ b/src/cmd/RbGTKGui.cpp
@@ -496,7 +496,7 @@ static void menuitem_set_wd_response( gchar *string )
         RevBayesCore::RbFileManager fm = RevBayesCore::RbFileManager( std::string(filename) );
         
         std::string fn = std::string(filename);
-#       if defined (RB_WIN)
+#       if defined (_WIN32)
         StringUtilities::replaceSubstring(fn, "\\", "\\\\");
 #       endif
 
@@ -528,7 +528,7 @@ static void menuitem_source_response( gchar *string )
         filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (dialog));
         std::string fn = std::string(filename);
 
-#       if defined (RB_WIN)
+#       if defined (_WIN32)
         StringUtilities::replaceSubstring(fn, "\\", "\\\\");
 #       endif
         

--- a/src/core/io/NclReader.cpp
+++ b/src/core/io/NclReader.cpp
@@ -1286,7 +1286,7 @@ std::vector<AbstractCharacterData*> NclReader::readMatrices(const std::string &f
         myFileManager.setStringWithNamesOfFilesInDirectory(vectorOffile_names);
     else
     {
-#       if defined (RB_WIN)
+#       if defined (_WIN32)
         vectorOffile_names.push_back( myFileManager.getFilePath() + "\\" + myFileManager.getFileName() );
 #       else
         vectorOffile_names.push_back( myFileManager.getFilePath() + "/" + myFileManager.getFileName() );
@@ -1686,7 +1686,7 @@ std::vector<Tree*>* NclReader::readBranchLengthTrees(const std::string &fn)
         std::string filepath = myFileManager.getFilePath();
         if ( filepath != "" )
         {
-#           if defined RB_WIN
+#           if defined _WIN32
             filepath += "\\";
 #           else
             filepath += "/";

--- a/src/core/utils/RbFileManager.cpp
+++ b/src/core/utils/RbFileManager.cpp
@@ -13,7 +13,7 @@
 #include "StringUtilities.h"
 #include "boost/filesystem/path.hpp"
 
-#ifdef RB_WIN
+#ifdef _WIN32
 #	include <dirent.h>
 #   include <unistd.h>
 #   include <windows.h>
@@ -36,7 +36,7 @@ RbFileManager::RbFileManager( void ) :
     new_line( "" )
 {
     
-#	ifdef RB_WIN
+#	ifdef _WIN32
     path_separator = "\\";
     new_line = "\r\n";
 #   else
@@ -54,7 +54,7 @@ RbFileManager::RbFileManager( void ) :
     full_file_name += file_name;
     
     
-#    ifdef RB_WIN
+#    ifdef _WIN32
     StringUtilities::replaceSubstring(full_file_name,"/","\\");
 #   endif
     
@@ -69,7 +69,7 @@ RbFileManager::RbFileManager(const std::string &fn) :
     path_separator( "" )
 {
     
-#	ifdef RB_WIN
+#	ifdef _WIN32
     path_separator = "\\";
 #	else
     path_separator = "/";
@@ -77,7 +77,7 @@ RbFileManager::RbFileManager(const std::string &fn) :
     
     parsePathFileNames( fn );
     
-#   ifdef RB_WIN
+#   ifdef _WIN32
     StringUtilities::replaceSubstring(file_path,"/","\\");
 #   endif
     
@@ -89,7 +89,7 @@ RbFileManager::RbFileManager(const std::string &fn) :
     
     full_file_name += file_name;
     
-#   ifdef RB_WIN
+#   ifdef _WIN32
     StringUtilities::replaceSubstring(full_file_name,"/","\\");
 #   endif
     
@@ -104,7 +104,7 @@ RbFileManager::RbFileManager(const std::string &pn, const std::string &fn) :
     path_separator( "" )
 {
     
-#	ifdef RB_WIN
+#	ifdef _WIN32
     path_separator = "\\";
     new_line = "\r\n";
 #	else
@@ -116,7 +116,7 @@ RbFileManager::RbFileManager(const std::string &pn, const std::string &fn) :
     std::string tmp = pn + path_separator + fn;
     parsePathFileNames( tmp );
 
-#   ifdef RB_WIN
+#   ifdef _WIN32
     StringUtilities::replaceSubstring(file_path,"/","\\");
 #   endif
     
@@ -128,7 +128,7 @@ RbFileManager::RbFileManager(const std::string &pn, const std::string &fn) :
     
     full_file_name += file_name;
     
-#   ifdef RB_WIN
+#   ifdef _WIN32
     StringUtilities::replaceSubstring(full_file_name,"/","\\");
 #   endif
     
@@ -206,7 +206,7 @@ std::string RbFileManager::expandUserDir(std::string path)
         char const *hdrive = getenv("HOMEDRIVE"), *hpath = getenv("HOMEPATH");
         if ( hdrive != NULL )
         {
-# ifdef RB_WIN
+# ifdef _WIN32
             path = std::string(hdrive) + hpath + "\\" + path;
 # else
             path.replace(0, 1, std::string(hdrive) + hpath);
@@ -613,7 +613,7 @@ bool RbFileManager::listDirectoryContents(const std::string& dirpath)
 bool RbFileManager::makeDirectory(const std::string &dn)
 {
     
-#	ifdef RB_WIN
+#	ifdef _WIN32
     
     CreateDirectory(dn.c_str(), NULL);
     
@@ -683,7 +683,7 @@ bool RbFileManager::parsePathFileNames(const std::string &input_string)
 {
     std::string name = input_string;
     
-#	ifdef RB_WIN
+#	ifdef _WIN32
     StringUtilities::replaceSubstring(name,"/","\\");
 #   endif
     
@@ -813,7 +813,7 @@ void RbFileManager::setFileName(std::string const &s)
 void RbFileManager::setFilePath(std::string const &s)
 {
     file_path = s;
-#	ifdef RB_WIN
+#	ifdef _WIN32
     StringUtilities::replaceSubstring(file_path,"/","\\");
 #   endif
     
@@ -856,7 +856,7 @@ bool RbFileManager::setStringWithNamesOfFilesInDirectory(const std::string& dirp
             
             bool skip_me = false;
 
-#ifdef RB_WIN
+#ifdef _WIN32
             if (stat( entrypath.c_str(), &entryinfo )) {
               // if this returned a non-zero value, something is wrong
               skip_me = true;

--- a/src/core/utils/RbSettings.cpp
+++ b/src/core/utils/RbSettings.cpp
@@ -11,7 +11,7 @@
 #include "RbFileManager.h"
 #include "StringUtilities.h"
 
-#	ifdef RB_WIN
+#	ifdef _WIN32
 #include <windows.h>
 #   endif
 
@@ -169,7 +169,7 @@ void RbSettings::initializeUserSettings(void)
     }
 
     // initialize the current directory to be the directory the binary is sitting in
-#	ifdef RB_WIN
+#	ifdef _WIN32
     
     char buffer[MAX_DIR_PATH];
     GetModuleFileName( NULL, buffer, MAX_DIR_PATH );

--- a/src/core/utils/StringUtilities.cpp
+++ b/src/core/utils/StringUtilities.cpp
@@ -263,7 +263,7 @@ std::string StringUtilities::formatStringForScreen(const std::string &s, const s
 std::string StringUtilities::getStringWithDeletedLastPathComponent(const std::string& s)
 {
     
-#	ifdef RB_WIN
+#	ifdef _WIN32
     std::string pathSeparator = "\\";
 #	else
     std::string pathSeparator = "/";
@@ -329,7 +329,7 @@ std::string StringUtilities::getFileContentsAsString(const std::string& s)
 /** Find the last component of a file path */
 std::string StringUtilities::getLastPathComponent(const std::string& s)
 {
-#	ifdef RB_WIN
+#	ifdef _WIN32
     std::string pathSeparator = "\\";
 #	else
     std::string pathSeparator = "/";


### PR DESCRIPTION
_WIN32 is automatically defined by compilers when targeting the windows
ABI (either 32-bit or 64-bit).  Instead of defining our own flag, we should use that.
