### PR TITLE
Change the standard to c++14.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('RevBayes', ['cpp', 'c'],
         version: '1.0.12',
         default_options: [
           'buildtype=release',
-          'cpp_std=c++11',
+          'cpp_std=c++14',
           'b_ndebug=if-release'
         ],
         meson_version: '>= 0.53',

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,7 @@ project(RevBayes)
 # https://gitlab.kitware.com/cmake/community/-/wikis/CMake-Versions-on-Linux-Distros
 #
 # So, we add the flag directly instead.
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)


### PR DESCRIPTION
C++14 adds few features, and fixes some defects in C++11.
This patch doesn't actually doesn't change any code -- it just allows compiling C++14 code.
This patch is needed for a small code cleanup on a different branch.