### PR TITLE
Cmake increase min version to 3.5.1

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5.1)
 project(RevBayes)
 
 # Consider:
@@ -7,7 +7,6 @@ project(RevBayes)
 
 # This is the RIGHT way, but requires cmake version >=3:
 #   set(CMAKE_CXX_STANDARD 11)
-# RHEL 6 & 7 compute clusters may have cmake 2.8.12
 #
 # https://gitlab.kitware.com/cmake/community/-/wikis/CMake-Versions-on-Linux-Distros
 #

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 project(RevBayes)
 
 # Consider:
@@ -7,16 +7,16 @@ project(RevBayes)
 
 # This is the RIGHT way, but requires cmake version >=3:
 #   set(CMAKE_CXX_STANDARD 11)
-# RHEL 7 compute clusters may have cmake 2.8.12
+# RHEL 6 & 7 compute clusters may have cmake 2.8.12
+#
+# https://gitlab.kitware.com/cmake/community/-/wikis/CMake-Versions-on-Linux-Distros
 #
 # So, we add the flag directly instead.
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
 
-if(NOT (${CMAKE_VERSION} VERSION_LESS "2.8.0"))
-  find_program(CCACHE_PROGRAM ccache)
-  if(CCACHE_PROGRAM)
-    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
-  endif()
+find_program(CCACHE_PROGRAM ccache)
+if(CCACHE_PROGRAM)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")
 endif()
 
 # Add extra CMake libraries into ./CMake


### PR DESCRIPTION
Switching cmake from v2 to v3 helps avoid some hacks in our CMakeLists.txt.
It also fixes some problems in finding BOOST.
I picked 3.5.1 (from 2016) because it was shipped with ubuntu 16.04. The most recent version is 3.22.

Most linux cluster should have a recent cmake available using i.e. `module add cmake`.

Based on the monthly meeting today, I think we have consensus on increasing the minimum version to v3.