### PR TITLE
Update slice sampling

### DIFF
--- a/src/core/moves/SliceSamplingMove.cpp
+++ b/src/core/moves/SliceSamplingMove.cpp
@@ -302,7 +302,8 @@ find_slice_boundaries_doubling(double x0,slice_function& g,double logy, double w
 
     //  std::cerr<<"[]    L0 = "<<L<<"   x0 = "<<x0<<"   R0 = "<<R<<"\n";
 
-    return {L,R,gL_cached,gR_cached};
+    // FIXME: GCC 5 complains if we don't write out the tuple type. GCC 7 does not need it.  How about GCC 6?
+    return std::tuple<double,double,optional<double>,optional<double>>{L,R,gL_cached,gR_cached};
 }
 
 double search_interval(double x0,double& L, double& R, slice_function& g,double logy)

--- a/src/core/moves/SliceSamplingMove.h
+++ b/src/core/moves/SliceSamplingMove.h
@@ -26,7 +26,9 @@ namespace RevBayesCore {
     class SliceSamplingMove : public AbstractMove {
 
     public:
-        SliceSamplingMove(StochasticNode<double> *p, double window_, double weight_, bool autoTune = false);        //!< Constructor
+        enum BoundarySearchMethod { search_stepping_out, search_doubling };
+
+        SliceSamplingMove(StochasticNode<double> *p, double window_, double weight_, BoundarySearchMethod, bool autoTune = false);        //!< Constructor
         virtual                                                 ~SliceSamplingMove(void);                           //!< Destructor
 
         // public methods
@@ -50,6 +52,7 @@ namespace RevBayesCore {
         double                                                  window;                                             //!< Window width for slice sampling
         double                                                  total_movement;                                     //!< total distance moved under auto-tuning
         int                                                     numPr;                                              //!< Number of probability evaluations
+        BoundarySearchMethod                                    search_method;                                      //!< Method of searching for the slice boundary.
     };
 }
 

--- a/src/revlanguage/moves/scalar/Move_SliceSampling.cpp
+++ b/src/revlanguage/moves/scalar/Move_SliceSampling.cpp
@@ -4,6 +4,7 @@
 
 #include "ArgumentRule.h"
 #include "ArgumentRules.h"
+#include "OptionRule.h"
 #include "RlBoolean.h"
 #include "ContinuousStochasticNode.h"
 #include "Move_SliceSampling.h"
@@ -17,6 +18,7 @@
 #include "RevPtr.h"
 #include "RevVariable.h"
 #include "RlMove.h"
+#include "RlString.h"
 
 namespace RevBayesCore { template <class valueType> class TypedDagNode; }
 
@@ -69,9 +71,19 @@ void Move_SliceSampling::constructInternalObject( void )
     RevBayesCore::ContinuousStochasticNode *node_ = static_cast<RevBayesCore::ContinuousStochasticNode *>( tmp );
     bool tune_ = static_cast<const RlBoolean &>( tune->getRevObject() ).getValue();
 
+    auto search_method_ = dynamic_cast<const RlString&>( search_method->getRevObject() ).getValue();
+    typedef RevBayesCore::SliceSamplingMove::BoundarySearchMethod search_method_t;
+    search_method_t search_method__;
+    if (search_method_ == "doubling")
+        search_method__ = RevBayesCore::SliceSamplingMove::BoundarySearchMethod::search_doubling;
+    else if (search_method_ == "stepping_out")
+        search_method__ = RevBayesCore::SliceSamplingMove::BoundarySearchMethod::search_stepping_out;
+    else
+        throw RbException("mvSlice: search_method should be \"doubling\" or \"stepping out\"");
+
     // finally create the internal move object
 
-    value = new RevBayesCore::SliceSamplingMove(node_ , window_, weight_ ,tune_);
+    value = new RevBayesCore::SliceSamplingMove(node_ , window_, weight_ , search_method__, tune_);
 }
 
 
@@ -143,6 +155,11 @@ const MemberRules& Move_SliceSampling::getParameterRules(void) const
         const MemberRules& inheritedRules = Move::getParameterRules();
         move_member_rules.insert( move_member_rules.end(), inheritedRules.begin(), inheritedRules.end() );
 
+        std::vector<std::string> optionsMethod;
+        optionsMethod.push_back( "stepping_out" );
+        optionsMethod.push_back( "doubling" );
+        move_member_rules.push_back( new OptionRule( "search_method", new RlString("doubling"), optionsMethod, "The method used to find the slice boundaries." ) );
+
         rules_set = true;
     }
 
@@ -205,6 +222,10 @@ void Move_SliceSampling::setConstParameter(const std::string& name, const RevPtr
     else if ( name == "tune" )
     {
         tune = var;
+    }
+    else if ( name == "search_method" )
+    {
+        search_method = var;
     }
     else
     {

--- a/src/revlanguage/moves/scalar/Move_SliceSampling.h
+++ b/src/revlanguage/moves/scalar/Move_SliceSampling.h
@@ -48,6 +48,7 @@ namespace RevLanguage {
         RevPtr<const RevVariable>                   x;                                                                                          //!< The variable on which the move works
         RevPtr<const RevVariable>                   window;                                                                                     //!< The tuning parameter
         RevPtr<const RevVariable>                   tune;                                                                                       //!< If autotuning should be used.
+        RevPtr<const RevVariable>                   search_method;                                                                              //!< How to find the slice boundaries.
         
     };
     


### PR DESCRIPTION
Hi,

This updates slice sampling to use the "doubling" strategy instead of the "stepping out" strategy to find slice boundaries.

It also introduces a new argument to mvSlice to select between the two strategies -- by the new "doubling" strategy is used by default.

I have done some basic testing, and the "doubling" strategy can definitely speed up burnin, in cases where you want a large step size initially, but not generally.

-BenRI