### PR TITLE
Bump the minimum cmake version to 2.8.12

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 project(RevBayes)
 
 # Consider:
@@ -7,16 +7,16 @@ project(RevBayes)
 
 # This is the RIGHT way, but requires cmake version >=3:
 #   set(CMAKE_CXX_STANDARD 11)
-# RHEL 7 compute clusters may have cmake 2.8.12
+# RHEL 6 & 7 compute clusters may have cmake 2.8.12
+#
+# https://gitlab.kitware.com/cmake/community/-/wikis/CMake-Versions-on-Linux-Distros
 #
 # So, we add the flag directly instead.
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
-if(NOT (${CMAKE_VERSION} VERSION_LESS "2.8.0"))
-  find_program(CCACHE_PROGRAM ccache)
-  if(CCACHE_PROGRAM)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
-  endif()
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
 endif()
 
 # Add extra CMake libraries into ./CMake


### PR DESCRIPTION
I'm getting a deprecation warning for setting the minimum version to 2.6.  (I have cmake 3.21.4).

```
    CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
    
    Compatibility with CMake < 2.8.12 will be removed from a future version of CMake.
```

Since RHEL 6 and 7 have 2.8.12, this should be safe for most old clusters.

https://gitlab.kitware.com/cmake/community/-/wikis/CMake-Versions-on-Linux-Distros

Does anybody have a cluster with cmake older than 2.8.12?  Often you can use a newer cmake than the default system cmake by typing something like `module add cmake`.

