### PR TITLE
Consolidate file monitor arguments

### DIFF
--- a/src/revlanguage/monitors/Mntr_AncestralState.cpp
+++ b/src/revlanguage/monitors/Mntr_AncestralState.cpp
@@ -5,7 +5,6 @@
 #include "ArgumentRule.h"
 #include "ArgumentRules.h"
 #include "AncestralStateMonitor.h"
-#include "RlMonitor.h"
 #include "IntegerPos.h"
 #include "RbException.h"
 #include "RevObject.h"
@@ -26,7 +25,7 @@ namespace RevBayesCore { template <class valueType> class TypedDagNode; }
 
 using namespace RevLanguage;
 
-Mntr_AncestralState::Mntr_AncestralState(void) : Monitor()
+Mntr_AncestralState::Mntr_AncestralState(void) : FileMonitor()
 {
     
 }
@@ -49,7 +48,7 @@ void Mntr_AncestralState::constructInternalObject( void )
 {
     const std::string&                  fn      = static_cast<const RlString &>( filename->getRevObject() ).getValue();
     const std::string&                  sep     = static_cast<const RlString &>( separator->getRevObject() ).getValue();
-    unsigned int                                 g       = (int)static_cast<const IntegerPos  &>( printgen->getRevObject() ).getValue();
+    unsigned int                        g       = (int)static_cast<const IntegerPos  &>( printgen->getRevObject() ).getValue();
     RevBayesCore::TypedDagNode<RevBayesCore::Tree>* t = static_cast<const Tree &>( tree->getRevObject() ).getDagNode();
     RevBayesCore::DagNode*				ch		= ctmc->getRevObject().getDagNode();
     bool                                ap      = static_cast<const RlBoolean &>( append->getRevObject() ).getValue();
@@ -139,12 +138,11 @@ const MemberRules& Mntr_AncestralState::getParameterRules(void) const
     {
         memberRules.push_back( new ArgumentRule("tree"          , Tree::getClassTypeSpec()     , "The tree which we monitor.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
         memberRules.push_back( new ArgumentRule("ctmc"          , RevObject::getClassTypeSpec(), "The CTMC process.", ArgumentRule::BY_REFERENCE, ArgumentRule::STOCHASTIC ) );
-        memberRules.push_back( new ArgumentRule("filename"      , RlString::getClassTypeSpec() , "The name of the file for storing the samples.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
         memberRules.push_back( new ArgumentRule("type"          , RlString::getClassTypeSpec() , "The type of data to store.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
-        memberRules.push_back( new ArgumentRule("printgen"      , IntegerPos::getClassTypeSpec()  , "The frequency how often to sample.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new IntegerPos(1) ) );
-        memberRules.push_back( new ArgumentRule("separator"     , RlString::getClassTypeSpec() , "The separator between columns in the file.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("\t") ) );
-        memberRules.push_back( new ArgumentRule("append"        , RlBoolean::getClassTypeSpec(), "Should we append or overwrite if the file exists?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
-        memberRules.push_back( new ArgumentRule("version"   , RlBoolean::getClassTypeSpec(), "Should we record the software version?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
+
+        // add the rules from the base class
+        const MemberRules &parentRules = FileMonitor::getParameterRules();
+        memberRules.insert(memberRules.end(), parentRules.begin(), parentRules.end());
 
         rules_set = true;
     }
@@ -174,18 +172,8 @@ void Mntr_AncestralState::printValue(std::ostream &o) const
 void Mntr_AncestralState::setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var)
 {
     
-    if ( name == "" ) {
-        vars.push_back( var );
-    }
-    else if ( name == "filename" )
+    if ( name == "tree" )
     {
-        filename = var;
-    }
-    else if ( name == "separator" )
-    {
-        separator = var;
-    }
-    else if ( name == "tree" ) {
         tree = var;
     }
     else if ( name == "type" )
@@ -196,21 +184,9 @@ void Mntr_AncestralState::setConstParameter(const std::string& name, const RevPt
     {
         ctmc = var;
     }
-    else if ( name == "printgen" )
-    {
-        printgen = var;
-    }
-    else if ( name == "append" ) 
-    {
-        append = var;
-    }
-    else if ( name == "version" )
-    {
-        version = var;
-    }
     else 
     {
-        Monitor::setConstParameter(name, var);
+        FileMonitor::setConstParameter(name, var);
     }
     
 }

--- a/src/revlanguage/monitors/Mntr_AncestralState.h
+++ b/src/revlanguage/monitors/Mntr_AncestralState.h
@@ -18,7 +18,7 @@
 #include <ostream>
 #include <vector>
 
-#include "RlMonitor.h"
+#include "RlFileMonitor.h"
 #include "RevObject.h"
 #include "RevPtr.h"
 #include "RevVariable.h"
@@ -26,7 +26,7 @@
 namespace RevLanguage {
 class TypeSpec;
     
-    class Mntr_AncestralState : public Monitor {
+    class Mntr_AncestralState : public FileMonitor {
         
     public:
         
@@ -46,15 +46,9 @@ class TypeSpec;
         
         void                                        setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var);       //!< Set member variable
         
-		std::vector<RevPtr<const RevVariable> >     vars;
-        RevPtr<const RevVariable>                   filename;
-        RevPtr<const RevVariable>                   printgen;
 		RevPtr<const RevVariable>                   tree;
 		RevPtr<const RevVariable>                   ctmc;
-        RevPtr<const RevVariable>                   separator;
-        RevPtr<const RevVariable>                   append;
-        RevPtr<const RevVariable>                   version;
-		RevPtr<const RevVariable>                   monitorType;
+        RevPtr<const RevVariable>                   monitorType;
     };
     
 }

--- a/src/revlanguage/monitors/Mntr_ExtendedNewickFile.cpp
+++ b/src/revlanguage/monitors/Mntr_ExtendedNewickFile.cpp
@@ -31,7 +31,7 @@ using namespace RevLanguage;
 
 
 
-Mntr_ExtendedNewickFile::Mntr_ExtendedNewickFile(void) : Monitor()
+Mntr_ExtendedNewickFile::Mntr_ExtendedNewickFile(void) : FileMonitor()
 {
     
 }
@@ -134,17 +134,17 @@ const MemberRules& Mntr_ExtendedNewickFile::getParameterRules(void) const
     if ( !rules_set )
     {
     
-        memberRules.push_back( new ArgumentRule("filename", RlString::getClassTypeSpec(), "The name of the file.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
         memberRules.push_back( new ArgumentRule("tree"    , TimeTree::getClassTypeSpec(), "The tree variable.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
         memberRules.push_back( new Ellipsis( "Variables at nodes or branches.", RevObject::getClassTypeSpec() ) );
         memberRules.push_back( new ArgumentRule("isNodeParameter" , RlBoolean::getClassTypeSpec(), "Is this a node or branch parameter?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
-        memberRules.push_back( new ArgumentRule("printgen"  , IntegerPos::getClassTypeSpec()  , "How frequently do we print.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new IntegerPos(1) ) );
-        memberRules.push_back( new ArgumentRule("separator" , RlString::getClassTypeSpec() , "The separator between variables.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("\t") ) );
         memberRules.push_back( new ArgumentRule("posterior" , RlBoolean::getClassTypeSpec(), "Should we print the posterior probability as well.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
         memberRules.push_back( new ArgumentRule("likelihood", RlBoolean::getClassTypeSpec(), "Should we print the likelihood as well?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
         memberRules.push_back( new ArgumentRule("prior"     , RlBoolean::getClassTypeSpec(), "Should we print the prior probability as well?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
-        memberRules.push_back( new ArgumentRule("version"   , RlBoolean::getClassTypeSpec(), "Should we record the software version?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
         
+        // add the rules from the base class
+        const MemberRules &parentRules = FileMonitor::getParameterRules();
+        memberRules.insert(memberRules.end(), parentRules.begin(), parentRules.end());
+
         rules_set = true;
     }
     
@@ -176,10 +176,6 @@ void Mntr_ExtendedNewickFile::setConstParameter(const std::string& name, const R
     {
         vars.push_back( var );
     }
-    else if ( name == "filename" )
-    {
-        filename = var;
-    }
     else if ( name == "tree" )
     {
         tree = var;
@@ -187,14 +183,6 @@ void Mntr_ExtendedNewickFile::setConstParameter(const std::string& name, const R
     else if ( name == "isNodeParameter" )
     {
         isNodeParameter = var;
-    }
-    else if ( name == "separator" )
-    {
-        separator = var;
-    }
-    else if ( name == "printgen" )
-    {
-        printgen = var;
     }
     else if ( name == "prior" )
     {
@@ -208,12 +196,8 @@ void Mntr_ExtendedNewickFile::setConstParameter(const std::string& name, const R
     {
         likelihood = var;
     }
-    else if ( name == "version" )
-    {
-        version = var;
-    }
     else
     {
-        RevObject::setConstParameter(name, var);
+        FileMonitor::setConstParameter(name, var);
     }
 }

--- a/src/revlanguage/monitors/Mntr_ExtendedNewickFile.h
+++ b/src/revlanguage/monitors/Mntr_ExtendedNewickFile.h
@@ -19,7 +19,7 @@
 #define Mntr_ExtendedNewickFile_H
 
 #include "ExtendedNewickTreeMonitor.h"
-#include "RlMonitor.h"
+#include "RlFileMonitor.h"
 #include "TypedDagNode.h"
 
 #include <ostream>
@@ -27,7 +27,7 @@
 
 namespace RevLanguage {
     
-    class Mntr_ExtendedNewickFile : public Monitor {
+    class Mntr_ExtendedNewickFile : public FileMonitor {
         
     public:
         
@@ -48,16 +48,12 @@ namespace RevLanguage {
         void                                        setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var);   //!< Set member variable
         
         std::vector<RevPtr<const RevVariable> >     vars;
-        RevPtr<const RevVariable>                   filename;
         RevPtr<const RevVariable>                   tree;
         RevPtr<const RevVariable>                   isNodeParameter;
-        RevPtr<const RevVariable>                   printgen;
-        RevPtr<const RevVariable>                   separator;
         RevPtr<const RevVariable>                   prior;
         RevPtr<const RevVariable>                   posterior;
         RevPtr<const RevVariable>                   likelihood;
-        RevPtr<const RevVariable>                   version;
-        
+
     };
     
 }

--- a/src/revlanguage/monitors/Mntr_File.cpp
+++ b/src/revlanguage/monitors/Mntr_File.cpp
@@ -24,7 +24,7 @@ namespace RevBayesCore { class DagNode; }
 
 using namespace RevLanguage;
 
-Mntr_File::Mntr_File(void) : Monitor() {
+Mntr_File::Mntr_File(void) : FileMonitor() {
     
 }
 
@@ -107,27 +107,24 @@ std::string Mntr_File::getMonitorName( void ) const
 const MemberRules& Mntr_File::getParameterRules(void) const
 {
     
-    static MemberRules filemonitorMemberRules;
+    static MemberRules memberRules;
     static bool rules_set = false;
     
     if ( !rules_set )
     {
-        
-        filemonitorMemberRules.push_back( new Ellipsis( "Variables to monitor", RevObject::getClassTypeSpec() ) );
-        filemonitorMemberRules.push_back( new ArgumentRule("filename"  , RlString::getClassTypeSpec() , "The name of the file.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
-        filemonitorMemberRules.push_back( new ArgumentRule("printgen"  , IntegerPos::getClassTypeSpec()  , "How often should we print.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new IntegerPos(1) ) );
-        filemonitorMemberRules.push_back( new ArgumentRule("separator" , RlString::getClassTypeSpec() , "The separator/delimiter between values.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("\t") ) );
-        filemonitorMemberRules.push_back( new ArgumentRule("posterior" , RlBoolean::getClassTypeSpec(), "Should we print the posterior probability as well?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
-        filemonitorMemberRules.push_back( new ArgumentRule("likelihood", RlBoolean::getClassTypeSpec(), "Should we print the likelihood as well?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
-        filemonitorMemberRules.push_back( new ArgumentRule("prior"     , RlBoolean::getClassTypeSpec(), "Should we print the prior probability as well?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
-        filemonitorMemberRules.push_back( new ArgumentRule("append"    , RlBoolean::getClassTypeSpec(), "Should we append or overwrite if the file exists?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
-        filemonitorMemberRules.push_back( new ArgumentRule("version", RlBoolean::getClassTypeSpec(), "Should we record the software version?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
+        memberRules.push_back( new Ellipsis( "Variables to monitor.", RevObject::getClassTypeSpec() ) );
+        memberRules.push_back( new ArgumentRule("posterior" , RlBoolean::getClassTypeSpec(), "Should we print the posterior probability as well?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
+        memberRules.push_back( new ArgumentRule("likelihood", RlBoolean::getClassTypeSpec(), "Should we print the likelihood as well?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
+        memberRules.push_back( new ArgumentRule("prior"     , RlBoolean::getClassTypeSpec(), "Should we print the prior probability as well?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
 
+        // add the rules from the base class
+        const MemberRules &parentRules = FileMonitor::getParameterRules();
+        memberRules.insert(memberRules.end(), parentRules.begin(), parentRules.end());
 
         rules_set = true;
     }
     
-    return filemonitorMemberRules;
+    return memberRules;
 }
 
 /** Get type spec */
@@ -154,18 +151,6 @@ void Mntr_File::setConstParameter(const std::string& name, const RevPtr<const Re
     {
         vars.push_back( var );
     }
-    else if ( name == "filename" )
-    {
-        filename = var;
-    }
-    else if ( name == "separator" )
-    {
-        separator = var;
-    }
-    else if ( name == "printgen" )
-    {
-        printgen = var;
-    }
     else if ( name == "prior" )
     {
         prior = var;
@@ -178,16 +163,8 @@ void Mntr_File::setConstParameter(const std::string& name, const RevPtr<const Re
     {
         likelihood = var;
     }
-    else if (name == "append")
-    {
-        append = var;
-    }
-    else if (name == "version")
-    {
-        version = var;
-    }
     else
     {
-        RevObject::setConstParameter(name, var);
+        FileMonitor::setConstParameter(name, var);
     }
 }

--- a/src/revlanguage/monitors/Mntr_File.h
+++ b/src/revlanguage/monitors/Mntr_File.h
@@ -19,7 +19,7 @@
 #define Mntr_File_H
 
 #include "VariableMonitor.h"
-#include "RlMonitor.h"
+#include "RlFileMonitor.h"
 #include "TypedDagNode.h"
 
 #include <ostream>
@@ -27,7 +27,7 @@
 
 namespace RevLanguage {
     
-    class Mntr_File : public Monitor {
+    class Mntr_File : public FileMonitor {
         
     public:
         
@@ -48,14 +48,9 @@ namespace RevLanguage {
         void                                        setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var);       //!< Set member variable
         
         std::vector<RevPtr<const RevVariable> >     vars;
-        RevPtr<const RevVariable>                   filename;
-        RevPtr<const RevVariable>                   printgen;
-        RevPtr<const RevVariable>                   separator;
         RevPtr<const RevVariable>                   prior;
         RevPtr<const RevVariable>                   posterior;
         RevPtr<const RevVariable>                   likelihood;
-        RevPtr<const RevVariable>                   append;
-        RevPtr<const RevVariable>                   version;
 
     };
     

--- a/src/revlanguage/monitors/Mntr_HomeologPhase.cpp
+++ b/src/revlanguage/monitors/Mntr_HomeologPhase.cpp
@@ -5,7 +5,6 @@
 
 #include "ArgumentRule.h"
 #include "ArgumentRules.h"
-#include "RlMonitor.h"
 #include "IntegerPos.h"
 #include "RevObject.h"
 #include "RlAbstractHomologousDiscreteCharacterData.h"
@@ -22,7 +21,7 @@ namespace RevBayesCore { template <class valueType> class TypedDagNode; }
 
 using namespace RevLanguage;
 
-Mntr_HomeologPhase::Mntr_HomeologPhase(void) : Monitor()
+Mntr_HomeologPhase::Mntr_HomeologPhase(void) : FileMonitor()
 {
     
 }
@@ -45,7 +44,7 @@ void Mntr_HomeologPhase::constructInternalObject( void )
 {
     const std::string&                  fn      = static_cast<const RlString &>( filename->getRevObject() ).getValue();
     const std::string&                  sep     = static_cast<const RlString &>( separator->getRevObject() ).getValue();
-    unsigned int                                 g       = (int)static_cast<const IntegerPos  &>( printgen->getRevObject() ).getValue();
+    unsigned int                        g       = (int)static_cast<const IntegerPos  &>( printgen->getRevObject() ).getValue();
     
     bool                                ap      = static_cast<const RlBoolean &>( append->getRevObject() ).getValue();
     bool                                wv      = static_cast<const RlBoolean &>( version->getRevObject() ).getValue();
@@ -108,22 +107,21 @@ std::string Mntr_HomeologPhase::getMonitorName( void ) const
 const MemberRules& Mntr_HomeologPhase::getParameterRules(void) const
 {
     
-    static MemberRules asMonitorMemberRules;
+    static MemberRules memberRules;
     static bool rules_set = false;
     
     if ( !rules_set )
     {
-        asMonitorMemberRules.push_back( new ArgumentRule("ctmc"           , AbstractHomologousDiscreteCharacterData::getClassTypeSpec(), "", ArgumentRule::BY_REFERENCE, ArgumentRule::ANY, NULL ) );
-        asMonitorMemberRules.push_back( new ArgumentRule("filename"       , RlString::getClassTypeSpec() , "", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
-        asMonitorMemberRules.push_back( new ArgumentRule("printgen"       , IntegerPos::getClassTypeSpec()  , "", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new IntegerPos(1) ) );
-        asMonitorMemberRules.push_back( new ArgumentRule("separator"      , RlString::getClassTypeSpec() , "", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("\t") ) );
-        asMonitorMemberRules.push_back( new ArgumentRule("append"         , RlBoolean::getClassTypeSpec(), "", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
-        asMonitorMemberRules.push_back( new ArgumentRule("version"        , RlBoolean::getClassTypeSpec(), "Should we record the software version?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
+        memberRules.push_back( new ArgumentRule("ctmc"           , AbstractHomologousDiscreteCharacterData::getClassTypeSpec(), "", ArgumentRule::BY_REFERENCE, ArgumentRule::ANY, NULL ) );
+
+        // add the rules from the base class
+        const MemberRules &parentRules = FileMonitor::getParameterRules();
+        memberRules.insert(memberRules.end(), parentRules.begin(), parentRules.end());
 
         rules_set = true;
     }
     
-    return asMonitorMemberRules;
+    return memberRules;
 }
 
 /** Get type spec */
@@ -148,32 +146,9 @@ void Mntr_HomeologPhase::printValue(std::ostream &o) const
 void Mntr_HomeologPhase::setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var)
 {
     
-    if ( name == "" ) {
-        vars.push_back( var );
-    }
-    else if ( name == "filename" )
-    {
-        filename = var;
-    }
-    else if ( name == "separator" )
-    {
-        separator = var;
-    }
-    else if ( name == "ctmc" )
+    if ( name == "ctmc" )
     {
         ctmc = var;
-    }
-    else if ( name == "printgen" )
-    {
-        printgen = var;
-    }
-    else if ( name == "append" )
-    {
-        append = var;
-    }
-    else if ( name == "version" )
-    {
-        version = var;
     }
     else
     {

--- a/src/revlanguage/monitors/Mntr_HomeologPhase.h
+++ b/src/revlanguage/monitors/Mntr_HomeologPhase.h
@@ -13,7 +13,7 @@
 #include <ostream>
 #include <vector>
 
-#include "RlMonitor.h"
+#include "RlFileMonitor.h"
 #include "RevObject.h"
 #include "RevPtr.h"
 #include "RevVariable.h"
@@ -21,14 +21,14 @@
 namespace RevLanguage {
 class TypeSpec;
     
-    class Mntr_HomeologPhase : public Monitor {
+    class Mntr_HomeologPhase : public FileMonitor {
         
     public:
         
         Mntr_HomeologPhase(void);                                                                                              //!< Default constructor
         
         // Basic utility functions
-        virtual Mntr_HomeologPhase*    clone(void) const;                                                                      //!< Clone object
+        virtual Mntr_HomeologPhase*                     clone(void) const;                                                                      //!< Clone object
         void                                            constructInternalObject(void);                                                          //!< We construct the a new internal monitor.
         static const std::string&                       getClassType(void);                                                                     //!< Get Rev type
         static const TypeSpec&                          getClassTypeSpec(void);                                                                 //!< Get class type spec
@@ -41,13 +41,8 @@ class TypeSpec;
         
         void                                            setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var);       //!< Set member variable
         
-		std::vector<RevPtr<const RevVariable> >         vars;
-        RevPtr<const RevVariable>                       filename;
-        RevPtr<const RevVariable>                       printgen;
-        RevPtr<const RevVariable>                       version;
 		RevPtr<const RevVariable>                       ctmc;
-        RevPtr<const RevVariable>                       separator;
-        RevPtr<const RevVariable>                       append;
+
     };
     
 }

--- a/src/revlanguage/monitors/Mntr_JointConditionalAncestralState.cpp
+++ b/src/revlanguage/monitors/Mntr_JointConditionalAncestralState.cpp
@@ -6,7 +6,6 @@
 #include "BinaryState.h"
 #include "ArgumentRule.h"
 #include "ArgumentRules.h"
-#include "RlMonitor.h"
 #include "IntegerPos.h"
 #include "RbException.h"
 #include "RevObject.h"
@@ -33,7 +32,7 @@ namespace RevBayesCore { template <class valueType> class TypedDagNode; }
 
 using namespace RevLanguage;
 
-Mntr_JointConditionalAncestralState::Mntr_JointConditionalAncestralState(void) : Monitor()
+Mntr_JointConditionalAncestralState::Mntr_JointConditionalAncestralState(void) : FileMonitor()
 {
     
 }
@@ -211,27 +210,26 @@ std::string Mntr_JointConditionalAncestralState::getMonitorName( void ) const
 const MemberRules& Mntr_JointConditionalAncestralState::getParameterRules(void) const
 {
     
-    static MemberRules asMonitorMemberRules;
+    static MemberRules memberRules;
     static bool rules_set = false;
     
     if ( !rules_set )
     {
-        asMonitorMemberRules.push_back( new ArgumentRule("tree"           , Tree::getClassTypeSpec() , "", ArgumentRule::BY_REFERENCE, ArgumentRule::ANY ) );
-        asMonitorMemberRules.push_back( new ArgumentRule("ctmc"           , AbstractHomologousDiscreteCharacterData::getClassTypeSpec(), "", ArgumentRule::BY_REFERENCE, ArgumentRule::ANY, NULL ) );
-        asMonitorMemberRules.push_back( new ArgumentRule("cdbdp"          , TimeTree::getClassTypeSpec(), "", ArgumentRule::BY_REFERENCE, ArgumentRule::ANY, NULL) );
-        asMonitorMemberRules.push_back( new ArgumentRule("filename"       , RlString::getClassTypeSpec() , "", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
-        asMonitorMemberRules.push_back( new ArgumentRule("type"           , RlString::getClassTypeSpec() , "", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
-        asMonitorMemberRules.push_back( new ArgumentRule("printgen"       , IntegerPos::getClassTypeSpec()  , "", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new IntegerPos(1) ) );
-        asMonitorMemberRules.push_back( new ArgumentRule("separator"      , RlString::getClassTypeSpec() , "", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("\t") ) );
-        asMonitorMemberRules.push_back( new ArgumentRule("append"         , RlBoolean::getClassTypeSpec(), "", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
-        asMonitorMemberRules.push_back( new ArgumentRule("withTips"       , RlBoolean::getClassTypeSpec(), "", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
-        asMonitorMemberRules.push_back( new ArgumentRule("withStartStates", RlBoolean::getClassTypeSpec(), "", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
-        asMonitorMemberRules.push_back( new ArgumentRule("version"        , RlBoolean::getClassTypeSpec(), "Should we record the software version?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
+        memberRules.push_back( new ArgumentRule("tree"           , Tree::getClassTypeSpec() , "", ArgumentRule::BY_REFERENCE, ArgumentRule::ANY ) );
+        memberRules.push_back( new ArgumentRule("ctmc"           , AbstractHomologousDiscreteCharacterData::getClassTypeSpec(), "", ArgumentRule::BY_REFERENCE, ArgumentRule::ANY, NULL ) );
+        memberRules.push_back( new ArgumentRule("cdbdp"          , TimeTree::getClassTypeSpec(), "", ArgumentRule::BY_REFERENCE, ArgumentRule::ANY, NULL) );
+        memberRules.push_back( new ArgumentRule("type"           , RlString::getClassTypeSpec() , "", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
+        memberRules.push_back( new ArgumentRule("withTips"       , RlBoolean::getClassTypeSpec(), "", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
+        memberRules.push_back( new ArgumentRule("withStartStates", RlBoolean::getClassTypeSpec(), "", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
+
+        // add the rules from the base class
+        const MemberRules &parentRules = FileMonitor::getParameterRules();
+        memberRules.insert(memberRules.end(), parentRules.begin(), parentRules.end());
 
         rules_set = true;
     }
     
-    return asMonitorMemberRules;
+    return memberRules;
 }
 
 /** Get type spec */
@@ -256,18 +254,7 @@ void Mntr_JointConditionalAncestralState::printValue(std::ostream &o) const
 void Mntr_JointConditionalAncestralState::setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var)
 {
     
-    if ( name == "" ) {
-        vars.push_back( var );
-    }
-    else if ( name == "filename" )
-    {
-        filename = var;
-    }
-    else if ( name == "separator" )
-    {
-        separator = var;
-    }
-    else if ( name == "tree" )
+    if ( name == "tree" )
     {
         tree = var;
     }
@@ -283,14 +270,6 @@ void Mntr_JointConditionalAncestralState::setConstParameter(const std::string& n
     {
         cdbdp = var;
     }
-    else if ( name == "printgen" )
-    {
-        printgen = var;
-    }
-    else if ( name == "append" )
-    {
-        append = var;
-    }
     else if ( name == "withTips" )
     {
         withTips = var;
@@ -299,13 +278,9 @@ void Mntr_JointConditionalAncestralState::setConstParameter(const std::string& n
     {
         withStartStates = var;
     }
-    else if ( name == "version" )
-    {
-        version = var;
-    }
     else
     {
-        Monitor::setConstParameter(name, var);
+        FileMonitor::setConstParameter(name, var);
     }
     
 }

--- a/src/revlanguage/monitors/Mntr_JointConditionalAncestralState.h
+++ b/src/revlanguage/monitors/Mntr_JointConditionalAncestralState.h
@@ -13,7 +13,7 @@
 #include <ostream>
 #include <vector>
 
-#include "RlMonitor.h"
+#include "RlFileMonitor.h"
 #include "RevObject.h"
 #include "RevPtr.h"
 #include "RevVariable.h"
@@ -21,7 +21,7 @@
 namespace RevLanguage {
 class TypeSpec;
     
-    class Mntr_JointConditionalAncestralState : public Monitor {
+    class Mntr_JointConditionalAncestralState : public FileMonitor {
         
     public:
         
@@ -41,16 +41,10 @@ class TypeSpec;
         
         void                                            setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var);       //!< Set member variable
         
-		std::vector<RevPtr<const RevVariable> >         vars;
-        RevPtr<const RevVariable>                       filename;
-        RevPtr<const RevVariable>                       printgen;
-        RevPtr<const RevVariable>                       version;
 		RevPtr<const RevVariable>                       tree;
 		RevPtr<const RevVariable>                       ctmc;
         RevPtr<const RevVariable>                       cdbdp;
-        RevPtr<const RevVariable>                       separator;
-        RevPtr<const RevVariable>                       append;
-		RevPtr<const RevVariable>                       monitorType;
+        RevPtr<const RevVariable>                       monitorType;
         RevPtr<const RevVariable>                       withTips;
         RevPtr<const RevVariable>                       withStartStates;
     };

--- a/src/revlanguage/monitors/Mntr_Model.cpp
+++ b/src/revlanguage/monitors/Mntr_Model.cpp
@@ -15,12 +15,11 @@
 #include "RevPtr.h"
 #include "RevVariable.h"
 #include "RlBoolean.h"
-#include "RlMonitor.h"
 
 
 using namespace RevLanguage;
 
-Mntr_Model::Mntr_Model(void) : Monitor() 
+Mntr_Model::Mntr_Model(void) : FileMonitor()
 {
     
 }
@@ -119,17 +118,16 @@ const MemberRules& Mntr_Model::getParameterRules(void) const
     if ( !rules_set ) 
     {
         
-        memberRules.push_back( new ArgumentRule("filename"      , RlString::getClassTypeSpec() , "The name of the file where to store the values.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
-        memberRules.push_back( new ArgumentRule("printgen"      , IntegerPos::getClassTypeSpec()  , "The frequency how often to sample values.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new IntegerPos(1) ) );
-        memberRules.push_back( new ArgumentRule("separator"     , RlString::getClassTypeSpec() , "The separator between different variables.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("\t") ) );
         memberRules.push_back( new ArgumentRule("posterior"     , RlBoolean::getClassTypeSpec(), "Should we print the joint posterior probability?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
         memberRules.push_back( new ArgumentRule("likelihood"    , RlBoolean::getClassTypeSpec(), "Should we print the likelihood?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
         memberRules.push_back( new ArgumentRule("prior"         , RlBoolean::getClassTypeSpec(), "Should we print the joint prior probability?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
-        memberRules.push_back( new ArgumentRule("append"        , RlBoolean::getClassTypeSpec(), "Should we append to an existing file?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
         memberRules.push_back( new ArgumentRule("stochasticOnly", RlBoolean::getClassTypeSpec(), "Should we monitor stochastic variables only?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
-        memberRules.push_back( new ArgumentRule("version", RlBoolean::getClassTypeSpec(), "Should we record the software version?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
         memberRules.push_back( new ArgumentRule{"exclude", ModelVector<RlString>::getClassTypeSpec(), "Variables to exclude from the monitor", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new ModelVector<RlString>()});
         
+        // add the rules from the base class
+        const MemberRules &parentRules = FileMonitor::getParameterRules();
+        memberRules.insert(memberRules.end(), parentRules.begin(), parentRules.end());
+
         rules_set = true;
     }
     
@@ -158,19 +156,7 @@ void Mntr_Model::printValue(std::ostream &o) const
 void Mntr_Model::setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var) 
 {
     
-    if ( name == "filename" ) 
-    {
-        filename = var;
-    }
-    else if ( name == "separator" ) 
-    {
-        separator = var;
-    }
-    else if ( name == "printgen" ) 
-    {
-        printgen = var;
-    }
-    else if ( name == "prior" ) 
+    if ( name == "prior" )
     {
         prior = var;
     }
@@ -182,17 +168,9 @@ void Mntr_Model::setConstParameter(const std::string& name, const RevPtr<const R
     {
         likelihood = var;
     }
-    else if ( name == "append" ) 
-    {
-        append = var;
-    }
     else if ( name == "stochasticOnly" ) 
     {
         stochOnly = var;
-    }
-    else if ( name == "version" )
-    {
-        version = var;
     }
     else if ( name == "exclude" )
     {
@@ -200,7 +178,7 @@ void Mntr_Model::setConstParameter(const std::string& name, const RevPtr<const R
     }
     else 
     {
-        Monitor::setConstParameter(name, var);
+        FileMonitor::setConstParameter(name, var);
     }
     
 }

--- a/src/revlanguage/monitors/Mntr_Model.h
+++ b/src/revlanguage/monitors/Mntr_Model.h
@@ -2,7 +2,7 @@
 #define Mntr_Model_H
 
 #include "ModelMonitor.h"
-#include "RlMonitor.h"
+#include "RlFileMonitor.h"
 #include "TypedDagNode.h"
 
 #include <ostream>
@@ -10,7 +10,7 @@
 
 namespace RevLanguage {
     
-    class Mntr_Model : public Monitor {
+    class Mntr_Model : public FileMonitor {
         
     public:
         
@@ -30,14 +30,9 @@ namespace RevLanguage {
         
         void                                        setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var);       //!< Set member variable
         
-        RevPtr<const RevVariable>                   filename;
-        RevPtr<const RevVariable>                   printgen;
-        RevPtr<const RevVariable>                   separator;
         RevPtr<const RevVariable>                   prior;
         RevPtr<const RevVariable>                   posterior;
         RevPtr<const RevVariable>                   likelihood;
-        RevPtr<const RevVariable>                   append;
-        RevPtr<const RevVariable>                   version;
         RevPtr<const RevVariable>                   stochOnly;
         RevPtr<const RevVariable>                   exclude;  //!< Vector of variable names to exclude from logging
         

--- a/src/revlanguage/monitors/Mntr_NexusFile.cpp
+++ b/src/revlanguage/monitors/Mntr_NexusFile.cpp
@@ -89,7 +89,7 @@ const MemberRules& Mntr_NexusFile::getParameterRules(void) const {
         memberRules.push_back( new Ellipsis( "Variables at nodes or branches.", RevObject::getClassTypeSpec() ) );
         memberRules.push_back( new ArgumentRule("isNodeParameter" , RlBoolean::getClassTypeSpec(), "Is this a node or branch parameter?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
         memberRules.push_back( new ArgumentRule("writeTaxa" , RlBoolean::getClassTypeSpec(), "Should a taxa block be written?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
-        memberRules.push_back( new ArgumentRule("printgen"  , IntegerPos::getClassTypeSpec()  , "How frequently do we print.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new IntegerPos(1) ) );
+        memberRules.push_back( new ArgumentRule("printgen"  , IntegerPos::getClassTypeSpec()  , "The number of generations between stored samples.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new IntegerPos(1) ) );
 
         rules_set = true;
     }
@@ -113,26 +113,33 @@ void Mntr_NexusFile::printValue(std::ostream &o) const {
 
 void Mntr_NexusFile::setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var) {
 
-    if ( name == "" ) {
-        vars.push_back( var );
+    if ( name == "" )
+    {
+        vars.push_back(var);
     }
-    else if ( name == "filename" ) {
+    else if ( name == "filename" )
+    {
         filename = var;
     }
-    else if ( name == "tree" ) {
+    else if ( name == "tree" )
+    {
         tree = var;
     }
-    else if ( name == "isNodeParameter" ) {
+    else if ( name == "isNodeParameter" )
+    {
         isNodeParameter = var;
     }
-    else if ( name == "printgen" ) {
+    else if ( name == "printgen" )
+    {
         printgen = var;
     }
-    else if ( name == "writeTaxa" ) {
+    else if ( name == "writeTaxa" )
+    {
         writeTaxa = var;
     }
-    else {
-        RevObject::setConstParameter(name, var);
+    else
+    {
+        Monitor::setConstParameter(name, var);
     }
 }
 

--- a/src/revlanguage/monitors/Mntr_Probability.cpp
+++ b/src/revlanguage/monitors/Mntr_Probability.cpp
@@ -19,7 +19,7 @@
 
 using namespace RevLanguage;
 
-Mntr_Probability::Mntr_Probability(void) : Monitor()
+Mntr_Probability::Mntr_Probability(void) : FileMonitor()
 {
     
 }
@@ -46,7 +46,7 @@ void Mntr_Probability::constructInternalObject( void )
     // now allocate a new sliding move
     const std::string&                  fn      = static_cast<const RlString &>( filename->getRevObject() ).getValue();
     const std::string&                  sep     = static_cast<const RlString &>( separator->getRevObject() ).getValue();
-    unsigned int                                 g       = (int)static_cast<const IntegerPos  &>( printgen->getRevObject() ).getValue();
+    unsigned int                        g       = (int)static_cast<const IntegerPos &>( printgen->getRevObject() ).getValue();
     bool                                pp      = static_cast<const RlBoolean &>( posterior->getRevObject() ).getValue();
     bool                                l       = static_cast<const RlBoolean &>( likelihood->getRevObject() ).getValue();
     bool                                pr      = static_cast<const RlBoolean &>( prior->getRevObject() ).getValue();
@@ -109,14 +109,13 @@ const MemberRules& Mntr_Probability::getParameterRules(void) const
     if ( !rules_set )
     {
         
-        memberRules.push_back( new ArgumentRule("filename"      , RlString::getClassTypeSpec() , "The name of the file where to store the values.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
-        memberRules.push_back( new ArgumentRule("printgen"      , IntegerPos::getClassTypeSpec()  , "The frequency how often to sample values.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new IntegerPos(1) ) );
-        memberRules.push_back( new ArgumentRule("separator"     , RlString::getClassTypeSpec() , "The separator between different variables.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("\t") ) );
         memberRules.push_back( new ArgumentRule("posterior"     , RlBoolean::getClassTypeSpec(), "Should we print the joint posterior probability?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
         memberRules.push_back( new ArgumentRule("likelihood"    , RlBoolean::getClassTypeSpec(), "Should we print the likelihood?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
         memberRules.push_back( new ArgumentRule("prior"         , RlBoolean::getClassTypeSpec(), "Should we print the joint prior probability?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
-        memberRules.push_back( new ArgumentRule("append"        , RlBoolean::getClassTypeSpec(), "Should we append to an existing file?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
-        memberRules.push_back( new ArgumentRule("version"       , RlBoolean::getClassTypeSpec(), "Should we record the software version?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
+
+        // add the rules from the base class
+        const MemberRules &parentRules = FileMonitor::getParameterRules();
+        memberRules.insert(memberRules.end(), parentRules.begin(), parentRules.end());
         
         rules_set = true;
     }
@@ -138,19 +137,7 @@ const TypeSpec& Mntr_Probability::getTypeSpec( void ) const
 void Mntr_Probability::setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var)
 {
     
-    if ( name == "filename" )
-    {
-        filename = var;
-    }
-    else if ( name == "separator" )
-    {
-        separator = var;
-    }
-    else if ( name == "printgen" )
-    {
-        printgen = var;
-    }
-    else if ( name == "prior" )
+    if ( name == "prior" )
     {
         prior = var;
     }
@@ -162,17 +149,9 @@ void Mntr_Probability::setConstParameter(const std::string& name, const RevPtr<c
     {
         likelihood = var;
     }
-    else if ( name == "append" )
-    {
-        append = var;
-    }
-    else if ( name == "version" )
-    {
-        version = var;
-    }
     else
     {
-        Monitor::setConstParameter(name, var);
+        FileMonitor::setConstParameter(name, var);
     }
     
 }

--- a/src/revlanguage/monitors/Mntr_Probability.h
+++ b/src/revlanguage/monitors/Mntr_Probability.h
@@ -2,7 +2,7 @@
 #define Mntr_Probability_H
 
 #include "ModelMonitor.h"
-#include "RlMonitor.h"
+#include "RlFileMonitor.h"
 #include "TypedDagNode.h"
 
 #include <ostream>
@@ -10,7 +10,7 @@
 
 namespace RevLanguage {
     
-    class Mntr_Probability : public Monitor {
+    class Mntr_Probability : public FileMonitor {
         
     public:
         
@@ -29,15 +29,10 @@ namespace RevLanguage {
         
         void                                        setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var);       //!< Set member variable
         
-        RevPtr<const RevVariable>                   filename;
-        RevPtr<const RevVariable>                   printgen;
-        RevPtr<const RevVariable>                   separator;
         RevPtr<const RevVariable>                   prior;
         RevPtr<const RevVariable>                   posterior;
         RevPtr<const RevVariable>                   likelihood;
-        RevPtr<const RevVariable>                   append;
-        RevPtr<const RevVariable>                   version;
-        
+
     };
     
 }

--- a/src/revlanguage/monitors/Mntr_Screen.cpp
+++ b/src/revlanguage/monitors/Mntr_Screen.cpp
@@ -89,10 +89,10 @@ const MemberRules& Mntr_Screen::getParameterRules(void) const
     {
         
         memberRules.push_back( new Ellipsis( "Variables to monitor.", RevObject::getClassTypeSpec() ) );
-        memberRules.push_back( new ArgumentRule("printgen"  , IntegerPos::getClassTypeSpec()  , "The frequency how often the variables are monitored.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new IntegerPos(1) ) );
-        memberRules.push_back( new ArgumentRule("posterior" , RlBoolean::getClassTypeSpec(), "Monitor the joint posterior probability.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
-        memberRules.push_back( new ArgumentRule("likelihood", RlBoolean::getClassTypeSpec(), "Monitor the joint likelihood.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
-        memberRules.push_back( new ArgumentRule("prior"     , RlBoolean::getClassTypeSpec(), "Monitor the joint prior probability.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
+        memberRules.push_back( new ArgumentRule("printgen"  , IntegerPos::getClassTypeSpec(), "The number of generations between displayed samples.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new IntegerPos(1) ) );
+        memberRules.push_back( new ArgumentRule("posterior" , RlBoolean::getClassTypeSpec() , "Monitor the joint posterior probability.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
+        memberRules.push_back( new ArgumentRule("likelihood", RlBoolean::getClassTypeSpec() , "Monitor the joint likelihood.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
+        memberRules.push_back( new ArgumentRule("prior"     , RlBoolean::getClassTypeSpec() , "Monitor the joint prior probability.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
         
         rules_set = true;
     }

--- a/src/revlanguage/monitors/Mntr_SiteMixtureAllocation.cpp
+++ b/src/revlanguage/monitors/Mntr_SiteMixtureAllocation.cpp
@@ -6,7 +6,6 @@
 #include "BinaryState.h"
 #include "ArgumentRule.h"
 #include "ArgumentRules.h"
-#include "RlMonitor.h"
 #include "IntegerPos.h"
 #include "RbException.h"
 #include "RevObject.h"
@@ -34,7 +33,7 @@ namespace RevBayesCore { template <class valueType> class TypedDagNode; }
 
 using namespace RevLanguage;
 
-Mntr_SiteMixtureAllocation::Mntr_SiteMixtureAllocation(void) : Monitor()
+Mntr_SiteMixtureAllocation::Mntr_SiteMixtureAllocation(void) : FileMonitor()
 {
     
 }
@@ -185,12 +184,11 @@ const MemberRules& Mntr_SiteMixtureAllocation::getParameterRules(void) const
     if ( !rules_set )
     {
         asMonitorMemberRules.push_back( new ArgumentRule("ctmc"           , AbstractHomologousDiscreteCharacterData::getClassTypeSpec(), "", ArgumentRule::BY_REFERENCE, ArgumentRule::ANY, NULL ) );
-        asMonitorMemberRules.push_back( new ArgumentRule("filename"       , RlString::getClassTypeSpec() , "", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
         asMonitorMemberRules.push_back( new ArgumentRule("type"           , RlString::getClassTypeSpec() , "", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
-        asMonitorMemberRules.push_back( new ArgumentRule("printgen"       , IntegerPos::getClassTypeSpec()  , "", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new IntegerPos(1) ) );
-        asMonitorMemberRules.push_back( new ArgumentRule("separator"      , RlString::getClassTypeSpec() , "", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("\t") ) );
-        asMonitorMemberRules.push_back( new ArgumentRule("append"         , RlBoolean::getClassTypeSpec(), "", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
-        asMonitorMemberRules.push_back( new ArgumentRule("version"        , RlBoolean::getClassTypeSpec(), "Should we record the software version?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
+
+        // add the rules from the base class
+        const MemberRules &parentRules = FileMonitor::getParameterRules();
+        asMonitorMemberRules.insert(asMonitorMemberRules.end(), parentRules.begin(), parentRules.end());
 
         rules_set = true;
     }
@@ -220,18 +218,7 @@ void Mntr_SiteMixtureAllocation::printValue(std::ostream &o) const
 void Mntr_SiteMixtureAllocation::setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var)
 {
     
-    if ( name == "" ) {
-        vars.push_back( var );
-    }
-    else if ( name == "filename" )
-    {
-        filename = var;
-    }
-    else if ( name == "separator" )
-    {
-        separator = var;
-    }
-    else if ( name == "type" )
+    if ( name == "type" )
     {
         monitorType = var;
     }
@@ -239,21 +226,9 @@ void Mntr_SiteMixtureAllocation::setConstParameter(const std::string& name, cons
     {
         ctmc = var;
     }
-    else if ( name == "printgen" )
-    {
-        printgen = var;
-    }
-    else if ( name == "append" )
-    {
-        append = var;
-    }
-    else if ( name == "version" )
-    {
-        version = var;
-    }
     else
     {
-        Monitor::setConstParameter(name, var);
+        FileMonitor::setConstParameter(name, var);
     }
     
 }

--- a/src/revlanguage/monitors/Mntr_SiteMixtureAllocation.h
+++ b/src/revlanguage/monitors/Mntr_SiteMixtureAllocation.h
@@ -12,7 +12,7 @@
 #include <ostream>
 #include <vector>
 
-#include "RlMonitor.h"
+#include "RlFileMonitor.h"
 #include "RevObject.h"
 #include "RevPtr.h"
 #include "RevVariable.h"
@@ -20,7 +20,7 @@
 namespace RevLanguage {
 class TypeSpec;
     
-    class Mntr_SiteMixtureAllocation : public Monitor {
+    class Mntr_SiteMixtureAllocation : public FileMonitor {
         
     public:
         
@@ -40,14 +40,8 @@ class TypeSpec;
         
         void                                            setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var);       //!< Set member variable
         
-		std::vector<RevPtr<const RevVariable> >         vars;
-        RevPtr<const RevVariable>                       filename;
-        RevPtr<const RevVariable>                       printgen;
-        RevPtr<const RevVariable>                       version;
 		RevPtr<const RevVariable>                       ctmc;
-        RevPtr<const RevVariable>                       separator;
-        RevPtr<const RevVariable>                       append;
-		RevPtr<const RevVariable>                       monitorType;
+   		RevPtr<const RevVariable>                       monitorType;
     };
     
 }

--- a/src/revlanguage/monitors/Mntr_StochasticBranchRate.cpp
+++ b/src/revlanguage/monitors/Mntr_StochasticBranchRate.cpp
@@ -5,7 +5,6 @@
 
 #include "ArgumentRule.h"
 #include "IntegerPos.h"
-#include "RlMonitor.h"
 #include "RevObject.h"
 #include "RlTimeTree.h"
 #include "RlString.h"
@@ -27,7 +26,7 @@ namespace RevBayesCore { template <class valueType> class TypedDagNode; }
 using namespace RevLanguage;
 
 
-Mntr_StochasticBranchRate::Mntr_StochasticBranchRate(void) : Monitor()
+Mntr_StochasticBranchRate::Mntr_StochasticBranchRate(void) : FileMonitor()
 {
     
 }
@@ -51,7 +50,7 @@ void Mntr_StochasticBranchRate::constructInternalObject( void )
     
     const std::string& file_name      = static_cast<const RlString  &>( filename->getRevObject()           ).getValue();
     const std::string& sep            = static_cast<const RlString  &>( separator->getRevObject()          ).getValue();
-    unsigned int                print_gen      = (int)static_cast<const IntegerPos   &>( printgen->getRevObject()      ).getValue();
+    unsigned int       print_gen      = (int)static_cast<const IntegerPos   &>( printgen->getRevObject()      ).getValue();
     bool               app            = static_cast<const RlBoolean &>( append->getRevObject()             ).getValue();
     bool               wv             = static_cast<const RlBoolean &>( version->getRevObject()            ).getValue();
     
@@ -120,12 +119,11 @@ const MemberRules& Mntr_StochasticBranchRate::getParameterRules(void) const
     if ( !rules_set )
     {
         monitor_rules.push_back( new ArgumentRule("cdbdp"          , TimeTree::getClassTypeSpec(),  "The character dependent birth-death process to monitor.",                      ArgumentRule::BY_REFERENCE, ArgumentRule::ANY ) );
-        monitor_rules.push_back( new ArgumentRule("filename"       , RlString::getClassTypeSpec() , "The file to save sampled character histories.",                                ArgumentRule::BY_VALUE,     ArgumentRule::ANY ) );
-        monitor_rules.push_back( new ArgumentRule("printgen"       , IntegerPos::getClassTypeSpec()  , "How frequently (in number of iterations) should we save sampled character histories? 1 by default.",                              ArgumentRule::BY_VALUE,     ArgumentRule::ANY, new IntegerPos(1) ) );
-        monitor_rules.push_back( new ArgumentRule("separator"      , RlString::getClassTypeSpec() , "The delimiter between variables. \t by default.",                              ArgumentRule::BY_VALUE,     ArgumentRule::ANY, new RlString("\t") ) );
-        monitor_rules.push_back( new ArgumentRule("append"         , RlBoolean::getClassTypeSpec(), "Should we append to an existing file? False by default.",                  ArgumentRule::BY_VALUE,     ArgumentRule::ANY, new RlBoolean(false) ) );
-        monitor_rules.push_back( new ArgumentRule("version"        , RlBoolean::getClassTypeSpec(), "Should we record the software version?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
-        
+
+        // add the rules from the base class
+        const MemberRules &parentRules = FileMonitor::getParameterRules();
+        monitor_rules.insert(monitor_rules.end(), parentRules.begin(), parentRules.end());
+
         rules_set = true;
     }
     
@@ -158,37 +156,13 @@ void Mntr_StochasticBranchRate::printValue(std::ostream &o) const
 void Mntr_StochasticBranchRate::setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var)
 {
     
-    if ( name == "" )
-    {
-        vars.push_back( var );
-    }
-    else if ( name == "filename" )
-    {
-        filename = var;
-    }
-    else if ( name == "separator" )
-    {
-        separator = var;
-    }
-    else if ( name == "cdbdp" )
+    if ( name == "cdbdp" )
     {
         cdbdp = var;
     }
-    else if ( name == "printgen" )
-    {
-        printgen = var;
-    }
-    else if ( name == "append" )
-    {
-        append = var;
-    }
-    else if ( name == "version" )
-    {
-        version = var;
-    }
     else
     {
-        Monitor::setConstParameter(name, var);
+        FileMonitor::setConstParameter(name, var);
     }
     
 }

--- a/src/revlanguage/monitors/Mntr_StochasticBranchRate.h
+++ b/src/revlanguage/monitors/Mntr_StochasticBranchRate.h
@@ -4,7 +4,7 @@
 #include <ostream>
 #include <vector>
 
-#include "RlMonitor.h"
+#include "RlFileMonitor.h"
 #include "RevObject.h"
 #include "RevPtr.h"
 #include "RevVariable.h"
@@ -13,7 +13,7 @@
 namespace RevLanguage {
 class TypeSpec;
     
-    class Mntr_StochasticBranchRate : public Monitor {
+    class Mntr_StochasticBranchRate : public FileMonitor {
         
     public:
         
@@ -33,14 +33,8 @@ class TypeSpec;
         
         void                                            setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var);       //!< Set member variable
         
-        std::vector<RevPtr<const RevVariable> >         vars;
-        RevPtr<const RevVariable>                       filename;
-        RevPtr<const RevVariable>                       printgen;
-        RevPtr<const RevVariable>                       version;
         RevPtr<const RevVariable>                       cdbdp;
-        RevPtr<const RevVariable>                       separator;
-        RevPtr<const RevVariable>                       append;
-        
+
     };
     
 }

--- a/src/revlanguage/monitors/Mntr_StochasticBranchStateTimes.cpp
+++ b/src/revlanguage/monitors/Mntr_StochasticBranchStateTimes.cpp
@@ -13,7 +13,6 @@
 
 #include "ArgumentRule.h"
 #include "IntegerPos.h"
-#include "RlMonitor.h"
 #include "RevObject.h"
 #include "RlTimeTree.h"
 #include "RlString.h"
@@ -35,7 +34,7 @@ namespace RevBayesCore { template <class valueType> class TypedDagNode; }
 using namespace RevLanguage;
 
 
-Mntr_StochasticBranchStateTimes::Mntr_StochasticBranchStateTimes(void) : Monitor()
+Mntr_StochasticBranchStateTimes::Mntr_StochasticBranchStateTimes(void) : FileMonitor()
 {
     
 }
@@ -59,7 +58,7 @@ void Mntr_StochasticBranchStateTimes::constructInternalObject( void )
     
     const std::string& file_name      = static_cast<const RlString  &>( filename->getRevObject()           ).getValue();
     const std::string& sep            = static_cast<const RlString  &>( separator->getRevObject()          ).getValue();
-    unsigned int                print_gen      = (int)static_cast<const IntegerPos   &>( printgen->getRevObject()      ).getValue();
+    unsigned int       print_gen      = (int)static_cast<const IntegerPos   &>( printgen->getRevObject()      ).getValue();
     bool               app            = static_cast<const RlBoolean &>( append->getRevObject()             ).getValue();
     bool               wv             = static_cast<const RlBoolean &>( version->getRevObject()            ).getValue();
     
@@ -128,11 +127,10 @@ const MemberRules& Mntr_StochasticBranchStateTimes::getParameterRules(void) cons
     if ( !rules_set )
     {
         monitor_rules.push_back( new ArgumentRule("cdbdp"          , TimeTree::getClassTypeSpec(),  "The character dependent birth-death process to monitor.",                      ArgumentRule::BY_REFERENCE, ArgumentRule::ANY ) );
-        monitor_rules.push_back( new ArgumentRule("filename"       , RlString::getClassTypeSpec() , "The file to save sampled character histories.",                                ArgumentRule::BY_VALUE,     ArgumentRule::ANY ) );
-        monitor_rules.push_back( new ArgumentRule("printgen"       , Natural::getClassTypeSpec()  , "How frequently (in number of iterations) should we save sampled character histories? 1 by default.",                              ArgumentRule::BY_VALUE,     ArgumentRule::ANY, new Natural(1) ) );
-        monitor_rules.push_back( new ArgumentRule("separator"      , RlString::getClassTypeSpec() , "The delimiter between variables. \t by default.",                              ArgumentRule::BY_VALUE,     ArgumentRule::ANY, new RlString("\t") ) );
-        monitor_rules.push_back( new ArgumentRule("append"         , RlBoolean::getClassTypeSpec(), "Should we append to an existing file? False by default.",                  ArgumentRule::BY_VALUE,     ArgumentRule::ANY, new RlBoolean(false) ) );
-        monitor_rules.push_back( new ArgumentRule("version"        , RlBoolean::getClassTypeSpec(), "Should we record the software version?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
+
+        // add the rules from the base class
+        const MemberRules &parentRules = FileMonitor::getParameterRules();
+        monitor_rules.insert(monitor_rules.end(), parentRules.begin(), parentRules.end());
 
         rules_set = true;
     }
@@ -166,36 +164,13 @@ void Mntr_StochasticBranchStateTimes::printValue(std::ostream &o) const
 void Mntr_StochasticBranchStateTimes::setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var)
 {
     
-    if ( name == "" ) {
-        vars.push_back( var );
-    }
-    else if ( name == "filename" )
-    {
-        filename = var;
-    }
-    else if ( name == "separator" )
-    {
-        separator = var;
-    }
-    else if ( name == "cdbdp" )
+    if ( name == "cdbdp" )
     {
         cdbdp = var;
     }
-    else if ( name == "printgen" )
-    {
-        printgen = var;
-    }
-    else if ( name == "append" )
-    {
-        append = var;
-    }
-    else if ( name == "version" )
-    {
-        version = var;
-    }
     else
     {
-        Monitor::setConstParameter(name, var);
+        FileMonitor::setConstParameter(name, var);
     }
     
 }

--- a/src/revlanguage/monitors/Mntr_StochasticBranchStateTimes.h
+++ b/src/revlanguage/monitors/Mntr_StochasticBranchStateTimes.h
@@ -12,7 +12,7 @@
 #include <ostream>
 #include <vector>
 
-#include "RlMonitor.h"
+#include "RlFileMonitor.h"
 #include "RevObject.h"
 #include "RevPtr.h"
 #include "RevVariable.h"
@@ -21,7 +21,7 @@
 namespace RevLanguage {
 class TypeSpec;
     
-    class Mntr_StochasticBranchStateTimes : public Monitor {
+    class Mntr_StochasticBranchStateTimes : public FileMonitor {
         
     public:
         
@@ -41,13 +41,7 @@ class TypeSpec;
         
         void                                            setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var);       //!< Set member variable
         
-        std::vector<RevPtr<const RevVariable> >         vars;
-        RevPtr<const RevVariable>                       filename;
-        RevPtr<const RevVariable>                       printgen;
-        RevPtr<const RevVariable>                       version;
         RevPtr<const RevVariable>                       cdbdp;
-        RevPtr<const RevVariable>                       separator;
-        RevPtr<const RevVariable>                       append;
 
     };
     

--- a/src/revlanguage/monitors/Mntr_StochasticCharacterMapping.cpp
+++ b/src/revlanguage/monitors/Mntr_StochasticCharacterMapping.cpp
@@ -15,7 +15,6 @@
 #include "IntegerPos.h"
 #include "NaturalNumbersState.h"
 #include "StandardState.h"
-#include "RlMonitor.h"
 #include "RbException.h"
 #include "RevObject.h"
 #include "RlAbstractHomologousDiscreteCharacterData.h"
@@ -41,7 +40,7 @@ namespace RevBayesCore { template <class valueType> class TypedDagNode; }
 using namespace RevLanguage;
 
 
-Mntr_StochasticCharacterMapping::Mntr_StochasticCharacterMapping(void) : Monitor()
+Mntr_StochasticCharacterMapping::Mntr_StochasticCharacterMapping(void) : FileMonitor()
 {
 
 }
@@ -67,7 +66,7 @@ void Mntr_StochasticCharacterMapping::constructInternalObject( void )
     bool               is             = static_cast<const RlBoolean       &>( include_simmap->getRevObject()     ).getValue();
     bool               sd             = static_cast<const RlBoolean       &>( use_simmap_default->getRevObject() ).getValue();
     const std::string& sep            = static_cast<const RlString        &>( separator->getRevObject()          ).getValue();
-    unsigned int                print_gen      = (int)static_cast<const IntegerPos    &>( printgen->getRevObject()           ).getValue();
+    unsigned int       print_gen      = (int)static_cast<const IntegerPos &>( printgen->getRevObject()           ).getValue();
     bool               app            = static_cast<const RlBoolean       &>( append->getRevObject()             ).getValue();
     bool               wv             = static_cast<const RlBoolean       &>( version->getRevObject()            ).getValue();
     size_t             idx            = (size_t)static_cast<const Natural &>( index->getRevObject()              ).getValue();
@@ -200,14 +199,13 @@ const MemberRules& Mntr_StochasticCharacterMapping::getParameterRules(void) cons
     {
         monitor_rules.push_back( new ArgumentRule("ctmc"           , AbstractHomologousDiscreteCharacterData::getClassTypeSpec(), "The continuous-time Markov process to monitor.", ArgumentRule::BY_REFERENCE, ArgumentRule::ANY, NULL ) );
         monitor_rules.push_back( new ArgumentRule("cdbdp"          , TimeTree::getClassTypeSpec(),  "The character dependent birth-death process to monitor.",                      ArgumentRule::BY_REFERENCE, ArgumentRule::ANY, NULL) );
-        monitor_rules.push_back( new ArgumentRule("filename"       , RlString::getClassTypeSpec() , "The file to save sampled character histories.",                                ArgumentRule::BY_VALUE,     ArgumentRule::ANY ) );
         monitor_rules.push_back( new ArgumentRule("include_simmap" , RlBoolean::getClassTypeSpec(), "Should we log SIMMAP/phytools compatible newick strings? True by default.",    ArgumentRule::BY_VALUE,     ArgumentRule::ANY, new RlBoolean(true) ) );
         monitor_rules.push_back( new ArgumentRule("use_simmap_default" , RlBoolean::getClassTypeSpec(), "Should we use the default SIMMAP/phytools event ordering? True by default.",    ArgumentRule::BY_VALUE,     ArgumentRule::ANY, new RlBoolean(true) ) );
-        monitor_rules.push_back( new ArgumentRule("printgen"       , IntegerPos::getClassTypeSpec()  , "How frequently (in number of iterations) should we save sampled character histories? 1 by default.",                              ArgumentRule::BY_VALUE,     ArgumentRule::ANY, new IntegerPos(1) ) );
-        monitor_rules.push_back( new ArgumentRule("separator"      , RlString::getClassTypeSpec() , "The delimiter between variables. \t by default.",                              ArgumentRule::BY_VALUE,     ArgumentRule::ANY, new RlString("\t") ) );
-        monitor_rules.push_back( new ArgumentRule("append"         , RlBoolean::getClassTypeSpec(), "Should we append to an existing file? False by default.",                  ArgumentRule::BY_VALUE,     ArgumentRule::ANY, new RlBoolean(false) ) );
-        monitor_rules.push_back( new ArgumentRule("version"        , RlBoolean::getClassTypeSpec(), "Should we record the software version?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
-        monitor_rules.push_back( new ArgumentRule("index"          , Natural::getClassTypeSpec(), "The index of the character to be mointored.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new Natural(1) ) );
+        monitor_rules.push_back( new ArgumentRule("index"          , Natural::getClassTypeSpec(), "The index of the character to be monitored.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new Natural(1) ) );
+
+        // add the rules from the base class
+        const MemberRules &parentRules = FileMonitor::getParameterRules();
+        monitor_rules.insert(monitor_rules.end(), parentRules.begin(), parentRules.end());
 
         rules_set = true;
     }
@@ -241,32 +239,13 @@ void Mntr_StochasticCharacterMapping::printValue(std::ostream &o) const
 void Mntr_StochasticCharacterMapping::setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var)
 {
 
-    if ( name == "" ) {
-        vars.push_back( var );
-    }
-    else if ( name == "filename" )
-    {
-        filename = var;
-    }
-    else if ( name == "separator" )
-    {
-        separator = var;
-    }
-    else if ( name == "cdbdp" )
+    if ( name == "cdbdp" )
     {
         cdbdp = var;
     }
     else if ( name == "ctmc" )
     {
         ctmc = var;
-    }
-    else if ( name == "printgen" )
-    {
-        printgen = var;
-    }
-    else if ( name == "append" )
-    {
-        append = var;
     }
     else if ( name == "include_simmap" )
     {
@@ -276,17 +255,13 @@ void Mntr_StochasticCharacterMapping::setConstParameter(const std::string& name,
     {
         use_simmap_default = var;
     }
-    else if ( name == "version" )
-    {
-        version = var;
-    }
     else if ( name == "index" )
     {
         index = var;
     }
     else
     {
-        Monitor::setConstParameter(name, var);
+        FileMonitor::setConstParameter(name, var);
     }
 
 }

--- a/src/revlanguage/monitors/Mntr_StochasticCharacterMapping.h
+++ b/src/revlanguage/monitors/Mntr_StochasticCharacterMapping.h
@@ -12,7 +12,7 @@
 #include <ostream>
 #include <vector>
 
-#include "RlMonitor.h"
+#include "RlFileMonitor.h"
 #include "RevObject.h"
 #include "RevPtr.h"
 #include "RevVariable.h"
@@ -21,14 +21,14 @@
 namespace RevLanguage {
 class TypeSpec;
 
-    class Mntr_StochasticCharacterMapping : public Monitor {
+    class Mntr_StochasticCharacterMapping : public FileMonitor {
 
     public:
 
         Mntr_StochasticCharacterMapping(void);                                                                                            //!< Default constructor
 
         // Basic utility functions
-        virtual Mntr_StochasticCharacterMapping*  clone(void) const;                                                                      //!< Clone object
+        virtual Mntr_StochasticCharacterMapping*        clone(void) const;                                                                      //!< Clone object
         void                                            constructInternalObject(void);                                                          //!< We construct the a new internal monitor.
         static const std::string&                       getClassType(void);                                                                     //!< Get Rev type
         static const TypeSpec&                          getClassTypeSpec(void);                                                                 //!< Get class type spec
@@ -41,14 +41,8 @@ class TypeSpec;
 
         void                                            setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var);       //!< Set member variable
 
-        std::vector<RevPtr<const RevVariable> >         vars;
-        RevPtr<const RevVariable>                       filename;
-        RevPtr<const RevVariable>                       printgen;
-        RevPtr<const RevVariable>                       version;
         RevPtr<const RevVariable>                       cdbdp;
         RevPtr<const RevVariable>                       ctmc;
-        RevPtr<const RevVariable>                       separator;
-        RevPtr<const RevVariable>                       append;
         RevPtr<const RevVariable>                       include_simmap;
         RevPtr<const RevVariable>                       use_simmap_default;
         RevPtr<const RevVariable>                       index;

--- a/src/revlanguage/monitors/Mntr_StochasticVariable.cpp
+++ b/src/revlanguage/monitors/Mntr_StochasticVariable.cpp
@@ -14,12 +14,11 @@
 #include "RevPtr.h"
 #include "RevVariable.h"
 #include "RlBoolean.h"
-#include "RlMonitor.h"
 
 
 using namespace RevLanguage;
 
-Mntr_StochasticVariable::Mntr_StochasticVariable(void) : Monitor()
+Mntr_StochasticVariable::Mntr_StochasticVariable(void) : FileMonitor()
 {
 
 }
@@ -44,9 +43,9 @@ void Mntr_StochasticVariable::constructInternalObject( void )
     delete value;
     
     // now allocate a new sliding move
-    const std::string&                  fn      = static_cast<const RlString &>( filename->getRevObject() ).getValue();
-    const std::string&                  sep     = static_cast<const RlString &>( separator->getRevObject() ).getValue();
-    unsigned long                                g       = static_cast<const IntegerPos  &>( printgen->getRevObject() ).getValue();
+    const std::string&                  fn      = static_cast<const RlString &> ( filename->getRevObject() ).getValue();
+    const std::string&                  sep     = static_cast<const RlString &> ( separator->getRevObject() ).getValue();
+    unsigned long                       g       = static_cast<const IntegerPos&>( printgen->getRevObject() ).getValue();
     bool                                ap      = static_cast<const RlBoolean &>( append->getRevObject() ).getValue();
     bool                                wv      = static_cast<const RlBoolean &>( version->getRevObject() ).getValue();
     RevBayesCore::StochasticVariableMonitor *m = new RevBayesCore::StochasticVariableMonitor((unsigned long)g, fn, sep);
@@ -84,23 +83,19 @@ const TypeSpec& Mntr_StochasticVariable::getClassTypeSpec(void)
 const MemberRules& Mntr_StochasticVariable::getParameterRules(void) const
 {
     
-    static MemberRules StochasticVariableMonitorMemberRules;
+    static MemberRules memberRules;
     static bool rules_set = false;
     
     if ( !rules_set )
     {
-        
-        StochasticVariableMonitorMemberRules.push_back( new ArgumentRule("filename"  , RlString::getClassTypeSpec() , "The name of the file.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
-        StochasticVariableMonitorMemberRules.push_back( new ArgumentRule("printgen"  , IntegerPos::getClassTypeSpec()  , "The frequency how often we print.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new IntegerPos(1) ) );
-        StochasticVariableMonitorMemberRules.push_back( new ArgumentRule("separator" , RlString::getClassTypeSpec() , "The delimiter between variables.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("\t") ) );
-        StochasticVariableMonitorMemberRules.push_back( new ArgumentRule("append"    , RlBoolean::getClassTypeSpec(), "Should we append or overwrite if the file exists?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
-        StochasticVariableMonitorMemberRules.push_back( new ArgumentRule("version"   , RlBoolean::getClassTypeSpec(), "Should we record the software version?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
-
+        // add the rules from the base class
+        const MemberRules &parentRules = FileMonitor::getParameterRules();
+        memberRules.insert(memberRules.end(), parentRules.begin(), parentRules.end());
         
         rules_set = true;
     }
     
-    return StochasticVariableMonitorMemberRules;
+    return memberRules;
 }
 
 
@@ -140,29 +135,6 @@ void Mntr_StochasticVariable::printValue(std::ostream &o) const
 void Mntr_StochasticVariable::setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var)
 {
     
-    if ( name == "filename" )
-    {
-        filename = var;
-    }
-    else if ( name == "separator" )
-    {
-        separator = var;
-    }
-    else if ( name == "printgen" )
-    {
-        printgen = var;
-    }
-    else if ( name == "append" )
-    {
-        append = var;
-    }
-    else if ( name == "version" )
-    {
-        version = var;
-    }
-    else
-    {
-        Monitor::setConstParameter(name, var);
-    }
+    FileMonitor::setConstParameter(name, var);
     
 }

--- a/src/revlanguage/monitors/Mntr_StochasticVariable.h
+++ b/src/revlanguage/monitors/Mntr_StochasticVariable.h
@@ -2,7 +2,7 @@
 #define Mntr_StochasticVariable_H
 
 #include "StochasticVariableMonitor.h"
-#include "RlMonitor.h"
+#include "RlFileMonitor.h"
 #include "TypedDagNode.h"
 
 #include <ostream>
@@ -10,7 +10,7 @@
 
 namespace RevLanguage {
     
-    class Mntr_StochasticVariable : public Monitor {
+    class Mntr_StochasticVariable : public FileMonitor {
         
     public:
         
@@ -29,13 +29,7 @@ namespace RevLanguage {
     protected:
         
         void                                        setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var);   //!< Set member variable
-        
-        RevPtr<const RevVariable>                   filename;
-        RevPtr<const RevVariable>                   printgen;
-        RevPtr<const RevVariable>                   separator;
-        RevPtr<const RevVariable>                   append;
-        RevPtr<const RevVariable>                   version;
-        
+
     };
     
 }

--- a/src/revlanguage/monitors/RlFileMonitor.cpp
+++ b/src/revlanguage/monitors/RlFileMonitor.cpp
@@ -1,0 +1,97 @@
+#include <string>
+
+#include "ArgumentRule.h"
+#include "ArgumentRules.h"
+#include "RlBoolean.h"
+#include "RlFileMonitor.h"
+#include "IntegerPos.h"
+#include "RlString.h"
+#include "RevPtr.h"
+#include "RevVariable.h"
+#include "TypeSpec.h"
+
+namespace RevBayesCore { class DagNode; }
+
+using namespace RevLanguage;
+
+FileMonitor::FileMonitor(void) : Monitor()
+{
+    
+}
+
+
+const std::string& FileMonitor::getClassType(void)
+{
+    
+    static std::string rev_type = "FileMonitor";
+    
+	return rev_type; 
+}
+
+
+const TypeSpec& FileMonitor::getClassTypeSpec(void)
+{
+    
+    static TypeSpec rev_type_spec = TypeSpec( getClassType(), new TypeSpec( Monitor::getClassTypeSpec() ) );
+    
+	return rev_type_spec; 
+}
+
+
+/** Return member rules (no members) */
+const MemberRules& FileMonitor::getParameterRules(void) const
+{
+
+    static MemberRules memberRules;
+    static bool rules_set = false;
+
+    if ( !rules_set )
+    {
+        memberRules.push_back( new ArgumentRule("append"    , RlBoolean::getClassTypeSpec() , "Should we append or overwrite if the file exists?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
+        memberRules.push_back( new ArgumentRule("filename"  , RlString::getClassTypeSpec()  , "The name of the file for storing the samples.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
+        memberRules.push_back( new ArgumentRule("printgen"  , IntegerPos::getClassTypeSpec(), "The number of generations between stored samples.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new IntegerPos(1) ) );
+        std::vector<std::string> sep = {"separator", "delimiter"};
+        memberRules.push_back( new ArgumentRule(sep , RlString::getClassTypeSpec()          , "The separator/delimiter between columns in the file.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("\t") ) );
+        memberRules.push_back( new ArgumentRule("version"   , RlBoolean::getClassTypeSpec() , "Should we record the software version?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
+
+        rules_set = true;
+    }
+
+    return memberRules;
+}
+
+
+/** Set a member variable */
+void FileMonitor::setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var)
+{
+
+    if ( name == "filename" )
+    {
+        filename = var;
+    }
+    else if ( name == "separator" || name == "delimiter" || name == "separator/delimiter" )
+    {
+        separator = var;
+    }
+    else if ( name == "printgen" )
+    {
+        printgen = var;
+    }
+    else if ( name == "append" )
+    {
+        append = var;
+    }
+    else if ( name == "version" )
+    {
+        version = var;
+    }
+    else
+    {
+        Monitor::setConstParameter(name, var);
+    }
+
+}
+
+
+
+

--- a/src/revlanguage/monitors/RlFileMonitor.h
+++ b/src/revlanguage/monitors/RlFileMonitor.h
@@ -1,0 +1,40 @@
+#ifndef RlFileMonitor_H
+#define RlFileMonitor_H
+
+#include "RlMonitor.h"
+
+namespace RevLanguage {
+
+    /** @brief Base class for all file monitors in Rev Language
+     *
+     * File onitors are tasked with saving information about one or several variable DAG node(s) to a file.
+     * */
+    
+    class FileMonitor : public Monitor {
+        
+    public:
+        
+        FileMonitor(void);  //!< Default constructor
+        
+        // Basic utility functions
+        virtual FileMonitor*                        clone(void) const = 0;
+        static const std::string&                   getClassType(void);
+        static const TypeSpec&                      getClassTypeSpec(void);
+
+        virtual const MemberRules&                  getParameterRules(void) const;                                        //!< Get member rules (const)
+
+    protected:
+
+        virtual void                                setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var);       //!< Set member variable
+
+        RevPtr<const RevVariable>                   append;
+        RevPtr<const RevVariable>                   filename;
+        RevPtr<const RevVariable>                   printgen;
+        RevPtr<const RevVariable>                   separator;
+        RevPtr<const RevVariable>                   version;
+
+    };
+    
+}
+
+#endif

--- a/src/revlanguage/monitors/characterhistory/Mntr_CharacterHistoryNewickFile.cpp
+++ b/src/revlanguage/monitors/characterhistory/Mntr_CharacterHistoryNewickFile.cpp
@@ -22,7 +22,6 @@
 #include "RevPtr.h"
 #include "RevVariable.h"
 #include "RlBoolean.h"
-#include "RlMonitor.h"
 #include "StochasticNode.h"
 #include "Real.h" // IWYU pragma: keep
 #include "StandardState.h" // IWYU pragma: keep
@@ -34,7 +33,7 @@ namespace RevBayesCore { template <class valueType> class TypedDagNode; }
 
 using namespace RevLanguage;
 
-Mntr_CharacterHistoryNewickFile::Mntr_CharacterHistoryNewickFile(void) : Monitor() {
+Mntr_CharacterHistoryNewickFile::Mntr_CharacterHistoryNewickFile(void) : FileMonitor() {
     
 }
 
@@ -61,12 +60,7 @@ void Mntr_CharacterHistoryNewickFile::constructInternalObject( void ) {
     unsigned int g = (int)static_cast<const Natural &>( printgen->getRevObject() ).getValue();
    
     RevBayesCore::TypedDagNode<RevBayesCore::Tree> *t = static_cast<const TimeTree &>( tree->getRevObject() ).getDagNode();
-    std::set<RevBayesCore::TypedDagNode<RevBayesCore::RbVector<double> > *> n;
-    for (std::set<RevPtr<const RevVariable> >::iterator i = vars.begin(); i != vars.end(); ++i) {
-        RevBayesCore::TypedDagNode< RevBayesCore::RbVector<double> >* node = static_cast< const ModelVector<Real> & >((*i)->getRevObject()).getDagNode();
-        n.insert( node );
-    }
-    
+
     RevBayesCore::TypedDagNode<RevBayesCore::AbstractHomologousDiscreteCharacterData>* ctmc_tdn   = static_cast<const RevLanguage::AbstractHomologousDiscreteCharacterData&>( ctmc->getRevObject() ).getDagNode();
     RevBayesCore::StochasticNode<RevBayesCore::AbstractHomologousDiscreteCharacterData>* ctmc_sn  = static_cast<RevBayesCore::StochasticNode<RevBayesCore::AbstractHomologousDiscreteCharacterData>* >(ctmc_tdn);
     
@@ -129,42 +123,36 @@ std::string Mntr_CharacterHistoryNewickFile::getMonitorName( void ) const
 const MemberRules& Mntr_CharacterHistoryNewickFile::getParameterRules(void) const
 {
     
-    static MemberRules Mntr_CharacterHistoryNewickFileMemberRules;
+    static MemberRules memberRules;
     static bool rules_set = false;
     
     if ( !rules_set )
     {
     
-        Mntr_CharacterHistoryNewickFileMemberRules.push_back( new ArgumentRule("filename"  , RlString::getClassTypeSpec(), "", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
-        Mntr_CharacterHistoryNewickFileMemberRules.push_back( new ArgumentRule("ctmc"      , AbstractHomologousDiscreteCharacterData::getClassTypeSpec(), "", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
-        Mntr_CharacterHistoryNewickFileMemberRules.push_back( new ArgumentRule("tree"      , TimeTree::getClassTypeSpec(), "", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
-        Mntr_CharacterHistoryNewickFileMemberRules.push_back( new ArgumentRule("printgen"  , IntegerPos::getClassTypeSpec(), "", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new IntegerPos(1) ) );
-        Mntr_CharacterHistoryNewickFileMemberRules.push_back( new ArgumentRule("separator" , RlString::getClassTypeSpec(), "", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("\t") ) );
-        Mntr_CharacterHistoryNewickFileMemberRules.push_back( new ArgumentRule("posterior" , RlBoolean::getClassTypeSpec(), "", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
-        Mntr_CharacterHistoryNewickFileMemberRules.push_back( new ArgumentRule("likelihood", RlBoolean::getClassTypeSpec(), "", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
-        Mntr_CharacterHistoryNewickFileMemberRules.push_back( new ArgumentRule("prior"     , RlBoolean::getClassTypeSpec(), "", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
-//        Mntr_CharacterHistoryNewickFileMemberRules.push_back( new ArgumentRule("counts", true, RlBoolean::getClassTypeSpec(), new RlBoolean(false) ) );
-//        Mntr_CharacterHistoryNewickFileMemberRules.push_back( new ArgumentRule("events", true, RlBoolean::getClassTypeSpec(), new RlBoolean(true) ) );
-        Mntr_CharacterHistoryNewickFileMemberRules.push_back( new ArgumentRule("append"    , RlBoolean::getClassTypeSpec(), "", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
-        
+        memberRules.push_back( new ArgumentRule("ctmc"      , AbstractHomologousDiscreteCharacterData::getClassTypeSpec(), "", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        memberRules.push_back( new ArgumentRule("tree"      , TimeTree::getClassTypeSpec(), "", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        memberRules.push_back( new ArgumentRule("posterior" , RlBoolean::getClassTypeSpec(), "", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
+        memberRules.push_back( new ArgumentRule("likelihood", RlBoolean::getClassTypeSpec(), "", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
+        memberRules.push_back( new ArgumentRule("prior"     , RlBoolean::getClassTypeSpec(), "", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
+
         std::vector<std::string> options_style;
-        //        options.push_back( RlString("std") );
         options_style.push_back( "events" );
         options_style.push_back( "counts" );
-        Mntr_CharacterHistoryNewickFileMemberRules.push_back( new OptionRule( "style", new RlString("events"), options_style, "" ) );
+        memberRules.push_back( new OptionRule( "style", new RlString("events"), options_style, "" ) );
 
         
         std::vector<std::string> options;
-//        options.push_back( RlString("std") );
         options.push_back( "biogeo" );
-        Mntr_CharacterHistoryNewickFileMemberRules.push_back( new OptionRule( "type", new RlString("biogeo"), options, "" ) );
+        memberRules.push_back( new OptionRule( "type", new RlString("biogeo"), options, "" ) );
 
-        
+        // add the rules from the base class
+        const MemberRules &parentRules = FileMonitor::getParameterRules();
+        memberRules.insert(memberRules.end(), parentRules.begin(), parentRules.end());
         
         rules_set = true;
     }
     
-    return Mntr_CharacterHistoryNewickFileMemberRules;
+    return memberRules;
 }
 
 /** Get type spec */
@@ -186,43 +174,36 @@ void Mntr_CharacterHistoryNewickFile::printValue(std::ostream &o) const {
 /** Set a member variable */
 void Mntr_CharacterHistoryNewickFile::setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var) {
     
-    if ( name == "" ) {
-        vars.insert( var );
-    }
-    else if ( name == "filename" ) {
-        filename = var;
-    }
-    else if ( name == "tree" ) {
+    if ( name == "tree" )
+    {
         tree = var;
     }
-    else if ( name == "ctmc" ) {
+    else if ( name == "ctmc" )
+    {
         ctmc = var;
     }
-    else if ( name == "separator" ) {
-        separator = var;
-    }
-    else if ( name == "printgen" ) {
-        printgen = var;
-    }
-    else if ( name == "prior" ) {
+    else if ( name == "prior" )
+    {
         prior = var;
     }
-    else if ( name == "posterior" ) {
+    else if ( name == "posterior" )
+    {
         posterior = var;
     }
-    else if ( name == "likelihood" ) {
+    else if ( name == "likelihood" )
+    {
         likelihood = var;
     }
-    else if ( name == "type" ) {
+    else if ( name == "type" )
+    {
         type = var;
     }
-    else if ( name == "style" ) {
+    else if ( name == "style" )
+    {
         style = var;
     }
-    else if ( name == "append" ) {
-        append = var;
-    }
-    else {
-        RevObject::setConstParameter(name, var);
+    else
+    {
+        FileMonitor::setConstParameter(name, var);
     }
 }

--- a/src/revlanguage/monitors/characterhistory/Mntr_CharacterHistoryNewickFile.h
+++ b/src/revlanguage/monitors/characterhistory/Mntr_CharacterHistoryNewickFile.h
@@ -19,7 +19,7 @@
 #define Mntr_CharacterHistoryNewickFile_H
 
 #include "TreeCharacterHistoryNodeMonitor.h"
-#include "RlMonitor.h"
+#include "RlFileMonitor.h"
 #include "TypedDagNode.h"
 
 #include <ostream>
@@ -27,7 +27,7 @@
 
 namespace RevLanguage {
     
-    class Mntr_CharacterHistoryNewickFile : public Monitor {
+    class Mntr_CharacterHistoryNewickFile : public FileMonitor {
         
     public:
         
@@ -47,21 +47,14 @@ namespace RevLanguage {
         
         void                                        setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var);       //!< Set member variable
         
-        std::set<RevPtr<const RevVariable> >        vars;
-        RevPtr<const RevVariable>                   filename;
         RevPtr<const RevVariable>                   tree;
         RevPtr<const RevVariable>                   ctmc;
-        RevPtr<const RevVariable>                   printgen;
-        RevPtr<const RevVariable>                   separator;
         RevPtr<const RevVariable>                   prior;
         RevPtr<const RevVariable>                   posterior;
         RevPtr<const RevVariable>                   likelihood;
         RevPtr<const RevVariable>                   type;
-//        RevPtr<const RevVariable>                      counts;
-//        RevPtr<const RevVariable>                      events;
-        RevPtr<const RevVariable>                      style;
-        RevPtr<const RevVariable>                      append;
-        
+        RevPtr<const RevVariable>                   style;
+
     };
     
 }

--- a/src/revlanguage/monitors/characterhistory/Mntr_CharacterHistoryNhxFile.h
+++ b/src/revlanguage/monitors/characterhistory/Mntr_CharacterHistoryNhxFile.h
@@ -19,7 +19,7 @@
 #define Mntr_CharacterHistoryNhxFile_H
 
 #include "TreeCharacterHistoryNhxMonitor.h"
-#include "RlMonitor.h"
+#include "RlFileMonitor.h"
 #include "TypedDagNode.h"
 
 #include <ostream>
@@ -27,7 +27,7 @@
 
 namespace RevLanguage {
     
-    class Mntr_CharacterHistoryNhxFile : public Monitor {
+    class Mntr_CharacterHistoryNhxFile : public FileMonitor {
         
     public:
         
@@ -47,15 +47,11 @@ namespace RevLanguage {
         
         void                                        setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var);       //!< Set member variable
         
-        std::set<RevPtr<const RevVariable> >        vars;
-        RevPtr<const RevVariable>                   filename;
         RevPtr<const RevVariable>                   tree;
         RevPtr<const RevVariable>                   ctmc;
         RevPtr<const RevVariable>                   atlas;
         RevPtr<const RevVariable>                   maxgen;
-        RevPtr<const RevVariable>                   samplegen;
         RevPtr<const RevVariable>                   burnin;
-        RevPtr<const RevVariable>                   separator;
         RevPtr<const RevVariable>                   prior;
         RevPtr<const RevVariable>                   posterior;
         RevPtr<const RevVariable>                   likelihood;

--- a/src/revlanguage/monitors/characterhistory/Mntr_CharacterHistorySummary.h
+++ b/src/revlanguage/monitors/characterhistory/Mntr_CharacterHistorySummary.h
@@ -10,7 +10,7 @@
 #define Mntr_CharacterHistorySummary_h
 
 #include "CharacterHistorySummaryMonitor.h"
-#include "RlMonitor.h"
+#include "RlFileMonitor.h"
 #include "TypedDagNode.h"
 
 #include <ostream>
@@ -18,14 +18,14 @@
 
 namespace RevLanguage {
     
-    class Mntr_CharacterHistorySummary : public Monitor {
+    class Mntr_CharacterHistorySummary : public FileMonitor {
         
     public:
         
         Mntr_CharacterHistorySummary(void);                                                                                              //!< Default constructor (0.0)
         
         // Basic utility functions
-        virtual Mntr_CharacterHistorySummary*    clone(void) const;                                                                      //!< Clone object
+        virtual Mntr_CharacterHistorySummary*       clone(void) const;                                                                      //!< Clone object
         void                                        constructInternalObject(void);                                                          //!< We construct the a new internal Mntr_CharacterHistorySummary.
         static const std::string&                   getClassType(void);                                                                     //!< Get class name
         static const TypeSpec&                      getClassTypeSpec(void);                                                                 //!< Get class type spec
@@ -38,20 +38,13 @@ namespace RevLanguage {
         
         void                                        setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var);       //!< Set member variable
         
-        std::set<RevPtr<const RevVariable> >        vars;
-        RevPtr<const RevVariable>                   filename;
         RevPtr<const RevVariable>                   tree;
         RevPtr<const RevVariable>                   ctmc;
-        RevPtr<const RevVariable>                   printgen;
-        RevPtr<const RevVariable>                   separator;
         RevPtr<const RevVariable>                   prior;
         RevPtr<const RevVariable>                   posterior;
         RevPtr<const RevVariable>                   likelihood;
         RevPtr<const RevVariable>                   type;
-        //        RevPtr<const RevVariable>                      counts;
-        //        RevPtr<const RevVariable>                      events;
-        RevPtr<const RevVariable>                      style;
-        RevPtr<const RevVariable>                      append;
+        RevPtr<const RevVariable>                   style;
         
     };
     


### PR DESCRIPTION
Collect the arguments relevant for monitors that print to a file in a separate base class. This makes the names and descriptions consistent across monitors (e.g. the use of the word delimiter vs. separator).