### PR TITLE
Allow intermediate `nan` likelihoods in PhyloCTMC

### DIFF
--- a/src/core/distributions/phylogenetics/substitution/PhyloCTMCSiteHomogeneous.h
+++ b/src/core/distributions/phylogenetics/substitution/PhyloCTMCSiteHomogeneous.h
@@ -256,8 +256,6 @@ void RevBayesCore::PhyloCTMCSiteHomogeneous<charType>::computeInternalNodeLikeli
 
                 // store the likelihood for this starting state
                 p_site_mixture[c1] = sum;
-                
-                assert(0.0 <= sum and sum <= 1.00000000001);
 
                 assert(isnan(sum) || (0 <= sum and sum <= 1.00000000001));
 
@@ -319,8 +317,6 @@ void RevBayesCore::PhyloCTMCSiteHomogeneous<charType>::computeInternalNodeLikeli
                     sum += p_site_mixture_left[c2] * p_site_mixture_middle[c2] * p_site_mixture_right[c2] * tp_a[c2];
 
                 } // end-for over all distination character
-                
-                assert(0 <= sum and sum <= 1.00000000001);
 
                 assert(isnan(sum) || (0 <= sum and sum <= 1.00000000001));
 

--- a/src/core/distributions/phylogenetics/substitution/PhyloCTMCSiteHomogeneous.h
+++ b/src/core/distributions/phylogenetics/substitution/PhyloCTMCSiteHomogeneous.h
@@ -122,6 +122,8 @@ void RevBayesCore::PhyloCTMCSiteHomogeneous<charType>::computeRootLikelihood( si
                 // add the probability of starting from this state
                 *p_site_j = *p_site_left_j * *p_site_right_j * *f_j;
 
+                assert(isnan(*p_site_j) || (0.0 <= *p_site_j and *p_site_j <= 1.00000000001));
+
                 // increment pointers
                 ++p_site_j; ++p_site_left_j; ++p_site_right_j;
             }
@@ -191,7 +193,7 @@ void RevBayesCore::PhyloCTMCSiteHomogeneous<charType>::computeRootLikelihood( si
                 // add the probability of starting from this state
                 *p_site_j = *p_site_left_j * *p_site_right_j * *p_site_middle_j * *f_j;
 
-                assert(0.0 <= *p_site_j and *p_site_j <= 1.00000000001);
+                assert(isnan(*p_site_j) || (0.0 <= *p_site_j and *p_site_j <= 1.00000000001));
 
                 // increment pointers
                 ++p_site_j; ++p_site_left_j; ++p_site_right_j; ++p_site_middle_j;
@@ -257,6 +259,8 @@ void RevBayesCore::PhyloCTMCSiteHomogeneous<charType>::computeInternalNodeLikeli
                 
                 assert(0.0 <= sum and sum <= 1.00000000001);
 
+                assert(isnan(sum) || (0 <= sum and sum <= 1.00000000001));
+
                 // increment the pointers to the next starting state
                 tp_a+=this->num_chars;
 
@@ -317,6 +321,8 @@ void RevBayesCore::PhyloCTMCSiteHomogeneous<charType>::computeInternalNodeLikeli
                 } // end-for over all distination character
                 
                 assert(0 <= sum and sum <= 1.00000000001);
+
+                assert(isnan(sum) || (0 <= sum and sum <= 1.00000000001));
 
                 // store the likelihood for this starting state
                 p_site_mixture[c1] = sum;


### PR DESCRIPTION
Issue #131 is caused by intermediate `nan` values in the computation of partial likelihoods in `PhyloCTMCSiteHomogeneous.h`. This fixes that issue by allowing `nan`s to pass through the assertion.