### PR TITLE
Fix slice sampling

### DIFF
--- a/src/core/moves/SliceSamplingMove.cpp
+++ b/src/core/moves/SliceSamplingMove.cpp
@@ -21,7 +21,7 @@ using boost::optional;
 
 using namespace RevBayesCore;
 
-const double log_0 = RbConstants::Double::min;
+const double log_0 = RbConstants::Double::neginf;
 
 // How can we make a run-time adjustable log level?
 int log_level = 0;

--- a/src/core/moves/SliceSamplingMove.h
+++ b/src/core/moves/SliceSamplingMove.h
@@ -6,6 +6,7 @@
 
 #include <set>
 #include <vector>
+#include <boost/optional.hpp>
 
 namespace RevBayesCore {
     
@@ -28,7 +29,7 @@ namespace RevBayesCore {
     public:
         enum BoundarySearchMethod { search_stepping_out, search_doubling };
 
-        SliceSamplingMove(StochasticNode<double> *p, double window_, double weight_, BoundarySearchMethod, bool autoTune = false);        //!< Constructor
+        SliceSamplingMove(StochasticNode<double> *p, boost::optional<double>, boost::optional<double>, double window_, double weight_, BoundarySearchMethod, bool autoTune = false);        //!< Constructor
         virtual                                                 ~SliceSamplingMove(void);                           //!< Destructor
 
         // public methods
@@ -49,6 +50,8 @@ namespace RevBayesCore {
 
         // parameters
         StochasticNode<double>*                                 variable;                                           //!< The variable the Proposal is working on
+        boost::optional<double>                                 lower_bound;                                        //!< Optional lower bound for variable
+        boost::optional<double>                                 upper_bound;                                        //!< Optional upper bound for variable
         double                                                  window;                                             //!< Window width for slice sampling
         double                                                  total_movement;                                     //!< total distance moved under auto-tuning
         int                                                     numPr;                                              //!< Number of probability evaluations


### PR DESCRIPTION
Fix two bugs in slice sampling:
- log_0 was defined incorrectly -- just use negative infinity
- rule out negative values when sampling RealPos variables.

I have some code to set the allowed values to the interval [min,max], but that is perhaps overkill.