### PR TITLE
Speedup: cache object files even if testing fails.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,9 @@ jobs:
         echo "::set-output name=timestamp::${stamp}"
 
     - name: ccache cache files
-      uses: actions/cache@v1.1.0
+#      uses: actions/cache@v2
+#     We want to cache the build artifacts whether or not the tests succeed.
+      uses: pat-s/always-upload-cache@v2
       with:
          path: ~/.ccache
          key: ${{ matrix.name }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}


### PR DESCRIPTION
Currently we recompiling object files from scratch unnecessarily, if integration tests fail.