### PR TITLE
Improved reading of delimited files

### DIFF
--- a/src/core/datatypes/phylogenetics/TreeDiscreteCharacterData.cpp
+++ b/src/core/datatypes/phylogenetics/TreeDiscreteCharacterData.cpp
@@ -149,7 +149,7 @@ void TreeDiscreteCharacterData::writeToFile(const std::string &dir, const std::s
         // tab-delimited file
         fm = RbFileManager(dir, fn + ".tsv");
         RevBayesCore::DelimitedCharacterDataWriter writer; 
-        writer.writeData(fm.getFullFileName(), *character_data, "\t"[0]);
+        writer.writeData(fm.getFullFileName(), *character_data);
 
         // write the character history's time spent in each state
         fm = RbFileManager(dir, fn + "_time_in_states.tsv");

--- a/src/core/datatypes/phylogenetics/characterdata/AbstractHomologousDiscreteCharacterData.cpp
+++ b/src/core/datatypes/phylogenetics/characterdata/AbstractHomologousDiscreteCharacterData.cpp
@@ -17,7 +17,7 @@ void AbstractHomologousDiscreteCharacterData::writeToFile(const std::string &dir
         // NEXUS does not support NaturalNumbers so write tab delimited file
         RbFileManager fm = RbFileManager(dir, fn + ".tsv");
         RevBayesCore::DelimitedCharacterDataWriter writer; 
-        writer.writeData(fm.getFullFileName(), *this, "\t"[0]);
+        writer.writeData(fm.getFullFileName(), *this);
     }
     else
     {

--- a/src/core/io/BranchLengthDistributionReader.cpp
+++ b/src/core/io/BranchLengthDistributionReader.cpp
@@ -7,10 +7,8 @@
 using namespace RevBayesCore;
 
 
-BranchLengthDistributionReader::BranchLengthDistributionReader(const std::string &fn, char d, size_t numSkipped) : DelimitedDataReader(fn, d, numSkipped)
+BranchLengthDistributionReader::BranchLengthDistributionReader(const std::string &fn, std::string d, size_t numSkipped) : DelimitedDataReader(fn, d, numSkipped)
 {
-	
-	filename = fn;
 	
 	for (size_t i = 0; i < chars.size(); ++i)
 	{

--- a/src/core/io/BranchLengthDistributionReader.h
+++ b/src/core/io/BranchLengthDistributionReader.h
@@ -29,7 +29,7 @@ namespace RevBayesCore {
 		
 		public:
 		
-		BranchLengthDistributionReader(const std::string &fn, char d='\t', size_t ns=0);
+		BranchLengthDistributionReader(const std::string &fn, std::string d="", size_t ns=0);
 		
 		const std::vector< std::pair<std::string, std::string > >&     		 getTipPairs(void);
 		const std::map < std::string, std::vector< double > >&   getBranchLengths(std::pair<std::string, std::string >& tipPair );
@@ -38,10 +38,10 @@ namespace RevBayesCore {
 		
 		protected:
 		
-		std::vector< std::pair < std::string, std::string > >             				 TipPairs;
+		std::vector< std::pair < std::string, std::string > >            TipPairs;
 		std::vector < std::map < std::string, std::vector< double > > >  matrix;
 		std::vector< std::string >                 		 				 geneFamilies;
-		std::map< std::pair<std::string, std::string >, size_t >  					 pairToIndex;
+		std::map< std::pair<std::string, std::string >, size_t >  		 pairToIndex;
 		
 	};
 	

--- a/src/core/io/DelimitedCharacterDataReader.cpp
+++ b/src/core/io/DelimitedCharacterDataReader.cpp
@@ -5,11 +5,9 @@
 using namespace RevBayesCore;
 
 
-DelimitedCharacterDataReader::DelimitedCharacterDataReader(const std::string &fn, char d, size_t num_skipped) : DelimitedDataReader(fn, d, num_skipped)
+DelimitedCharacterDataReader::DelimitedCharacterDataReader(const std::string &fn, std::string d, size_t num_skipped) : DelimitedDataReader(fn, d, num_skipped)
 {
     
-    filename = fn;
-
     data = std::vector<std::vector<std::string> >( chars.size(), std::vector<std::string>() );
     for (size_t i = 0; i < chars.size(); ++i)
     {

--- a/src/core/io/DelimitedCharacterDataReader.h
+++ b/src/core/io/DelimitedCharacterDataReader.h
@@ -26,7 +26,7 @@ namespace RevBayesCore {
         
     public:
         
-        DelimitedCharacterDataReader(const std::string &fn, char d='\t', size_t ns=0);
+        DelimitedCharacterDataReader(const std::string &fn, std::string d="", size_t ns=0);
         
         const std::vector<std::string>&                 getNames(void);
         const std::vector<std::vector<std::string> >&   getData(void);

--- a/src/core/io/DelimitedCharacterDataWriter.cpp
+++ b/src/core/io/DelimitedCharacterDataWriter.cpp
@@ -30,7 +30,7 @@ DelimitedCharacterDataWriter::DelimitedCharacterDataWriter( void )
  * \param[in]   data        The character data object which is written out.
  * \param[in]   del         The text character to delimit columns.
  */
-void DelimitedCharacterDataWriter::writeData(std::string const &fileName, const HomologousCharacterData &data, char del)
+void DelimitedCharacterDataWriter::writeData(std::string const &fileName, const HomologousCharacterData &data, std::string del)
 {
     
     // the filestream object

--- a/src/core/io/DelimitedCharacterDataWriter.h
+++ b/src/core/io/DelimitedCharacterDataWriter.h
@@ -25,7 +25,7 @@ namespace RevBayesCore {
     public:
         DelimitedCharacterDataWriter();
         
-        void                    writeData(const std::string& fn, const HomologousCharacterData &d, char del='\t');
+        void                    writeData(const std::string& fn, const HomologousCharacterData &d, std::string del="\t");
 //        void                    writeData(const std::string& fn, const Abstr &d, char del='\t');
 
         

--- a/src/core/io/DelimitedDataReader.cpp
+++ b/src/core/io/DelimitedDataReader.cpp
@@ -7,10 +7,11 @@
 
 #include "RbFileManager.h"
 #include "RbException.h"
+#include "StringUtilities.h"
 
 using namespace RevBayesCore;
 
-DelimitedDataReader::DelimitedDataReader(const std::string &fn, char d, size_t lines_skipped) :
+DelimitedDataReader::DelimitedDataReader(const std::string &fn, std::string d, size_t lines_skipped) :
     filename(fn), 
     delimiter(d),
     chars()
@@ -54,17 +55,8 @@ void DelimitedDataReader::readData( size_t lines_to_skip )
             continue;
         }
 
-        std::string field = "";
-        std::stringstream ss(read_line);
+        StringUtilities::stringSplit(read_line, delimiter, tmpChars, true);
 
-        int pos = 0;
-        while ( std::getline(ss,field,delimiter) )
-        {
-            field.erase(std::find_if (field.rbegin(), field.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), field.end());
-            field.erase(field.begin(), std::find_if (field.begin(), field.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
-            tmpChars.push_back(field);
-            pos++;
-        };
         chars.push_back(tmpChars);
         tmpChars.clear();
     };

--- a/src/core/io/DelimitedDataReader.h
+++ b/src/core/io/DelimitedDataReader.h
@@ -26,7 +26,7 @@ namespace RevBayesCore {
     class DelimitedDataReader {
         
     public:
-        DelimitedDataReader(const std::string &fn, char d='\t', size_t ns=0);
+        DelimitedDataReader(const std::string &fn, std::string d="", size_t ns=0);
         
         void                                                readData( size_t ls);
         const std::vector<std::vector<std::string> >&       getChars(void);
@@ -37,7 +37,7 @@ namespace RevBayesCore {
         
         // protected member only accessible for derived classes
         std::string                                         filename;
-        char                                                delimiter;
+        std::string                                         delimiter;
         std::vector<std::vector<std::string> >              chars;
         
     };

--- a/src/core/io/DistanceMatrixReader.cpp
+++ b/src/core/io/DistanceMatrixReader.cpp
@@ -10,10 +10,8 @@
 using namespace RevBayesCore;
 
 
-DistanceMatrixReader::DistanceMatrixReader(const std::string &fn, char d, size_t numSkipped) : DelimitedDataReader(fn, d, numSkipped)
+DistanceMatrixReader::DistanceMatrixReader(const std::string &fn, std::string d, size_t numSkipped) : DelimitedDataReader(fn, d, numSkipped)
 {
-	
-	filename = fn;
 	
 	//First, get the size of the matrix
 	int siz = int(chars.size()) -1;//atoi( chars[0][0].c_str() );

--- a/src/core/io/DistanceMatrixReader.h
+++ b/src/core/io/DistanceMatrixReader.h
@@ -28,7 +28,7 @@ namespace RevBayesCore {
 		
 	public:
 		
-		DistanceMatrixReader(const std::string &fn, char d='\t', size_t ns=0);
+		DistanceMatrixReader(const std::string &fn, std::string d="", size_t ns=0);
 		
 		const std::vector<Taxon>&                       getTaxa(void);
 		const MatrixReal&   							getMatrix(void);

--- a/src/core/io/MatrixReader.cpp
+++ b/src/core/io/MatrixReader.cpp
@@ -16,109 +16,27 @@
 using namespace RevBayesCore;
 
 
-MatrixReader::MatrixReader(const std::string &fn, char d, size_t lines_skipped) :
-    filename(fn),
-    delimiter(d)
+MatrixReader::MatrixReader(const std::string &fn, std::string d, size_t lines_skipped) : DelimitedDataReader(fn, d, lines_skipped)
 {
     
-    readData( lines_skipped );
-    
-}
+    //First, get the size of the matrix
+    int siz = int(chars.size()) -1;//atoi( chars[0][0].c_str() );
+    matrix = MatrixReal( siz );
 
-const std::string& MatrixReader::getFilename(void)
-{
-    return filename;
+    for (size_t i = 1; i < chars.size(); ++i)
+    {
+        std::string name = chars[i][0];
+
+        for (size_t j = 1; j < chars[i].size(); ++j)
+        {
+            matrix[i-1][j-1] = atof( chars[i][j].c_str() );
+        }
+
+    }
+    
 }
 
 const MatrixReal& MatrixReader::getMatrix(void)
 {
 	return matrix;
-}
-
-void MatrixReader::readData( size_t lines_to_skip )
-{
-    
-    
-    // make a growable container
-    std::vector<std::string> tmpChars;
-    std::vector<std::vector<double> > tmpMatrix;
-    
-    // open file
-    std::ifstream readStream;
-    RbFileManager f = RbFileManager(filename);
-    if ( f.openFile(readStream) == false )
-    {
-        throw RbException( "Could not open file " + filename );
-    }
-    
-    // read file
-    // bool firstLine = true;
-    std::string read_line = "";
-    size_t lines_skipped = 0;
-    while (f.safeGetline(readStream,read_line))
-    {
-        ++lines_skipped;
-        if ( lines_skipped <= lines_to_skip)
-        {
-            continue;
-        }
-        
-        // skip blank lines
-        std::string::iterator first_nonspace = std::find_if (read_line.begin(), read_line.end(), std::not1(std::ptr_fun<int,int>(isspace)));
-        if (first_nonspace == read_line.end())
-        {
-            continue;
-        }
-        
-        std::string field = "";
-        std::stringstream ss(read_line);
-        
-        int pos = 0;
-        while ( std::getline(ss,field,delimiter) )
-        {
-            field.erase(std::find_if (field.rbegin(), field.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), field.end());
-            field.erase(field.begin(), std::find_if (field.begin(), field.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
-            tmpChars.push_back(field);
-            pos++;
-        }
-        
-        double nchar = tmpChars.size();
-        std::vector<double> tmpValues(nchar);
-        for (size_t i = 0; i < nchar; ++i) {
-            tmpValues[i] = atof( tmpChars[i].c_str() );
-        }
-        tmpMatrix.push_back(tmpValues);
-        
-        tmpChars.clear();
- 
-    }
-
-
-    // make sure that all the rows are of the same size
-    size_t nrow = tmpMatrix.size();
-    size_t ncol = tmpMatrix[0].size();
-    for (size_t i = 1; i < nrow; ++i)
-    {
-        if ( tmpMatrix[i].size() != ncol )
-        {
-            RbException("Error reading matrix file: not all rows contain the same number of columns.");
-        }
-    }
-    
-    
-    
-    // make the matrix
-    matrix = MatrixReal(nrow, ncol);
-    for (size_t i = 0; i < nrow; ++i)
-    {
-        for (size_t j = 0; j < ncol; ++j)
-        {
-            matrix[i][j] = tmpMatrix[i][j];
-        }
-    }
-    
-
-    // close the input file connection
-    f.closeFile( readStream );
-    
 }

--- a/src/core/io/MatrixReader.h
+++ b/src/core/io/MatrixReader.h
@@ -1,9 +1,7 @@
 #ifndef MatrixReader_H
 #define MatrixReader_H
 
-#include <stddef.h>
-#include <iosfwd>
-
+#include "DelimitedDataReader.h"
 #include "MatrixReal.h"
 
 namespace RevBayesCore {
@@ -21,13 +19,11 @@ namespace RevBayesCore {
 	 * @since 2015-03-03, version 1.0
 	 *
 	 */
-	class MatrixReader {
+	class MatrixReader : public DelimitedDataReader {
 		
     public:
-        MatrixReader(const std::string &fn, char d='\t', size_t ls=0);
+        MatrixReader(const std::string &fn, std::string d="", size_t ls=0);
         
-        void                                                readData( size_t ls);
-        const std::string&                                  getFilename(void);
         const MatrixReal&   							    getMatrix(void);
 
         
@@ -35,9 +31,7 @@ namespace RevBayesCore {
     protected:
         
         // protected member only accessible for derived classes
-        std::string                                         filename;
-        char                                                delimiter;
-		MatrixReal                                          matrix;
+        MatrixReal                                          matrix;
 		
 	};
 	

--- a/src/core/io/PoMoCountFileReader.cpp
+++ b/src/core/io/PoMoCountFileReader.cpp
@@ -21,9 +21,8 @@
 using namespace RevBayesCore;
 
 
-PoMoCountFileReader::PoMoCountFileReader(const std::string &fn, const size_t virtualPopulationSize, char d, size_t ns) : DelimitedDataReader(fn, d, ns), virtualPopulationSize_ ( virtualPopulationSize )
+PoMoCountFileReader::PoMoCountFileReader(const std::string &fn, const size_t virtualPopulationSize, std::string d, size_t ns) : DelimitedDataReader(fn, d, ns), virtualPopulationSize_ ( virtualPopulationSize )
 {
-	filename = fn;
 	matrix_ = new HomologousDiscreteCharacterData<PoMoState> ();
 
 	// chars is a matrix containing all the lines of the file fn.

--- a/src/core/io/PoMoCountFileReader.h
+++ b/src/core/io/PoMoCountFileReader.h
@@ -31,7 +31,7 @@ namespace RevBayesCore {
 
 	public:
 
-		PoMoCountFileReader(const std::string &fn, const size_t virtualPopulationSize = 9, char d=' ', size_t ns=0);
+		PoMoCountFileReader(const std::string &fn, const size_t virtualPopulationSize = 9, std::string d="", size_t ns=0);
 
 		const size_t 																getNumberOfPopulations( void );
 		const size_t 																getNumberOfSites( void );

--- a/src/core/io/RelativeNodeAgeConstraintsReader.cpp
+++ b/src/core/io/RelativeNodeAgeConstraintsReader.cpp
@@ -6,10 +6,8 @@
 using namespace RevBayesCore;
 
 
-RelativeNodeAgeConstraintsReader::RelativeNodeAgeConstraintsReader(const std::string &fn, char d, size_t ns) : DelimitedDataReader(fn, d, ns)
+RelativeNodeAgeConstraintsReader::RelativeNodeAgeConstraintsReader(const std::string &fn, std::string d, size_t ns) : DelimitedDataReader(fn, d, ns)
 {
-    
-    filename = fn;
     
     for (size_t i = 0; i < chars.size(); ++i)
     {

--- a/src/core/io/RelativeNodeAgeConstraintsReader.h
+++ b/src/core/io/RelativeNodeAgeConstraintsReader.h
@@ -26,7 +26,7 @@ namespace RevBayesCore {
         
     public:
         
-        RelativeNodeAgeConstraintsReader(const std::string &fn, char d='\t', size_t ns=0);
+        RelativeNodeAgeConstraintsReader(const std::string &fn, std::string d="", size_t ns=0);
         
         const std::vector< std::pair < std::pair<std::string, std::string >, std::pair<std::string, std::string > > >& getConstraints(void);
         const size_t                                                                                     getNumberOfConstraints(void);

--- a/src/core/io/RelativeNodeAgeWeightedConstraintsReader.cpp
+++ b/src/core/io/RelativeNodeAgeWeightedConstraintsReader.cpp
@@ -9,10 +9,9 @@
 using namespace RevBayesCore;
 
 
-RelativeNodeAgeWeightedConstraintsReader::RelativeNodeAgeWeightedConstraintsReader(const std::string &fn, char d, size_t ns, double thresh) : DelimitedDataReader(fn, d, ns)
+RelativeNodeAgeWeightedConstraintsReader::RelativeNodeAgeWeightedConstraintsReader(const std::string &fn, std::string d, size_t ns, double thresh) : DelimitedDataReader(fn, d, ns)
 {
     
-    filename = fn;
     for (size_t i = 0; i < chars.size(); ++i)
     {
         

--- a/src/core/io/RelativeNodeAgeWeightedConstraintsReader.h
+++ b/src/core/io/RelativeNodeAgeWeightedConstraintsReader.h
@@ -26,7 +26,7 @@ namespace RevBayesCore {
         
     public:
         
-        RelativeNodeAgeWeightedConstraintsReader(const std::string &fn, char d='\t', size_t ns=0, double thresh=9.9e90);
+        RelativeNodeAgeWeightedConstraintsReader(const std::string &fn, std::string d="", size_t ns=0, double thresh=9.9e90);
         
         const std::vector< std::pair < std::pair < std::pair<std::string, std::string >, std::pair<std::string, std::string > >, double > >& getConstraints(void);
         const size_t                                                                                     getNumberOfConstraints(void);

--- a/src/core/io/TaxonReader.cpp
+++ b/src/core/io/TaxonReader.cpp
@@ -23,7 +23,7 @@ using namespace RevBayesCore;
  * \param[in]     fn       The name of the file where the data is stored.
  * \param[in]     delim    The delimiter between the columns.
  */
-TaxonReader::TaxonReader(const std::string &fn, char delim) : DelimitedDataReader( fn, delim )
+TaxonReader::TaxonReader(const std::string &fn, std::string delim) : DelimitedDataReader( fn, delim )
 {
     
     //Reading the header

--- a/src/core/io/TaxonReader.h
+++ b/src/core/io/TaxonReader.h
@@ -24,7 +24,7 @@ namespace RevBayesCore {
         
     public:
         
-        TaxonReader(const std::string &fn, char d='\t');                        //!< Constructor
+        TaxonReader(const std::string &fn, std::string d="");                        //!< Constructor
         
         const std::vector<Taxon>&   getTaxa(void) const;                        //!< Get the taxa.
 

--- a/src/core/io/TimeAtlasDataReader.cpp
+++ b/src/core/io/TimeAtlasDataReader.cpp
@@ -26,9 +26,8 @@
 
 using namespace RevBayesCore;
 
-TimeAtlasDataReader::TimeAtlasDataReader(std::string fn, char d) : DelimitedDataReader(fn, d)
+TimeAtlasDataReader::TimeAtlasDataReader(std::string fn, std::string d) : DelimitedDataReader(fn, d)
 {
-    filename = fn;
     readJson();
 }
 
@@ -37,14 +36,11 @@ TimeAtlasDataReader::TimeAtlasDataReader(const TimeAtlasDataReader& tadr) : Deli
     
     areas = tadr.areas;
     epochs = tadr.epochs;
-    filename = tadr.filename;
     
 }
 
 void TimeAtlasDataReader::readJson(void)
 {
-    
-    RBOUT( "Attempting to read the of file \"" + this->filename + "\"");
     
     std::ifstream readStream;
     RbFileManager* f = new RbFileManager(this->filename);
@@ -143,9 +139,6 @@ void TimeAtlasDataReader::readJson(void)
         
         
         sortEpochs();
-
-        RBOUT( "Successfully read file" );
-        //fillData(pt);
     }
     catch (std::exception const& e)
     {
@@ -192,9 +185,4 @@ std::vector<double> TimeAtlasDataReader::getEpochs(void)
 std::vector<std::vector<GeographicArea*> > TimeAtlasDataReader::getAreas(void)
 {
     return areas;
-}
-
-std::string TimeAtlasDataReader::getFilename(void)
-{
-    return filename;
 }

--- a/src/core/io/TimeAtlasDataReader.h
+++ b/src/core/io/TimeAtlasDataReader.h
@@ -23,12 +23,11 @@ class GeographicArea;
     {
     public:
         
-        TimeAtlasDataReader(std::string fn, char d='\t');
+        TimeAtlasDataReader(std::string fn, std::string d="");
         TimeAtlasDataReader(const TimeAtlasDataReader& tadr);
         
         std::vector<double> getEpochs(void);
         std::vector<std::vector<GeographicArea*> > getAreas(void);
-        std::string getFilename(void);
         void readJson(void);
         void printJson(boost::property_tree::ptree const& pt);
         void fillData(boost::property_tree::ptree const& pt);
@@ -57,9 +56,6 @@ class GeographicArea;
                 return first.age > second.age;
             }
         };
-    
-    private:
-        std::string filename;
         
     };
 }

--- a/src/core/io/TraceContinuousReader.cpp
+++ b/src/core/io/TraceContinuousReader.cpp
@@ -19,7 +19,7 @@ using namespace RevBayesCore;
  * \param[in]     fn       The name of the file where the data is stored.
  * \param[in]     delim    The delimiter between the columns.
  */
-TraceContinuousReader::TraceContinuousReader(const std::string &fn, char delim) : DelimitedDataReader( fn, delim )
+TraceContinuousReader::TraceContinuousReader(const std::string &fn, std::string delim) : DelimitedDataReader( fn, delim )
 {
     
     const std::vector<std::string>& headers = chars[0];

--- a/src/core/io/TraceContinuousReader.h
+++ b/src/core/io/TraceContinuousReader.h
@@ -24,7 +24,7 @@ namespace RevBayesCore {
         
     public:
         
-        TraceContinuousReader(const std::string &fn, char d='\t');              //!< Constructor
+        TraceContinuousReader(const std::string &fn, std::string d="");              //!< Constructor
         
         std::vector<TraceNumeric>&          getTraces(void);                            //!< Get the data.
         const std::vector<TraceNumeric>&    getTraces(void) const;                      //!< Get the data.

--- a/src/core/utils/StringUtilities.cpp
+++ b/src/core/utils/StringUtilities.cpp
@@ -19,6 +19,8 @@
 
 #include <stdio.h>
 #include <iomanip>
+
+#include <algorithm>
 #include <string>
 #include <cstdlib>
 
@@ -563,32 +565,64 @@ void StringUtilities::replaceAllOccurrences(std::string& str, char old_ch, char 
 }
 
 
-/** Utility function for dividing string into pieces */
-void StringUtilities::stringSplit(const std::string &s, const std::string &delim, std::vector<std::string>& results)
+/**
+ * Utility function for dividing string into pieces
+ * If no delimiter is specified, then the string is split on whitespace.
+ */
+void StringUtilities::stringSplit(std::string str, std::string delim, std::vector<std::string>& results, bool trim)
 {
-    
-    // create our own copy of the string
-    std::string str = s;
 
-    size_t cutAt;
-    while ( (cutAt = StringUtilities::findFirstOf(str, delim)) != str.npos )
+    std::string::iterator cut;
+
+    // if we are delimiting on whitespace*,
+    // then assume the first and last fields are non-empty
+    // i.e. remove leading and trailing whitespace
+    if ( delim.empty() )
     {
-        if (cutAt > 0)
+        // erase trailing whitespace
+        str.erase(std::find_if (str.rbegin(), str.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), str.end());
+        // erase leading whitespace
+        str.erase(str.begin(), std::find_if (str.begin(), str.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+    }
+
+    while ( true )
+    {
+        if ( delim.empty() )
         {
-            results.push_back(str.substr(0, cutAt));
+            // find first whitespace character
+            cut = std::find_if(str.begin(), str.end(), ::isspace);
         }
         else
         {
-            results.push_back( "" );
+            // find the first occurrence of the full delimiter string
+            cut = std::search(str.begin(), str.end(), delim.begin(), delim.end());
         }
-        str = str.substr(cutAt+delim.size());
+
+        std::string substr(str.begin(), cut);
+
+        if ( trim )
+        {
+            // erase trailing whitespace
+            substr.erase(std::find_if (substr.rbegin(), substr.rend(), std::not1(std::ptr_fun<int, int>(std::isspace))).base(), substr.end());
+            // erase leading whitespace
+            substr.erase(substr.begin(), std::find_if (substr.begin(), substr.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+        }
+
+        results.push_back(substr);
+
+        if ( cut == str.end() )
+        {
+            break;
+        }
+
+        str = std::string(cut + delim.size(), str.end());
+
+        if ( delim.empty() )
+        {
+            // erase leading whitespace in remaining string
+            str.erase(str.begin(), std::find_if (str.begin(), str.end(), std::not1(std::ptr_fun<int, int>(std::isspace))));
+        }
     }
-    
-    if (str.length() > 0)
-    {
-        results.push_back(str);
-    }
-    
 }
 
 

--- a/src/core/utils/StringUtilities.h
+++ b/src/core/utils/StringUtilities.h
@@ -42,9 +42,9 @@ namespace StringUtilities {
     std::string                 oneLiner(const std::string& input, size_t maxLen);                                  //!< Get a one-liner of specified length
     void                        replaceSubstring(std::string& str, const std::string& oldStr, const std::string& newStr);
     void                        replaceAllOccurrences(std::string& str, char old_ch, char new_ch);
-    void                        stringSplit(const std::string &str, const std::string &delim, std::vector<std::string>& results); //!< Split a string into pieces
+    void                        stringSplit(std::string str, std::string delim, std::vector<std::string>& results, bool trim = false); //!< Split a string into pieces
     void                        toLower(std::string& str);                                                          //!< Convert string's characters to lower case
-    std::string                 toString(double x, int digits=6);                                                          //!< Convert string's characters to lower case
+    std::string                 toString(double x, int digits=6);                                                   //!< Convert string's characters to lower case
     
     /**
      * Generic to_string function

--- a/src/revlanguage/analysis/mcmc/RlPathSampler.cpp
+++ b/src/revlanguage/analysis/mcmc/RlPathSampler.cpp
@@ -52,7 +52,7 @@ void PathSampler::constructInternalObject( void )
     const std::string&   fn      = static_cast<const RlString &>( filename->getRevObject() ).getValue();
     const std::string&   pn      = static_cast<const RlString &>( powerColumnName->getRevObject() ).getValue();
     const std::string&   ln      = static_cast<const RlString &>( likelihoodColumnName->getRevObject() ).getValue();
-    const std::string&   del     = static_cast<const RlString &>( delimmiter->getRevObject() ).getValue();
+    const std::string&   del     = static_cast<const RlString &>( delimiter->getRevObject() ).getValue();
     
     value = new RevBayesCore::PathSampler(fn, pn, ln, del);
     
@@ -122,7 +122,8 @@ const MemberRules& PathSampler::getParameterRules(void) const
         samplerMemberRules.push_back( new ArgumentRule("filename"            , RlString::getClassTypeSpec(), "The filename where the likelihood samples are stored in.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
         samplerMemberRules.push_back( new ArgumentRule("powerColumnName"     , RlString::getClassTypeSpec(), "The name of the column that holds the values of the powers.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
         samplerMemberRules.push_back( new ArgumentRule("likelihoodColumnName", RlString::getClassTypeSpec(), "The name of the column that holds the likelihood values.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
-        samplerMemberRules.push_back( new ArgumentRule("delimiter"           , RlString::getClassTypeSpec(), "The delimiter between columns.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString( "\t" ) ) );
+        std::vector<std::string> sep = {"separator","delimiter"};
+        samplerMemberRules.push_back( new ArgumentRule(sep                   , RlString::getClassTypeSpec(), "The separator/delimiter between columns.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString( "\t" ) ) );
         
         rules_set = true;
     }
@@ -162,9 +163,9 @@ void PathSampler::setConstParameter(const std::string& name, const RevPtr<const 
     {
         filename = var;
     }
-    else if ( name == "delimiter")
+    else if ( name == "delimiter" || name == "separator" || name == "separator/delimiter")
     {
-        delimmiter = var;
+        delimiter = var;
     }
     else
     {

--- a/src/revlanguage/analysis/mcmc/RlPathSampler.h
+++ b/src/revlanguage/analysis/mcmc/RlPathSampler.h
@@ -48,7 +48,7 @@ namespace RevLanguage {
         
         RevPtr<const RevVariable>                   likelihoodColumnName;
         RevPtr<const RevVariable>                   powerColumnName;
-        RevPtr<const RevVariable>                   delimmiter;
+        RevPtr<const RevVariable>                   delimiter;
         RevPtr<const RevVariable>                   filename;
         
     };

--- a/src/revlanguage/analysis/mcmc/RlSteppingStoneSampler.cpp
+++ b/src/revlanguage/analysis/mcmc/RlSteppingStoneSampler.cpp
@@ -52,7 +52,7 @@ void SteppingStoneSampler::constructInternalObject( void )
     const std::string&   fn      = static_cast<const RlString &>( filename->getRevObject() ).getValue();
     const std::string&   pn      = static_cast<const RlString &>( powerColumnName->getRevObject() ).getValue();
     const std::string&   ln      = static_cast<const RlString &>( likelihoodColumnName->getRevObject() ).getValue();
-    const std::string&   del     = static_cast<const RlString &>( delimmiter->getRevObject() ).getValue();
+    const std::string&   del     = static_cast<const RlString &>( delimiter->getRevObject() ).getValue();
     
     value = new RevBayesCore::SteppingStoneSampler(fn, pn, ln, del);
     
@@ -121,8 +121,9 @@ const MemberRules& SteppingStoneSampler::getParameterRules(void) const
         samplerMemberRules.push_back( new ArgumentRule("filename"            , RlString::getClassTypeSpec(), "The name of the file where the likelhood samples are stored.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
         samplerMemberRules.push_back( new ArgumentRule("powerColumnName"     , RlString::getClassTypeSpec(), "The name of the column of the powers.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
         samplerMemberRules.push_back( new ArgumentRule("likelihoodColumnName", RlString::getClassTypeSpec(), "The name of the column of the likelihood samples.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
-        samplerMemberRules.push_back( new ArgumentRule("delimiter"           , RlString::getClassTypeSpec(), "The column delimiter.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString( "\t" ) ) );
-        
+        std::vector<std::string> sep = {"separator","delimiter"};
+        samplerMemberRules.push_back( new ArgumentRule(sep                   , RlString::getClassTypeSpec(), "The separator/delimiter between columns.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString( "\t" ) ) );
+
         rules_set = true;
     }
     
@@ -163,9 +164,9 @@ void SteppingStoneSampler::setConstParameter(const std::string& name, const RevP
     {
         filename = var;
     }
-    else if ( name == "delimiter")
+    else if ( name == "delimiter" || name == "separator" || name == "separator/delimiter")
     {
-        delimmiter = var;
+        delimiter = var;
     }
     else
     {

--- a/src/revlanguage/analysis/mcmc/RlSteppingStoneSampler.h
+++ b/src/revlanguage/analysis/mcmc/RlSteppingStoneSampler.h
@@ -48,7 +48,7 @@ namespace RevLanguage {
         
         RevPtr<const RevVariable>                   likelihoodColumnName;
         RevPtr<const RevVariable>                   powerColumnName;
-        RevPtr<const RevVariable>                   delimmiter;
+        RevPtr<const RevVariable>                   delimiter;
         RevPtr<const RevVariable>                   filename;
         
     };

--- a/src/revlanguage/analysis/mcmc/output/RlBurninEstimationConvergenceAssessment.cpp
+++ b/src/revlanguage/analysis/mcmc/output/RlBurninEstimationConvergenceAssessment.cpp
@@ -399,7 +399,8 @@ const MemberRules& BurninEstimationConvergenceAssessment::getParameterRules(void
         filenameTypes.push_back( RlString::getClassTypeSpec() );
         filenameTypes.push_back( ModelVector<RlString>::getClassTypeSpec() );
         memberRules.push_back( new ArgumentRule("filename", filenameTypes, "The name of the file with the parameter samples.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
-        memberRules.push_back( new ArgumentRule("delimiter", RlString::getClassTypeSpec(), "The delimiter/separator between values.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("\t") ) );
+        std::vector<std::string> sep = {"separator","delimiter"};
+        memberRules.push_back( new ArgumentRule(sep, RlString::getClassTypeSpec(), "The separator/delimiter between values.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("") ) );
         
         rules_set = true;
     }
@@ -532,7 +533,7 @@ void BurninEstimationConvergenceAssessment::setConstParameter(const std::string&
         }
         
     }
-    else if ( name == "delimiter")
+    else if ( name == "delimiter" || name == "separator" || name == "separator/delimiter")
     {
         delimiter = static_cast<const RlString&>( var->getRevObject() ).getValue();
     }

--- a/src/revlanguage/functions/io/Func_TaxonReader.cpp
+++ b/src/revlanguage/functions/io/Func_TaxonReader.cpp
@@ -50,7 +50,7 @@ RevPtr<RevVariable> Func_TaxonReader::execute( void )
     
     // get the information from the arguments for reading the file
     const RlString& fn = static_cast<const RlString&>( args[0].getVariable()->getRevObject() );
-    char del = static_cast<const RlString&>( args[1].getVariable()->getRevObject() ).getValue()[0];
+    std::string del = static_cast<const RlString&>( args[1].getVariable()->getRevObject() ).getValue();
     
     RevBayesCore::TaxonReader tr = RevBayesCore::TaxonReader(fn.getValue(), del);
     const std::vector<RevBayesCore::Taxon>& taxa = tr.getTaxa();
@@ -69,7 +69,8 @@ const ArgumentRules& Func_TaxonReader::getArgumentRules( void ) const
     if (!rules_set)
     {
         argumentRules.push_back( new ArgumentRule( "filename", RlString::getClassTypeSpec(), "Relative or absolute file name.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
-        argumentRules.push_back( new ArgumentRule( "delimiter", RlString::getClassTypeSpec(), "Delimiter between columns.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("\t") ) );
+        std::vector<std::string> sep = {"separator","delimiter"};
+        argumentRules.push_back( new ArgumentRule( sep, RlString::getClassTypeSpec(), "The separator/delimiter between columns.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("") ) );
         rules_set = true;
     }
     

--- a/src/revlanguage/functions/io/Func_readAncestralStateTrace.cpp
+++ b/src/revlanguage/functions/io/Func_readAncestralStateTrace.cpp
@@ -104,7 +104,8 @@ const ArgumentRules& Func_readAncestralStateTrace::getArgumentRules( void ) cons
     {
 		
         argumentRules.push_back( new ArgumentRule( "file"     , RlString::getClassTypeSpec(), "The name of the file which holds the ancestral state trace.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
-        argumentRules.push_back( new ArgumentRule( "separator", RlString::getClassTypeSpec(), "The separater between sampled values.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("\t") ) );
+        std::vector<std::string> sep = {"separator","delimiter"};
+        argumentRules.push_back( new ArgumentRule( sep, RlString::getClassTypeSpec(), "The separater/delimiter between columns.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("") ) );
         rules_set = true;
     }
     
@@ -163,7 +164,7 @@ const TypeSpec& Func_readAncestralStateTrace::getReturnType( void ) const
 }
 
 
-std::vector<RevBayesCore::AncestralStateTrace> Func_readAncestralStateTrace::readAncestralStates(const std::string &fileName, const std::string &delimitter)
+std::vector<RevBayesCore::AncestralStateTrace> Func_readAncestralStateTrace::readAncestralStates(const std::string &fileName, const std::string &delimiter)
 {
     
     RevBayesCore::RbFileManager fm = RevBayesCore::RbFileManager(fileName);
@@ -206,7 +207,7 @@ std::vector<RevBayesCore::AncestralStateTrace> Func_readAncestralStateTrace::rea
 		
         // split every line into its columns
 		std::vector<std::string> columns;
-		StringUtilities::stringSplit(line, delimitter, columns);
+		StringUtilities::stringSplit(line, delimiter, columns);
 	
 		// we assume a header at the first line of the file
 		if (has_header_been_read == false) 

--- a/src/revlanguage/functions/io/Func_readAncestralStateTreeTrace.cpp
+++ b/src/revlanguage/functions/io/Func_readAncestralStateTreeTrace.cpp
@@ -123,7 +123,8 @@ const ArgumentRules& Func_readAncestralStateTreeTrace::getArgumentRules( void ) 
         options.push_back( "clock" );
         options.push_back( "non-clock" );
         argumentRules.push_back( new OptionRule( "treetype", new RlString("clock"), options, "The type of tree." ) );
-        argumentRules.push_back( new ArgumentRule( "separator", RlString::getClassTypeSpec(), "The separater/delimiter between values.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("\t") ) );
+        std::vector<std::string> sep = {"separator","delimiter"};
+        argumentRules.push_back( new ArgumentRule( sep, RlString::getClassTypeSpec(), "The separator/delimiter between columns.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("") ) );
 
         std::vector<TypeSpec> burninTypes;
         burninTypes.push_back( Probability::getClassTypeSpec() );
@@ -189,7 +190,7 @@ const TypeSpec& Func_readAncestralStateTreeTrace::getReturnType( void ) const
 }
 
 
-TraceTree* Func_readAncestralStateTreeTrace::readBranchLengthTrees(const std::vector<std::string> &vectorOfFileNames, const std::string &delimitter)
+TraceTree* Func_readAncestralStateTreeTrace::readBranchLengthTrees(const std::vector<std::string> &vectorOfFileNames, const std::string &delimiter)
 {
     
     
@@ -248,7 +249,7 @@ TraceTree* Func_readAncestralStateTreeTrace::readBranchLengthTrees(const std::ve
             std::vector<std::string> columns;
             
             // we should provide other delimiters too
-            StringUtilities::stringSplit(line, delimitter, columns);
+            StringUtilities::stringSplit(line, delimiter, columns);
             
             // we assume a header at the first line of the file
             if (!hasHeaderBeenRead) {
@@ -287,7 +288,7 @@ TraceTree* Func_readAncestralStateTreeTrace::readBranchLengthTrees(const std::ve
 }
 
 
-TraceTree* Func_readAncestralStateTreeTrace::readTimeTrees(const std::vector<std::string> &vectorOfFileNames, const std::string &delimitter) {
+TraceTree* Func_readAncestralStateTreeTrace::readTimeTrees(const std::vector<std::string> &vectorOfFileNames, const std::string &delimiter) {
     
     
     std::vector<RevBayesCore::TraceTree> data;
@@ -343,7 +344,7 @@ TraceTree* Func_readAncestralStateTreeTrace::readTimeTrees(const std::vector<std
             std::vector<std::string> columns;
             
             // we should provide other delimiters too
-            StringUtilities::stringSplit(line, delimitter, columns);
+            StringUtilities::stringSplit(line, delimiter, columns);
             
             // we assume a header at the first line of the file
             if ( hasHeaderBeenRead == false )

--- a/src/revlanguage/functions/io/Func_readCharacterData.cpp
+++ b/src/revlanguage/functions/io/Func_readCharacterData.cpp
@@ -7,7 +7,7 @@
 #include "ArgumentRule.h"
 #include "ConstantNode.h"
 #include "HomologousDiscreteCharacterData.h"
-#include "Func_readCharacterDataUniversal.h"
+#include "Func_readCharacterData.h"
 #include "ModelVector.h"
 #include "NclReader.h"
 #include "NonHomologousDiscreteCharacterData.h"
@@ -62,14 +62,14 @@ using namespace RevLanguage;
  *
  * \return A new copy of the process.
  */
-Func_readCharacterDataUniversal* Func_readCharacterDataUniversal::clone( void ) const {
+Func_readCharacterData* Func_readCharacterData::clone( void ) const {
     
-    return new Func_readCharacterDataUniversal( *this );
+    return new Func_readCharacterData( *this );
 }
 
 
 /** Execute function */
-RevPtr<RevVariable> Func_readCharacterDataUniversal::execute( void ) {
+RevPtr<RevVariable> Func_readCharacterData::execute( void ) {
         
     // get the information from the arguments for reading the file
     const std::string& fn = static_cast<const RlString&>( args[0].getVariable()->getRevObject() ).getValue();
@@ -346,7 +346,7 @@ RevPtr<RevVariable> Func_readCharacterDataUniversal::execute( void ) {
 
 
 /** Get argument rules */
-const ArgumentRules& Func_readCharacterDataUniversal::getArgumentRules( void ) const {
+const ArgumentRules& Func_readCharacterData::getArgumentRules( void ) const {
     
     static ArgumentRules argumentRules = ArgumentRules();
     static bool rules_set = false;
@@ -361,15 +361,15 @@ const ArgumentRules& Func_readCharacterDataUniversal::getArgumentRules( void ) c
 
 
 /** Get Rev type of object */
-const std::string& Func_readCharacterDataUniversal::getClassType(void) {
+const std::string& Func_readCharacterData::getClassType(void) {
     
-    static std::string rev_type = "Func_readCharacterDataUniversal";
+    static std::string rev_type = "Func_readCharacterData";
     return rev_type;
 }
 
 
 /** Get class type spec describing type of object */
-const TypeSpec& Func_readCharacterDataUniversal::getClassTypeSpec(void) {
+const TypeSpec& Func_readCharacterData::getClassTypeSpec(void) {
     
     static TypeSpec rev_type_spec = TypeSpec( getClassType(), new TypeSpec( Function::getClassTypeSpec() ) );
     return rev_type_spec;
@@ -379,7 +379,7 @@ const TypeSpec& Func_readCharacterDataUniversal::getClassTypeSpec(void) {
 /**
  * Get the primary Rev name for this function.
  */
-std::string Func_readCharacterDataUniversal::getFunctionName( void ) const {
+std::string Func_readCharacterData::getFunctionName( void ) const {
 
     // create a name variable that is the same for all instance of this class
     std::string f_name = "readCharacterData";
@@ -389,7 +389,7 @@ std::string Func_readCharacterDataUniversal::getFunctionName( void ) const {
 
 
 /** Get type spec */
-const TypeSpec& Func_readCharacterDataUniversal::getTypeSpec( void ) const {
+const TypeSpec& Func_readCharacterData::getTypeSpec( void ) const {
     
     static TypeSpec type_spec = getClassTypeSpec();
     return type_spec;
@@ -397,7 +397,7 @@ const TypeSpec& Func_readCharacterDataUniversal::getTypeSpec( void ) const {
 
 
 /** Get return type */
-const TypeSpec& Func_readCharacterDataUniversal::getReturnType( void ) const {
+const TypeSpec& Func_readCharacterData::getReturnType( void ) const {
     
     static TypeSpec return_typeSpec = ModelVector<AbstractHomologousDiscreteCharacterData>::getClassTypeSpec();
     return return_typeSpec;

--- a/src/revlanguage/functions/io/Func_readCharacterData.h
+++ b/src/revlanguage/functions/io/Func_readCharacterData.h
@@ -1,5 +1,5 @@
-#ifndef Func_readCharacterDataUniversal_H
-#define Func_readCharacterDataUniversal_H
+#ifndef Func_readCharacterData_H
+#define Func_readCharacterData_H
 
 #include "Procedure.h"
 #include "RbFileManager.h"
@@ -49,11 +49,11 @@ namespace RevLanguage {
      * the table is unlikely to complete with Yes's (Y) in all of the cells.
      */
     
-    class Func_readCharacterDataUniversal : public Procedure {
+    class Func_readCharacterData : public Procedure {
         
     public:
         // Basic utility functions
-        Func_readCharacterDataUniversal*    clone(void) const;                                                      //!< Clone the object
+        Func_readCharacterData*             clone(void) const;                                                      //!< Clone the object
         static const std::string&           getClassType(void);                                                     //!< Get Rev type
         static const TypeSpec&              getClassTypeSpec(void);                                                 //!< Get class type spec
         std::string                         getFunctionName(void) const;                                            //!< Get the primary name of the function in Rev

--- a/src/revlanguage/functions/io/Func_readDelimitedCharacterData.cpp
+++ b/src/revlanguage/functions/io/Func_readDelimitedCharacterData.cpp
@@ -7,7 +7,7 @@
 #include "ArgumentRule.h"
 #include "DelimitedCharacterDataReader.h"
 #include "HomologousDiscreteCharacterData.h"
-#include "Func_readCharacterDataDelimited.h"
+#include "Func_readDelimitedCharacterData.h"
 #include "NaturalNumbersState.h"
 #include "OptionRule.h"
 #include "RbException.h"
@@ -41,14 +41,14 @@ using namespace RevLanguage;
  *
  * \return A new copy of the process.
  */
-Func_readCharacterDataDelimited* Func_readCharacterDataDelimited::clone( void ) const
+Func_readDelimitedCharacterData* Func_readDelimitedCharacterData::clone( void ) const
 {
     
-    return new Func_readCharacterDataDelimited( *this );
+    return new Func_readDelimitedCharacterData( *this );
 }
 
 
-std::string Func_readCharacterDataDelimited::bitToState(const std::string &s)
+std::string Func_readDelimitedCharacterData::bitToState(const std::string &s)
 {
     
     std::stringstream ss;
@@ -72,7 +72,7 @@ std::string Func_readCharacterDataDelimited::bitToState(const std::string &s)
 
 
 /** Execute function */
-RevPtr<RevVariable> Func_readCharacterDataDelimited::execute()
+RevPtr<RevVariable> Func_readDelimitedCharacterData::execute()
 {
     
     // get the information from the arguments for reading the file
@@ -95,7 +95,7 @@ RevPtr<RevVariable> Func_readCharacterDataDelimited::execute()
         RevBayesCore::HomologousDiscreteCharacterData<RevBayesCore::NaturalNumbersState> *coreStates = new RevBayesCore::HomologousDiscreteCharacterData<RevBayesCore::NaturalNumbersState>();
         
         // get data from file
-        RevBayesCore::DelimitedCharacterDataReader* tsv_data = new RevBayesCore::DelimitedCharacterDataReader(fn, del[0], lines_to_skip);
+        RevBayesCore::DelimitedCharacterDataReader* tsv_data = new RevBayesCore::DelimitedCharacterDataReader(fn, del, lines_to_skip);
 
         int max = StringUtilities::asIntegerNumber( lab );
         
@@ -136,7 +136,7 @@ RevPtr<RevVariable> Func_readCharacterDataDelimited::execute()
         RevBayesCore::HomologousDiscreteCharacterData<RevBayesCore::NaturalNumbersState> *coreStates = new RevBayesCore::HomologousDiscreteCharacterData<RevBayesCore::NaturalNumbersState>();
         
         // get data from file
-        RevBayesCore::DelimitedCharacterDataReader* tsv_data = new RevBayesCore::DelimitedCharacterDataReader(fn, del[0], lines_to_skip);
+        RevBayesCore::DelimitedCharacterDataReader* tsv_data = new RevBayesCore::DelimitedCharacterDataReader(fn, del, lines_to_skip);
         
         // loop through data and get each NaturalNumbers value
         for (size_t i = 0; i < tsv_data->getData().size(); ++i)
@@ -178,7 +178,7 @@ RevPtr<RevVariable> Func_readCharacterDataDelimited::execute()
         RevBayesCore::HomologousDiscreteCharacterData<RevBayesCore::StandardState> *coreStates = new RevBayesCore::HomologousDiscreteCharacterData<RevBayesCore::StandardState>();
         
         // get data from file
-        RevBayesCore::DelimitedCharacterDataReader* tsv_data = new RevBayesCore::DelimitedCharacterDataReader(fn, del[0], lines_to_skip);
+        RevBayesCore::DelimitedCharacterDataReader* tsv_data = new RevBayesCore::DelimitedCharacterDataReader(fn, del, lines_to_skip);
         
         // loop through data and get each NaturalNumbers value
         for (size_t i = 0; i < tsv_data->getData().size(); ++i)
@@ -217,7 +217,7 @@ RevPtr<RevVariable> Func_readCharacterDataDelimited::execute()
         RevBayesCore::ContinuousCharacterData *coreStates = new RevBayesCore::ContinuousCharacterData();
         
         // get data from file
-        RevBayesCore::DelimitedCharacterDataReader* tsv_data = new RevBayesCore::DelimitedCharacterDataReader(fn, del[0], lines_to_skip);
+        RevBayesCore::DelimitedCharacterDataReader* tsv_data = new RevBayesCore::DelimitedCharacterDataReader(fn, del, lines_to_skip);
         
         // loop through data and get each NaturalNumbers value
         for (size_t i = 0; i < tsv_data->getData().size(); ++i)
@@ -255,7 +255,7 @@ RevPtr<RevVariable> Func_readCharacterDataDelimited::execute()
         RevBayesCore::HomologousDiscreteCharacterData<RevBayesCore::TaxaState> *coreStates = new RevBayesCore::HomologousDiscreteCharacterData<RevBayesCore::TaxaState>();
 
         // get data from file
-        RevBayesCore::DelimitedCharacterDataReader* tsv_data = new RevBayesCore::DelimitedCharacterDataReader(fn, del[0], lines_to_skip);
+        RevBayesCore::DelimitedCharacterDataReader* tsv_data = new RevBayesCore::DelimitedCharacterDataReader(fn, del, lines_to_skip);
 
 
         int max = StringUtilities::asIntegerNumber( lab );
@@ -300,7 +300,7 @@ RevPtr<RevVariable> Func_readCharacterDataDelimited::execute()
 
 
 /** Get argument rules */
-const ArgumentRules& Func_readCharacterDataDelimited::getArgumentRules( void ) const
+const ArgumentRules& Func_readDelimitedCharacterData::getArgumentRules( void ) const
 {
     
     static ArgumentRules argumentRules = ArgumentRules();
@@ -319,7 +319,8 @@ const ArgumentRules& Func_readCharacterDataDelimited::getArgumentRules( void ) c
         type_options.push_back( "Taxa" );
         argumentRules.push_back( new OptionRule( "type", new RlString("NaturalNumbers"), type_options, "The type of data." ) );
         argumentRules.push_back( new ArgumentRule( "stateLabels", RlString::getClassTypeSpec(), "The state labels (for standard states) or max number for NaturalNumbers.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString( "" ) ) );
-        argumentRules.push_back( new ArgumentRule( "delimiter", RlString::getClassTypeSpec(), "The delimiter between columns.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString( "\t" ) ) );
+        std::vector<std::string> sep = {"separator","delimiter"};
+        argumentRules.push_back( new ArgumentRule( sep, RlString::getClassTypeSpec(), "The separator/delimiter between columns.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString( "" ) ) );
         argumentRules.push_back( new ArgumentRule( "headers", RlBoolean::getClassTypeSpec(), "Has this file a header line?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean( true ) ) );
         rules_set = true;
         
@@ -330,17 +331,17 @@ const ArgumentRules& Func_readCharacterDataDelimited::getArgumentRules( void ) c
 
 
 /** Get Rev type of object */
-const std::string& Func_readCharacterDataDelimited::getClassType(void)
+const std::string& Func_readDelimitedCharacterData::getClassType(void)
 {
     
-    static std::string rev_type = "Func_readCharacterDataDelimited";
+    static std::string rev_type = "Func_readDelimitedCharacterData";
     
     return rev_type;
 }
 
 
 /** Get class type spec describing type of object */
-const TypeSpec& Func_readCharacterDataDelimited::getClassTypeSpec(void)
+const TypeSpec& Func_readDelimitedCharacterData::getClassTypeSpec(void)
 {
     
     static TypeSpec rev_type_spec = TypeSpec( getClassType(), new TypeSpec( Function::getClassTypeSpec() ) );
@@ -352,17 +353,30 @@ const TypeSpec& Func_readCharacterDataDelimited::getClassTypeSpec(void)
 /**
  * Get the primary Rev name for this function.
  */
-std::string Func_readCharacterDataDelimited::getFunctionName( void ) const
+std::string Func_readDelimitedCharacterData::getFunctionName( void ) const
 {
     // create a name variable that is the same for all instance of this class
-    std::string f_name = "readCharacterDataDelimited";
+    std::string f_name = "readDelimitedCharacterData";
     
     return f_name;
 }
 
 
+/**
+ * Get the primary Rev name for this function.
+ */
+std::vector<std::string> Func_readDelimitedCharacterData::getFunctionNameAliases( void ) const
+{
+    // create a name variable that is the same for all instance of this class
+    std::vector<std::string> f_names;
+    f_names.push_back("readCharacterDataDelimited");
+
+    return f_names;
+}
+
+
 /** Get type spec */
-const TypeSpec& Func_readCharacterDataDelimited::getTypeSpec( void ) const
+const TypeSpec& Func_readDelimitedCharacterData::getTypeSpec( void ) const
 {
     
     static TypeSpec type_spec = getClassTypeSpec();
@@ -372,7 +386,7 @@ const TypeSpec& Func_readCharacterDataDelimited::getTypeSpec( void ) const
 
 
 /** Get return type */
-const TypeSpec& Func_readCharacterDataDelimited::getReturnType( void ) const
+const TypeSpec& Func_readDelimitedCharacterData::getReturnType( void ) const
 {
     
     static TypeSpec return_typeSpec = NaturalNumbersState::getClassTypeSpec();

--- a/src/revlanguage/functions/io/Func_readDelimitedCharacterData.h
+++ b/src/revlanguage/functions/io/Func_readDelimitedCharacterData.h
@@ -1,5 +1,5 @@
-#ifndef Func_readCharacterDataDelimited_H
-#define Func_readCharacterDataDelimited_H
+#ifndef Func_readDelimitedCharacterData_H
+#define Func_readDelimitedCharacterData_H
 
 #include "Procedure.h"
 #include "RbFileManager.h"
@@ -22,14 +22,15 @@ namespace RevLanguage {
      * @since 2015-03-03, version 1.0
      *
      */
-    class Func_readCharacterDataDelimited :  public Procedure {
+    class Func_readDelimitedCharacterData :  public Procedure {
         
     public:
         // Basic utility functions
-        Func_readCharacterDataDelimited*    clone(void) const;                                          //!< Clone the object
+        Func_readDelimitedCharacterData*    clone(void) const;                                          //!< Clone the object
         static const std::string&           getClassType(void);                                         //!< Get Rev type
         static const TypeSpec&              getClassTypeSpec(void);                                     //!< Get class type spec
         std::string                         getFunctionName(void) const;                                //!< Get the primary name of the function in Rev
+        std::vector<std::string>            getFunctionNameAliases(void) const;                         //!< Get the aliases of the function in Rev
         const TypeSpec&                     getTypeSpec(void) const;                                    //!< Get language type of the object
         
         // Regular functions

--- a/src/revlanguage/functions/io/Func_readDelimitedDataFile.cpp
+++ b/src/revlanguage/functions/io/Func_readDelimitedDataFile.cpp
@@ -6,7 +6,7 @@
 #include "ArgumentRule.h"
 #include "ConstantNode.h"
 #include "DelimitedDataReader.h"
-#include "Func_readDataDelimitedFile.h"
+#include "Func_readDelimitedDataFile.h"
 #include "ModelObject.h"
 #include "ModelVector.h"
 #include "RbException.h"
@@ -52,14 +52,14 @@ using namespace RevLanguage;
  *
  * \return A new copy of the process.
  */
-Func_readDataDelimitedFile* Func_readDataDelimitedFile::clone( void ) const
+Func_readDelimitedDataFile* Func_readDelimitedDataFile::clone( void ) const
 {
     
-    return new Func_readDataDelimitedFile( *this );
+    return new Func_readDelimitedDataFile( *this );
 }
 
 
-std::string Func_readDataDelimitedFile::bitToState(const std::string &s)
+std::string Func_readDelimitedDataFile::bitToState(const std::string &s)
 {
     
     std::stringstream ss;
@@ -83,7 +83,7 @@ std::string Func_readDataDelimitedFile::bitToState(const std::string &s)
 
 
 /** Execute function */
-RevPtr<RevVariable> Func_readDataDelimitedFile::execute( void )
+RevPtr<RevVariable> Func_readDelimitedDataFile::execute( void )
 {
     
     // get the information from the arguments for reading the file
@@ -93,7 +93,7 @@ RevPtr<RevVariable> Func_readDataDelimitedFile::execute( void )
     bool rownames          = static_cast<const RlBoolean&>( args[3].getVariable()->getRevObject() ).getValue();
     
     // get data from file
-    RevBayesCore::DelimitedDataReader* tsv_data = new RevBayesCore::DelimitedDataReader(fn, del[0], header);
+    RevBayesCore::DelimitedDataReader* tsv_data = new RevBayesCore::DelimitedDataReader(fn, del, header);
     const std::vector<std::vector<std::string> >&data = tsv_data->getChars();
 
     WorkspaceVector<WorkspaceVector<AbstractModelObject> > matrix;
@@ -275,7 +275,7 @@ RevPtr<RevVariable> Func_readDataDelimitedFile::execute( void )
 
 
 /** Get argument rules */
-const ArgumentRules& Func_readDataDelimitedFile::getArgumentRules( void ) const
+const ArgumentRules& Func_readDelimitedDataFile::getArgumentRules( void ) const
 {
     
     static ArgumentRules argumentRules = ArgumentRules();
@@ -284,9 +284,10 @@ const ArgumentRules& Func_readDataDelimitedFile::getArgumentRules( void ) const
     if (!rules_set)
     {
         
-        argumentRules.push_back( new ArgumentRule( "file",      RlString::getClassTypeSpec(), "The name of the file to read in.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
+        argumentRules.push_back( new ArgumentRule( "file",      RlString::getClassTypeSpec(), "The name of the file to read.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
         argumentRules.push_back( new ArgumentRule( "header",    RlBoolean::getClassTypeSpec(), "Skip first line?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ));
-        argumentRules.push_back( new ArgumentRule( "delimiter", RlString::getClassTypeSpec(), "The delimiter between columns.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString( "\t" ) ) );
+        std::vector<std::string> sep = {"separator","delimiter"};
+        argumentRules.push_back( new ArgumentRule( sep, RlString::getClassTypeSpec(), "The separator/delimiter between columns.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString( "" ) ) );
         argumentRules.push_back( new ArgumentRule( "rownames",  RlBoolean::getClassTypeSpec(), "Skip first column?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ));
         rules_set = true;
         
@@ -297,17 +298,17 @@ const ArgumentRules& Func_readDataDelimitedFile::getArgumentRules( void ) const
 
 
 /** Get Rev type of object */
-const std::string& Func_readDataDelimitedFile::getClassType(void)
+const std::string& Func_readDelimitedDataFile::getClassType(void)
 {
     
-    static std::string rev_type = "Func_readDataDelimitedFile";
+    static std::string rev_type = "Func_readDelimitedDataFile";
     
     return rev_type;
 }
 
 
 /** Get class type spec describing type of object */
-const TypeSpec& Func_readDataDelimitedFile::getClassTypeSpec(void)
+const TypeSpec& Func_readDelimitedDataFile::getClassTypeSpec(void)
 {
     
     static TypeSpec rev_type_spec = TypeSpec( getClassType(), new TypeSpec( Function::getClassTypeSpec() ) );
@@ -319,10 +320,10 @@ const TypeSpec& Func_readDataDelimitedFile::getClassTypeSpec(void)
 /**
  * Get the primary Rev name for this function.
  */
-std::string Func_readDataDelimitedFile::getFunctionName( void ) const
+std::string Func_readDelimitedDataFile::getFunctionName( void ) const
 {
     // create a name variable that is the same for all instance of this class
-    std::string f_name = "readDataDelimitedFile";
+    std::string f_name = "readDelimitedDataFile";
 
     return f_name;
 }
@@ -331,18 +332,19 @@ std::string Func_readDataDelimitedFile::getFunctionName( void ) const
 /**
  * Get the primary Rev name for this function.
  */
-std::vector<std::string> Func_readDataDelimitedFile::getFunctionNameAliases( void ) const
+std::vector<std::string> Func_readDelimitedDataFile::getFunctionNameAliases( void ) const
 {
     // create a name variable that is the same for all instance of this class
     std::vector<std::string> f_names;
     f_names.push_back("readTable");
+    f_names.push_back("readDataDelimitedFile");
 
     return f_names;
 }
 
 
 /** Get type spec */
-const TypeSpec& Func_readDataDelimitedFile::getTypeSpec( void ) const
+const TypeSpec& Func_readDelimitedDataFile::getTypeSpec( void ) const
 {
     
     static TypeSpec type_spec = getClassTypeSpec();
@@ -352,7 +354,7 @@ const TypeSpec& Func_readDataDelimitedFile::getTypeSpec( void ) const
 
 
 /** Get return type */
-const TypeSpec& Func_readDataDelimitedFile::getReturnType( void ) const
+const TypeSpec& Func_readDelimitedDataFile::getReturnType( void ) const
 {
     
     static TypeSpec return_typeSpec = WorkspaceVector<WorkspaceVector<AbstractModelObject> >::getClassTypeSpec();

--- a/src/revlanguage/functions/io/Func_readDelimitedDataFile.h
+++ b/src/revlanguage/functions/io/Func_readDelimitedDataFile.h
@@ -1,29 +1,37 @@
+#ifndef Func_readDataDelimitedFile_hpp
+#define Func_readDataDelimitedFile_hpp
 
-#ifndef Func_writeCharacterDataDelimited_H
-#define Func_writeCharacterDataDelimited_H
 
 #include "Procedure.h"
+#include "RbFileManager.h"
+
+#include <map>
+#include <string>
+#include <vector>
 
 
 namespace RevLanguage {
     
     /**
-     * Function that writes character data as a delimited text file.
+     * The Rev procedure to read character data from delimited files.
      *
+     * This procedure can read several data types.
      *
      *
      * @copyright Copyright 2009-
-     * @author The RevBayes Development Core Team (Will Freyman)
-     * @since 2013-04-15, version 1.0
+     * @author The RevBayes Development Core Team (Michael Landis)
+     * @since 2015-03-03, version 1.0
+     *
      */
-    class Func_writeCharacterDataDelimited : public Procedure {
+    class Func_readDelimitedDataFile : public Procedure {
         
     public:
         // Basic utility functions
-        Func_writeCharacterDataDelimited*                    clone(void) const;                                          //!< Clone the object
+        Func_readDelimitedDataFile*         clone(void) const;                                          //!< Clone the object
         static const std::string&           getClassType(void);                                         //!< Get Rev type
         static const TypeSpec&              getClassTypeSpec(void);                                     //!< Get class type spec
         std::string                         getFunctionName(void) const;                                //!< Get the primary name of the function in Rev
+        std::vector<std::string>            getFunctionNameAliases(void) const;                         //!< Get the aliases of the function in Rev
         const TypeSpec&                     getTypeSpec(void) const;                                    //!< Get language type of the object
         
         // Regular functions
@@ -31,9 +39,11 @@ namespace RevLanguage {
         const ArgumentRules&                getArgumentRules(void) const;                               //!< Get argument rules
         const TypeSpec&                     getReturnType(void) const;                                  //!< Get type of return value
         
+    private:
+        std::string                         bitToState(const std::string &s);
         
     };
     
 }
 
-#endif
+#endif /* Func_readDataDelimitedFile_hpp */

--- a/src/revlanguage/functions/io/Func_readDistanceMatrix.cpp
+++ b/src/revlanguage/functions/io/Func_readDistanceMatrix.cpp
@@ -36,8 +36,9 @@ RevPtr<RevVariable> Func_readDistanceMatrix::execute( void )
 	
 	// get the information from the arguments for reading the file
 	const RlString& fn = static_cast<const RlString&>( args[0].getVariable()->getRevObject() );
-	
-	RevBayesCore::DistanceMatrixReader* dmr = new RevBayesCore::DistanceMatrixReader( fn.getValue(), ' ' );
+	const std::string& del = static_cast<const RlString&>( args[1].getVariable()->getRevObject() ).getValue();
+
+	RevBayesCore::DistanceMatrixReader* dmr = new RevBayesCore::DistanceMatrixReader( fn.getValue(), del );
 	RevBayesCore::DistanceMatrix* dm = new RevBayesCore::DistanceMatrix(dmr);
 		
 	return new RevVariable( new DistanceMatrix(dm) );
@@ -55,7 +56,9 @@ const ArgumentRules& Func_readDistanceMatrix::getArgumentRules( void ) const
 	{
 		
 		argumentRules.push_back( new ArgumentRule( "file", RlString::getClassTypeSpec(), "Relative or absolute name of the file.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
-		rules_set = true;
+		std::vector<std::string> sep = {"separator","delimiter"};
+        argumentRules.push_back( new ArgumentRule( sep, RlString::getClassTypeSpec(), "The separator/delimiter between columns.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString( "" ) ) );
+        rules_set = true;
 		
 	}
 	

--- a/src/revlanguage/functions/io/Func_readMatrix.cpp
+++ b/src/revlanguage/functions/io/Func_readMatrix.cpp
@@ -38,7 +38,7 @@ RevPtr<RevVariable> Func_readMatrix::execute( void )
 	const RlString&    fn  = static_cast<const RlString&>( args[0].getVariable()->getRevObject() );
     const std::string& del = static_cast<const RlString&>( args[1].getVariable()->getRevObject() ).getValue();
 
-    RevBayesCore::MatrixReader* mr = new RevBayesCore::MatrixReader( fn.getValue(), del[0] );
+    RevBayesCore::MatrixReader* mr = new RevBayesCore::MatrixReader( fn.getValue(), del );
     RevBayesCore::MatrixReal    m  = mr->getMatrix();
     MatrixReal*                 rm = new MatrixReal( m );
 
@@ -57,8 +57,9 @@ const ArgumentRules& Func_readMatrix::getArgumentRules( void ) const
 	if (!rules_set)
 	{
 		
-		argumentRules.push_back( new ArgumentRule( "file", RlString::getClassTypeSpec(), "Relative or absolute name of the file.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
-        argumentRules.push_back( new ArgumentRule( "delimiter", RlString::getClassTypeSpec(), "The delimiter between columns.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString( "\t" ) ) );
+		argumentRules.push_back( new ArgumentRule( "file", RlString::getClassTypeSpec(), "The name of the file to read.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
+		std::vector<std::string> sep = {"separator","delimiter"};
+		argumentRules.push_back( new ArgumentRule( sep, RlString::getClassTypeSpec(), "The separator/delimiter between columns.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString( "" ) ) );
 		rules_set = true;
 		
 	}

--- a/src/revlanguage/functions/io/Func_readPoMoCountFile.cpp
+++ b/src/revlanguage/functions/io/Func_readPoMoCountFile.cpp
@@ -47,7 +47,7 @@ RevPtr<RevVariable> Func_readPoMoCountFile::execute( void )
 	RevBayesCore::TypedDagNode<long>* virtualPopulationSize = static_cast<const Integer &>( this->args[1].getVariable()->getRevObject() ).getDagNode();
     RevBayesCore::TypedDagNode<long>* n_states = static_cast<const Integer &>( this->args[2].getVariable()->getRevObject() ).getDagNode();
 
-	RevBayesCore::PoMoCountFileReader* pcfr = new RevBayesCore::PoMoCountFileReader( fn.getValue(), virtualPopulationSize->getValue(), ' ' );
+	RevBayesCore::PoMoCountFileReader* pcfr = new RevBayesCore::PoMoCountFileReader( fn.getValue(), virtualPopulationSize->getValue());
 
 	RevBayesCore::HomologousDiscreteCharacterData<RevBayesCore::PoMoState> *pomoAln = new RevBayesCore::HomologousDiscreteCharacterData<RevBayesCore::PoMoState>( *(pcfr->getMatrix() ) );
 

--- a/src/revlanguage/functions/io/Func_readRelativeNodeAgeConstraints.cpp
+++ b/src/revlanguage/functions/io/Func_readRelativeNodeAgeConstraints.cpp
@@ -31,8 +31,9 @@ RevPtr<RevVariable> Func_readRelativeNodeAgeConstraints::execute( void )
     
     // get the information from the arguments for reading the file
     const RlString& fn = static_cast<const RlString&>( args[0].getVariable()->getRevObject() );
+    const std::string& del = static_cast<const RlString&>( args[1].getVariable()->getRevObject() ).getValue();
     
-    RevBayesCore::RelativeNodeAgeConstraintsReader* dmr = new RevBayesCore::RelativeNodeAgeConstraintsReader( fn.getValue(), '\t' );
+    RevBayesCore::RelativeNodeAgeConstraintsReader* dmr = new RevBayesCore::RelativeNodeAgeConstraintsReader( fn.getValue(), del );
     RevBayesCore::RelativeNodeAgeConstraints* dm = new RevBayesCore::RelativeNodeAgeConstraints(dmr);
     
     return new RevVariable( new RlRelativeNodeAgeConstraints(dm) );
@@ -50,6 +51,8 @@ const ArgumentRules& Func_readRelativeNodeAgeConstraints::getArgumentRules( void
     {
         
         argumentRules.push_back( new ArgumentRule( "file", RlString::getClassTypeSpec(), "Relative or absolute name of the file.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
+        std::vector<std::string> sep = {"separator","delimiter"};
+        argumentRules.push_back( new ArgumentRule( sep, RlString::getClassTypeSpec(), "The separator/delimiter between columns.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString( "" ) ) );
         rules_set = true;
         
     }

--- a/src/revlanguage/functions/io/Func_readRelativeNodeAgeWeightedConstraints.cpp
+++ b/src/revlanguage/functions/io/Func_readRelativeNodeAgeWeightedConstraints.cpp
@@ -31,9 +31,11 @@ RevPtr<RevVariable> Func_readRelativeNodeAgeWeightedConstraints::execute( void )
 {
     
     // get the information from the arguments for reading the file
-    const RlString& fn = static_cast<const RlString&>( args[0].getVariable()->getRevObject() );
-    double th = static_cast<const Real&>( args[1].getVariable()->getRevObject() ).getValue();
-    RevBayesCore::RelativeNodeAgeWeightedConstraintsReader* dmr = new RevBayesCore::RelativeNodeAgeWeightedConstraintsReader( fn.getValue(), '\t', 0, th );
+    std::string fn = static_cast<const RlString&>( args[0].getVariable()->getRevObject() ).getValue();
+    std::string sep = static_cast<const RlString&>( args[1].getVariable()->getRevObject() ).getValue();
+    double th = static_cast<const Real&>( args[2].getVariable()->getRevObject() ).getValue();
+
+    RevBayesCore::RelativeNodeAgeWeightedConstraintsReader* dmr = new RevBayesCore::RelativeNodeAgeWeightedConstraintsReader( fn, sep, 0, th );
     RevBayesCore::RelativeNodeAgeWeightedConstraints* dm = new RevBayesCore::RelativeNodeAgeWeightedConstraints(dmr);
     
     return new RevVariable( new RlRelativeNodeAgeWeightedConstraints(dm) );
@@ -51,6 +53,8 @@ const ArgumentRules& Func_readRelativeNodeAgeWeightedConstraints::getArgumentRul
     {
         
         argumentRules.push_back( new ArgumentRule( "file", RlString::getClassTypeSpec(), "Relative or absolute name of the file.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
+        std::vector<std::string> sep = {"separator","delimiter"};
+        argumentRules.push_back( new ArgumentRule( sep, RlString::getClassTypeSpec(), "The separator/delimiter between columns.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString( "" ) ) );
         argumentRules.push_back( new ArgumentRule( "threshold", Real::getClassTypeSpec(), "weight threshold below which constraints are ignored.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
         
         rules_set = true;

--- a/src/revlanguage/functions/io/Func_readStochasticVariableTrace.cpp
+++ b/src/revlanguage/functions/io/Func_readStochasticVariableTrace.cpp
@@ -69,7 +69,8 @@ const ArgumentRules& Func_readStochasticVariableTrace::getArgumentRules( void ) 
     {
         
         argumentRules.push_back( new ArgumentRule( "file"     , RlString::getClassTypeSpec(), "The name of the file.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
-        argumentRules.push_back( new ArgumentRule( "delimiter", RlString::getClassTypeSpec(), "The delimiter used between the output of variables.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("\t") ) );
+        std::vector<std::string> sep = {"separator","delimiter"};
+        argumentRules.push_back( new ArgumentRule( sep, RlString::getClassTypeSpec(), "The separator/delimiter between columns.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("") ) );
         rules_set = true;
     }
     

--- a/src/revlanguage/functions/io/Func_readTrace.cpp
+++ b/src/revlanguage/functions/io/Func_readTrace.cpp
@@ -209,7 +209,8 @@ const ArgumentRules& Func_readTrace::getArgumentRules( void ) const
     {
         
         argumentRules.push_back( new ArgumentRule( "file"     , RlString::getClassTypeSpec(), "Name of the file.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
-        argumentRules.push_back( new ArgumentRule( "delimiter", RlString::getClassTypeSpec(), "The delimiter between columns (e.g., the iteration number and the trees).", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("\t") ) );
+        std::vector<std::string> sep = {"separator","delimiter"};
+        argumentRules.push_back( new ArgumentRule( sep, RlString::getClassTypeSpec(), "The separator/delimiter between columns.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("") ) );
 
         std::vector<TypeSpec> burninTypes;
         burninTypes.push_back( Probability::getClassTypeSpec() );

--- a/src/revlanguage/functions/io/Func_readTreeTrace.cpp
+++ b/src/revlanguage/functions/io/Func_readTreeTrace.cpp
@@ -247,7 +247,8 @@ const ArgumentRules& Func_readTreeTrace::getArgumentRules( void ) const
         tree_options.push_back( "non-clock" );
         argumentRules.push_back( new OptionRule( "treetype", new RlString("clock"), tree_options, "The type of trees." ) );
         argumentRules.push_back( new ArgumentRule( "outgroup"   , Clade::getClassTypeSpec(), "The clade (consisting of one or more taxa) used as an outgroup.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY, NULL ) );
-        argumentRules.push_back( new ArgumentRule( "separator", RlString::getClassTypeSpec(), "The separator/delimiter between values in the file.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("\t") ) );
+        std::vector<std::string> sep = {"separator","delimiter"};
+        argumentRules.push_back( new ArgumentRule( sep, RlString::getClassTypeSpec(), "The separator/delimiter between columns.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("") ) );
 
         std::vector<TypeSpec> burninTypes;
         burninTypes.push_back( Probability::getClassTypeSpec() );
@@ -318,7 +319,7 @@ const TypeSpec& Func_readTreeTrace::getReturnType( void ) const
 }
 
 
-WorkspaceVector<TraceTree>* Func_readTreeTrace::readTrees(const std::vector<std::string> &vector_of_file_names, const std::string &delimitter, bool clock, long thinning)
+WorkspaceVector<TraceTree>* Func_readTreeTrace::readTrees(const std::vector<std::string> &vector_of_file_names, const std::string &delimiter, bool clock, long thinning)
 {
     
     std::vector<TraceTree> data;
@@ -406,7 +407,7 @@ WorkspaceVector<TraceTree>* Func_readTreeTrace::readTrees(const std::vector<std:
             std::vector<std::string> columns;
             
             // we should provide other delimiters too
-            StringUtilities::stringSplit(line, delimitter, columns);
+            StringUtilities::stringSplit(line, delimiter, columns);
             
             // we assume a header at the first line of the file
             if ( has_header_been_read == false )

--- a/src/revlanguage/functions/io/Func_summarizeCharacterMaps.cpp
+++ b/src/revlanguage/functions/io/Func_summarizeCharacterMaps.cpp
@@ -124,7 +124,8 @@ const ArgumentRules& Func_summarizeCharacterMaps::getArgumentRules( void ) const
         burninTypes.push_back( Probability::getClassTypeSpec() );
         burninTypes.push_back( Integer::getClassTypeSpec() );
         argumentRules.push_back( new ArgumentRule( "burnin"   , burninTypes  , "The fraction/number of samples to discard as burnin.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new Probability(0.25) ) );
-        argumentRules.push_back( new ArgumentRule("separator" , RlString::getClassTypeSpec() , "The delimiter between variables. \t by default.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("\t") ) );
+        std::vector<std::string> sep = {"separator","delimiter"};
+        argumentRules.push_back( new ArgumentRule( sep , RlString::getClassTypeSpec() , "The separator/delimiter between columns.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("\t") ) );
         argumentRules.push_back( new ArgumentRule( "verbose"   , RlBoolean::getClassTypeSpec()  , "Printing verbose output", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true) ) );
         
         rules_set = true;

--- a/src/revlanguage/functions/io/Func_writeDelimitedCharacterData.cpp
+++ b/src/revlanguage/functions/io/Func_writeDelimitedCharacterData.cpp
@@ -3,7 +3,7 @@
 #include <vector>
 
 #include "ArgumentRule.h"
-#include "Func_writeCharacterDataDelimited.h"
+#include "Func_writeDelimitedCharacterData.h"
 #include "RevNullObject.h"
 #include "RlAbstractHomologousDiscreteCharacterData.h"
 #include "RlContinuousCharacterData.h"
@@ -32,10 +32,10 @@ using namespace RevLanguage;
  *
  * \return A new copy of myself
  */
-Func_writeCharacterDataDelimited* Func_writeCharacterDataDelimited::clone( void ) const
+Func_writeDelimitedCharacterData* Func_writeDelimitedCharacterData::clone( void ) const
 {
     
-    return new Func_writeCharacterDataDelimited( *this );
+    return new Func_writeDelimitedCharacterData( *this );
 }
 
 
@@ -47,7 +47,7 @@ Func_writeCharacterDataDelimited* Func_writeCharacterDataDelimited::clone( void 
  *
  * \return NULL because the output is going into a file
  */
-RevPtr<RevVariable> Func_writeCharacterDataDelimited::execute( void )
+RevPtr<RevVariable> Func_writeDelimitedCharacterData::execute( void )
 {
     
     // get the information from the arguments for reading the file
@@ -66,7 +66,7 @@ RevPtr<RevVariable> Func_writeCharacterDataDelimited::execute( void )
     const std::string& del = static_cast<const RlString&>( args[2].getVariable()->getRevObject() ).getValue();
     
     RevBayesCore::DelimitedCharacterDataWriter writer;
-    writer.writeData(fn.getValue(), *data, del[0]);
+    writer.writeData(fn.getValue(), *data, del);
     
     return NULL;
 }
@@ -81,7 +81,7 @@ RevPtr<RevVariable> Func_writeCharacterDataDelimited::execute( void )
  *
  * \return The argument rules.
  */
-const ArgumentRules& Func_writeCharacterDataDelimited::getArgumentRules( void ) const
+const ArgumentRules& Func_writeDelimitedCharacterData::getArgumentRules( void ) const
 {
     
     static ArgumentRules argument_rules = ArgumentRules();
@@ -95,7 +95,8 @@ const ArgumentRules& Func_writeCharacterDataDelimited::getArgumentRules( void ) 
         data_arg_types.push_back( AbstractHomologousDiscreteCharacterData::getClassTypeSpec() );
         data_arg_types.push_back( ContinuousCharacterData::getClassTypeSpec() );
         argument_rules.push_back( new ArgumentRule( "data"    , data_arg_types, "The character data object.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
-        argument_rules.push_back( new ArgumentRule( "delimiter", RlString::getClassTypeSpec(), "The delimiter between columns.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString( "\t" ) ) );
+        std::vector<std::string> sep = {"separator","delimiter"};
+        argument_rules.push_back( new ArgumentRule( sep, RlString::getClassTypeSpec(), "The separator/delimiter between columns.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString( "\t" ) ) );
         rules_set = true;
     }
     
@@ -108,10 +109,10 @@ const ArgumentRules& Func_writeCharacterDataDelimited::getArgumentRules( void ) 
  *
  * \return The class' name.
  */
-const std::string& Func_writeCharacterDataDelimited::getClassType(void)
+const std::string& Func_writeDelimitedCharacterData::getClassType(void)
 {
     
-    static std::string rev_type = "Func_writeCharacterDataDelimited";
+    static std::string rev_type = "Func_writeDelimitedCharacterData";
     
     return rev_type;
 }
@@ -122,7 +123,7 @@ const std::string& Func_writeCharacterDataDelimited::getClassType(void)
  *
  * \return TypeSpec of this class.
  */
-const TypeSpec& Func_writeCharacterDataDelimited::getClassTypeSpec(void)
+const TypeSpec& Func_writeDelimitedCharacterData::getClassTypeSpec(void)
 {
     
     static TypeSpec rev_type_spec = TypeSpec( getClassType(), new TypeSpec( Function::getClassTypeSpec() ) );
@@ -134,12 +135,25 @@ const TypeSpec& Func_writeCharacterDataDelimited::getClassTypeSpec(void)
 /**
  * Get the primary Rev name for this function.
  */
-std::string Func_writeCharacterDataDelimited::getFunctionName( void ) const
+std::string Func_writeDelimitedCharacterData::getFunctionName( void ) const
 {
     // create a name variable that is the same for all instance of this class
-    std::string f_name = "writeCharacterDataDelimited";
+    std::string f_name = "writeDelimitedCharacterData";
     
     return f_name;
+}
+
+
+/**
+ * Get the primary Rev name for this function.
+ */
+std::vector<std::string> Func_writeDelimitedCharacterData::getFunctionNameAliases( void ) const
+{
+    // create a name variable that is the same for all instance of this class
+    std::vector<std::string> f_names;
+    f_names.push_back("writeCharacterDataDelimited");
+
+    return f_names;
 }
 
 
@@ -148,7 +162,7 @@ std::string Func_writeCharacterDataDelimited::getFunctionName( void ) const
  *
  * \return The type spec of this object.
  */
-const TypeSpec& Func_writeCharacterDataDelimited::getTypeSpec( void ) const
+const TypeSpec& Func_writeDelimitedCharacterData::getTypeSpec( void ) const
 {
     
     static TypeSpec type_spec = getClassTypeSpec();
@@ -163,7 +177,7 @@ const TypeSpec& Func_writeCharacterDataDelimited::getTypeSpec( void ) const
  *
  * \return NULL
  */
-const TypeSpec& Func_writeCharacterDataDelimited::getReturnType( void ) const
+const TypeSpec& Func_writeDelimitedCharacterData::getReturnType( void ) const
 {
     
     static TypeSpec return_typeSpec = RevNullObject::getClassTypeSpec();

--- a/src/revlanguage/functions/io/Func_writeDelimitedCharacterData.h
+++ b/src/revlanguage/functions/io/Func_writeDelimitedCharacterData.h
@@ -1,33 +1,26 @@
-#ifndef Func_readDataDelimitedFile_hpp
-#define Func_readDataDelimitedFile_hpp
 
+#ifndef Func_writeDelimitedCharacterData_H
+#define Func_writeDelimitedCharacterData_H
 
 #include "Procedure.h"
-#include "RbFileManager.h"
-
-#include <map>
-#include <string>
-#include <vector>
 
 
 namespace RevLanguage {
     
     /**
-     * The Rev procedure to read character data from delimited files.
+     * Function that writes character data as a delimited text file.
      *
-     * This procedure can read several data types.
      *
      *
      * @copyright Copyright 2009-
-     * @author The RevBayes Development Core Team (Michael Landis)
-     * @since 2015-03-03, version 1.0
-     *
+     * @author The RevBayes Development Core Team (Will Freyman)
+     * @since 2013-04-15, version 1.0
      */
-    class Func_readDataDelimitedFile : public Procedure {
+    class Func_writeDelimitedCharacterData : public Procedure {
         
     public:
         // Basic utility functions
-        Func_readDataDelimitedFile*         clone(void) const;                                          //!< Clone the object
+        Func_writeDelimitedCharacterData*   clone(void) const;                                          //!< Clone the object
         static const std::string&           getClassType(void);                                         //!< Get Rev type
         static const TypeSpec&              getClassTypeSpec(void);                                     //!< Get class type spec
         std::string                         getFunctionName(void) const;                                //!< Get the primary name of the function in Rev
@@ -39,11 +32,9 @@ namespace RevLanguage {
         const ArgumentRules&                getArgumentRules(void) const;                               //!< Get argument rules
         const TypeSpec&                     getReturnType(void) const;                                  //!< Get type of return value
         
-    private:
-        std::string                         bitToState(const std::string &s);
         
     };
     
 }
 
-#endif /* Func_readDataDelimitedFile_hpp */
+#endif

--- a/src/revlanguage/workspace/RbRegister_Basic.cpp
+++ b/src/revlanguage/workspace/RbRegister_Basic.cpp
@@ -207,10 +207,10 @@
 #include "Func_readAncestralStateTrace.h"
 #include "Func_readAtlas.h"
 #include "Func_readBranchLengthTrees.h"
-#include "Func_readCharacterDataDelimited.h"
-#include "Func_readCharacterDataUniversal.h"
+#include "Func_readDelimitedCharacterData.h"
+#include "Func_readCharacterData.h"
 #include "Func_readContinuousCharacterData.h"
-#include "Func_readDataDelimitedFile.h"
+#include "Func_readDelimitedDataFile.h"
 #include "Func_readDiscreteCharacterData.h"
 #include "Func_readDistanceMatrix.h"
 #include "Func_readMatrix.h"
@@ -226,7 +226,7 @@
 #include "Func_TaxonReader.h"
 #include "Func_treeTrace.h"
 #include "Func_write.h"
-#include "Func_writeCharacterDataDelimited.h"
+#include "Func_writeDelimitedCharacterData.h"
 #include "Func_writeFasta.h"
 #include "Func_writeNexus.h"
 
@@ -523,9 +523,11 @@ void RevLanguage::Workspace::initializeBasicGlobalWorkspace(void)
         addFunction( new Func_readAtlas()                               );
 		addFunction( new Func_readBranchLengthTrees()                   );
         addFunction( new Func_readContinuousCharacterData()             );
+        addFunction( new Func_readDelimitedCharacterData()              );
+        addFunction( new Func_readDelimitedDataFile()                   );
         addFunction( new Func_readDiscreteCharacterData()               );
 		addFunction( new Func_readDistanceMatrix()                      );
-        addFunction( new Func_readCharacterDataUniversal()              );
+        addFunction( new Func_readCharacterData()              );
         addFunction( new Func_readMatrix()                              );
         addFunction( new Func_readRelativeNodeAgeConstraints()          );
         addFunction( new Func_readRelativeNodeAgeWeightedConstraints()  );
@@ -534,14 +536,12 @@ void RevLanguage::Workspace::initializeBasicGlobalWorkspace(void)
         addFunction( new Func_readTrace()                               );
         addFunction( new Func_readTrees()                               );
         addFunction( new Func_readTreeTrace()                           );
-		addFunction( new Func_readCharacterDataDelimited()              );
-        addFunction( new Func_readDataDelimitedFile()                   );
-        addFunction( new Func_readVCF()                                 );
+		addFunction( new Func_readVCF()                                 );
         addFunction( new Func_source()                                  );
         addFunction( new Func_summarizeCharacterMaps()                  );
         addFunction( new Func_treeTrace()                               );
         addFunction( new Func_write()                                   );
-        addFunction( new Func_writeCharacterDataDelimited()             );
+        addFunction( new Func_writeDelimitedCharacterData()             );
         addFunction( new Func_writeFasta()                              );
         addFunction( new Func_writeNexus()                              );
         


### PR DESCRIPTION
This pull request does several things:

1. Consolidate parsing of strings with delimiters into `StringUtilities::stringSplit`. This was to avoid multiple implementations of the same functionality.
2. Change the behavior of `StringUtilities::stringSplit` to allow an arbitrary amount of whitespace to serve as a delimiter. This was to allow files delimited with whitespace to be formatted in a more natural, human-readable way.
3. Change the default delimiter to whitespace on nearly all delimited file readers. The default in most cases was already `\t` and so this change is backwards compatible.
4. Fix inconsistent use of `separator` vs. `delimiter` in various file reading function arguments. Some functions used `separator`, others used `delimiter`.
5. Rename some functions to have more natural-sounding names. For example, I think `readDelimitedDataFile` is more grammatical than `readDataDelimitedFile`.
6. Various other small fixes.