### PR TITLE
Require Boost version 1.74

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,42 +28,49 @@ jobs:
             os: ubuntu-18.04
             compiler: gcc
             version: "6"
+            install_boost: 1.74
             mpi: false
 
           - name: ubuntu-gcc-7
             os: ubuntu-latest
             compiler: gcc
             version: "7"
+            install_boost: 1.74
             mpi: false
 
           - name: ubuntu-gcc-8
             os: ubuntu-latest
             compiler: gcc
             version: "8"
+            install_boost: 1.74
             mpi: false
 
           - name: ubuntu-gcc-9
             os: ubuntu-latest
             compiler: gcc
             version: "9"
+            install_boost: 1.74
             mpi: false
 
           - name: ubuntu-gcc-9-mpi
             os: ubuntu-latest
             compiler: gcc
             version: "9"
+            install_boost: 1.74
             mpi: true
 
           - name: ubuntu-gcc-10
             os: ubuntu-latest
             compiler: gcc
             version: "10"
+            install_boost: 1.74
             mpi: false
 
           - name: ubuntu-clang-8
             os: ubuntu-latest
             compiler: clang
             version: "8"
+            install_boost: 1.74
             mpi: false
 
           - name: macos-xcode-11.7
@@ -152,7 +159,16 @@ jobs:
       run: |
         # Don't use weird boost version installed by github actions.
         sudo rm -rf /usr/local/share/boost
-        sudo apt-get install -y libboost-dev libboost-program-options-dev libboost-date-time-dev libboost-filesystem-dev libboost-regex-dev libboost-serialization-dev libboost-system-dev libboost-thread-dev
+
+        # Maybe install a particular boost version.
+        if [ -n "${{ matrix.install_boost }}" ] ; then
+          sudo apt-get remove libboost-all-dev
+          sudo add-apt-repository ppa:mhier/libboost-latest
+          sudo apt-get update
+          sudo apt-get install -y libboost${{ matrix.install_boost }}-dev
+        else
+          sudo apt-get install -y libboost-all-dev
+        fi
 
     - name: Install BOOST and set up build (Windows meson cross compile)
       if: matrix.name == 'windows'

--- a/meson.build
+++ b/meson.build
@@ -58,7 +58,7 @@ boost_modules = [ 'regex',
 want_static = get_option('static')
 
 # This doesn't build an internal boost from the internal copy, yet.
-boost = dependency('boost', modules : boost_modules, static: want_static)
+boost = dependency('boost', modules : boost_modules, version: '>=1.74', static: want_static)
 
 openlibm = dependency('openlibm', static: want_static)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,7 +90,7 @@ endif()
 
 MESSAGE("Searching for BOOST:")
 find_package(Boost
-1.60.0
+1.74.0
 COMPONENTS regex
 program_options
 thread


### PR DESCRIPTION
I think that linux compiles already need to download and compile boost, with the version in the examples being 1.71
This PR bumps that to 1.71 and makes it a requirement.
The latest version is 1.77.
I don't think this would affect mac or windows.