### PR TITLE
Refactor codon models

### DIFF
--- a/help/md/fnCodonGY94.md
+++ b/help/md/fnCodonGY94.md
@@ -23,7 +23,7 @@ frequencies to vary independently.
 ## details
 ## authors
 ## see_also
-fnF1x4, fnF3x4
+fnF1x4, fnF3x4, fnCodonMG94
 
 ## example
         kappa ~ dnLognormal(0,1)

--- a/help/md/fnCodonGY94.md
+++ b/help/md/fnCodonGY94.md
@@ -23,7 +23,7 @@ frequencies to vary independently.
 ## details
 ## authors
 ## see_also
-fnF1x4, fnF3x4, fnCodonMG94
+fnF1x4, fnF3x4, fnCodonMG94, fnCodonMG94K
 
 ## example
         kappa ~ dnLognormal(0,1)

--- a/help/md/fnCodonMG94.md
+++ b/help/md/fnCodonMG94.md
@@ -1,0 +1,35 @@
+## name
+fnCodonMG94
+
+## title
+The Muse-Gaut (1994) codon rate matrix
+
+## description
+The Muse-Gaut (1994) codon model.
+
+A rate matrix on the 61 non-stop codons (in the standard genetic code).
+
+Rates between codons with more than one nucleotide change are equal to 0.
+
+In this model the rate Q(i,j) from i -> j is proportional to the frequency of
+nucleotide in codon j that changed.  This differs from the Goldman-Yang (1994) model,
+where Q(i,j) is proportional to the frequency of the entire codon j.
+
+Unlike the Goldman-Yang (1994) model, the Muse-Gaut (1994) model does not allow all the codon
+frequencies to vary independently.
+
+## details
+## authors
+## see_also
+fnCodonGY94
+
+## example
+        omega ~ dnUniform(0,1)
+        pi ~ dnDirichlet( rep(2.0, 4) )
+        Q := fnCodonMG94( omega, pi )
+
+## references
+- citation: Muse, S. and B. Gaut (1994) A likelihood approach for comparing synonymous and nonsynonymous
+      nucleotide substitution rates, with application to the chloroplast genome. Mol. Biol. Evol. (1994) 11 (5):715-724
+  doi: https://doi.org/10.1093/oxfordjournals.molbev.a040152
+   

--- a/help/md/fnCodonMG94.md
+++ b/help/md/fnCodonMG94.md
@@ -21,12 +21,14 @@ frequencies to vary independently.
 ## details
 ## authors
 ## see_also
-fnCodonGY94, fnCodonMG94K
+fnCodonMG94, fnCodonMG94K
 
 ## example
         omega ~ dnUniform(0,1)
         pi ~ dnDirichlet( rep(2.0, 4) )
-        Q := fnCodonMG94( omega, pi )
+        Q1 := fnCodonMG94( omega, pi )
+
+        Q2 := fndNdS( omega, fnX3( fnF81(pi) ) ) # MG94 = F81 + X3 + dNdS
 
 ## references
 - citation: Muse, S. and B. Gaut (1994) A likelihood approach for comparing synonymous and nonsynonymous

--- a/help/md/fnCodonMG94K.md
+++ b/help/md/fnCodonMG94K.md
@@ -1,11 +1,11 @@
 ## name
-fnCodonMG94
+fnCodonMG94K
 
 ## title
-The Muse-Gaut (1994) codon rate matrix
+The Muse-Gaut (1994) codon rate matrix + K.
 
 ## description
-The Muse-Gaut (1994) codon model.
+The Muse-Gaut (1994) codon model, extended with a transition/transversion rate ratio.
 
 A rate matrix on the 61 non-stop codons (in the standard genetic code).
 
@@ -14,6 +14,9 @@ Rates between codons with more than one nucleotide change are equal to 0.
 In this model the rate Q(i,j) from i -> j is proportional to the frequency of
 nucleotide in codon j that changed.  This differs from the Goldman-Yang (1994) model,
 where Q(i,j) is proportional to the frequency of the entire codon j.
+
+This version is an extension of the fnCodonMG94 model to add a transition/transversion
+rate ratio.  This makes it more comparable to the Goldman-Yang (1994) model.
 
 Unlike the Goldman-Yang (1994) model, the Muse-Gaut (1994) model does not allow all the codon
 frequencies to vary independently.
@@ -24,9 +27,10 @@ frequencies to vary independently.
 fnCodonGY94, fnCodonMG94K
 
 ## example
+        kappa ~ dnLognormal(0,1)
         omega ~ dnUniform(0,1)
         pi ~ dnDirichlet( rep(2.0, 4) )
-        Q := fnCodonMG94( omega, pi )
+        Q := fnCodonMG94K( kappa, omega, pi )
 
 ## references
 - citation: Muse, S. and B. Gaut (1994) A likelihood approach for comparing synonymous and nonsynonymous

--- a/help/md/fnCodonMG94K.md
+++ b/help/md/fnCodonMG94K.md
@@ -30,7 +30,9 @@ fnCodonGY94, fnCodonMG94K
         kappa ~ dnLognormal(0,1)
         omega ~ dnUniform(0,1)
         pi ~ dnDirichlet( rep(2.0, 4) )
-        Q := fnCodonMG94K( kappa, omega, pi )
+        Q1 := fnCodonMG94K( kappa, omega, pi )
+
+        Q2 := fndNdS( omega, fnX3( fnHKY( kappa, pi) ) ) # MG94K = HKY + X3 + dNdS
 
 ## references
 - citation: Muse, S. and B. Gaut (1994) A likelihood approach for comparing synonymous and nonsynonymous

--- a/help/md/fnF2x4.md
+++ b/help/md/fnF2x4.md
@@ -1,0 +1,23 @@
+## name
+fnF2x4
+
+## title
+The F2x4 doublet frequency model
+
+## description
+This treats doublet frequencies as a product of independent nucleotide frequencies.
+
+## details
+## authors
+## see_also
+fnX2
+
+## example
+        # An RNA stem model with independent base frequencies (from fnF2x4),
+        # and simultaneous 2-nucleotide changes allows.
+        nuc_pi ~ dnDirichlet( v(2.0, 2.0, 2.0, 2.0) )
+        rna_stem_er ~ dnDirichlet( rep(1.0, 16*15/2) )
+        rna_stem_pi := fnF2x4(nuc_pi, nuc_pi)
+        Q := fnGTR(rna_stem_er, rna_stem_pi)
+
+## references

--- a/help/md/fnFMutSel.md
+++ b/help/md/fnFMutSel.md
@@ -1,16 +1,19 @@
 ## name
-fnMutSel
+fnFMutSel
 
 ## title
-Add mutation-selection balance to a rate matrix.
+The FMutSel model
 
 ## description
-Constructs a rate matrix from scaled selection coefficients w[i] and
-mutation rate matrix mu(i,j).
+Constructs a rate matrix from 61 scaled selection coefficients w[i] and
+a 4x4 nucleotide mutation rate matrix mu(i,j).  In the original paper
+the nucleotide mutation rate matrix is a GTR rate matrix.
 
-fnMutSel takes 61 scaled selection coefficients, one for each codon.
-This differs from fnMutSelAA, which takes 20 scaled selection coefficients,
-one for each amino acid.
+The FMutSel0 model differs from FMutSel by constraining all codons for
+the same amino acid to have the same scaled selection coefficient.
+
+The function fnMutSel differs from fnFMutSel by taking a codon mutation
+rate matrix.
 
 A substitution from allele i -> j can be decomposed into
  (1) all individuals initially have state i
@@ -27,13 +30,18 @@ and the initial frequency 1/N of allele j.
 ## details
 ## authors
 ## see_also
-fnCodonGY94, fnCodonMG94, fnX3, fndNdS, fnMutSelAA
+fnCodonGY94, fnCodonMG94, fnFMutSel0, fnMutSel
 
 ## example
         er ~ dnDirichlet( v(1,1,1,1,1,1) )
         nuc_pi ~ dnDirichlet( rep(2.0, 4) )
         F ~ dnIID(61, dnNormal(0,1))
-        Q := fnMutSel(F, fnX3( fnGTR(er,nuc_pi) ) )   # GTR + X3 + MutSel
+        omega ~ dnUniform(0,1)
+        # The FMutSel model from Yang and Nielsen (2008)        
+        Q1 := fnFMutSel(F, omega, fnGTR(er, nuc_pi))
+
+        # The same -- fMutSel = GTR(er,nuc_pi) + X3 + MutSel(F) + dNdS(omega)
+        Q2 := fndNdS(omega, fnMutSel(F, fnX3( fnGTR(er, nuc_pi))))
 
 ## references
 - citation: Yang, Z. and R. Nielsen. Mutation-Selection Models of Codon Substitution and Their Use to Estimate

--- a/help/md/fnFMutSel0.md
+++ b/help/md/fnFMutSel0.md
@@ -1,16 +1,20 @@
 ## name
-fnMutSel
+fnFMutSel0
 
 ## title
-Add mutation-selection balance to a rate matrix.
+The FMutSel0 model
 
 ## description
-Constructs a rate matrix from scaled selection coefficients w[i] and
-mutation rate matrix mu(i,j).
+Constructs a rate matrix from 61 scaled selection coefficients w[i] and
+a 4x4 nucleotide mutation rate matrix mu(i,j).  In the original paper
+the nucleotide mutation rate matrix is a GTR rate matrix.
 
-fnMutSel takes 61 scaled selection coefficients, one for each codon.
-This differs from fnMutSelAA, which takes 20 scaled selection coefficients,
-one for each amino acid.
+The FMutSel0 model is a restriction of the FMutSel model that constrains
+all codons for the same amino acid to have the same scaled selection
+coefficient.
+
+The function fnMutSelAA differs from fnFMutSel0 by taking a codon mutation
+rate matrix.
 
 A substitution from allele i -> j can be decomposed into
  (1) all individuals initially have state i
@@ -27,13 +31,18 @@ and the initial frequency 1/N of allele j.
 ## details
 ## authors
 ## see_also
-fnCodonGY94, fnCodonMG94, fnX3, fndNdS, fnMutSelAA
+fnCodonGY94, fnCodonMG94, fnFMutSel0, fnMutSel
 
 ## example
         er ~ dnDirichlet( v(1,1,1,1,1,1) )
         nuc_pi ~ dnDirichlet( rep(2.0, 4) )
-        F ~ dnIID(61, dnNormal(0,1))
-        Q := fnMutSel(F, fnX3( fnGTR(er,nuc_pi) ) )   # GTR + X3 + MutSel
+        F ~ dnIID(20, dnNormal(0,1))
+        omega ~ dnUniform(0,1)
+        # The FMutSel0 model from Yang and Nielsen (2008)        
+        Q1 := fnFMutSel0(F, omega, fnGTR(er, nuc_pi))
+
+        # The same -- fMutSel0 = GTR(er,nuc_pi) + X3 + MutSel(F) + dNdS(omega)
+        Q2 := fndNdS(omega, fnMutSelAA(F, fnX3( fnGTR(er, nuc_pi))))
 
 ## references
 - citation: Yang, Z. and R. Nielsen. Mutation-Selection Models of Codon Substitution and Their Use to Estimate

--- a/help/md/fnMutSel.md
+++ b/help/md/fnMutSel.md
@@ -1,0 +1,37 @@
+## name
+fnMutSel
+
+## title
+Add mutation-selection balance to a rate matrix.
+
+## description
+Constructs a rate matrix from scaled selection coefficients w[i] and
+mutation rate matrix mu(i,j).
+
+A substitution from allele i -> j can be decomposed into
+ (1) all individuals initially have state i
+ (2) a single individual mutates from i -> j, at rate mu(i,j)
+ (3) the allele j goes to fixation
+
+Then the substitution rate Q is then given by
+  Q(i,j) = mu(i,j) * Pr(j goes to fixation | i was fixed previously).
+
+The probability of fixation is determined by scaled selection coefficients:
+  w[i] = 2*N*s[i]
+and the initial frequency 1/N of allele j.
+
+## details
+## authors
+## see_also
+fnCodonGY94, fnCodonMG94, fnX3, fndNdS
+
+## example
+        er ~ dnDirichlet( v(1,1,1,1,1,1) )
+        nuc_pi ~ dnDirichlet( rep(2.0, 4) )
+        w ~ dnIID(61, dnNormal(0,1))
+        Q := fnMutSel(w, fnX3( fnGTR(er,nuc_pi) ) )   # GTR + X3 + MutSel
+
+## references
+- citation: Yang, Z. and R. Nielsen. Mutation-Selection Models of Codon Substitution and Their Use to Estimate
+      Selective Strengths on Codon Usage.  Mol. Biol. Evol. (2008) 25(3):568--579
+  doi: https://doi.org/10.1093/molbev/msm284

--- a/help/md/fnMutSel.md
+++ b/help/md/fnMutSel.md
@@ -27,13 +27,17 @@ and the initial frequency 1/N of allele j.
 ## details
 ## authors
 ## see_also
-fnCodonGY94, fnCodonMG94, fnX3, fndNdS, fnMutSelAA
+fnCodonGY94, fnCodonMG94, fnMutSelAA, fnFMutSel, fndNdS
 
 ## example
         er ~ dnDirichlet( v(1,1,1,1,1,1) )
         nuc_pi ~ dnDirichlet( rep(2.0, 4) )
         F ~ dnIID(61, dnNormal(0,1))
         Q := fnMutSel(F, fnX3( fnGTR(er,nuc_pi) ) )   # GTR + X3 + MutSel
+
+        # A mutation-selection balance model on RNA, with GTR mutation.
+        F2 ~ dnIID(16, dnNormal(0,1))
+        Q2 := fnMutSel(F2, fnX2( fnGTR(er,nuc_pi) ) ) # GTR + X2 + MutSel
 
 ## references
 - citation: Yang, Z. and R. Nielsen. Mutation-Selection Models of Codon Substitution and Their Use to Estimate

--- a/help/md/fnMutSelAA.md
+++ b/help/md/fnMutSelAA.md
@@ -1,16 +1,17 @@
 ## name
-fnMutSel
+fnMutSelAA
 
 ## title
-Add mutation-selection balance to a rate matrix.
+Add mutation-selection balance to a rate matrix -- fitnesses on amino acids
 
 ## description
 Constructs a rate matrix from scaled selection coefficients w[i] and
 mutation rate matrix mu(i,j).
 
-fnMutSel takes 61 scaled selection coefficients, one for each codon.
-This differs from fnMutSelAA, which takes 20 scaled selection coefficients,
-one for each amino acid.
+fnMutSelAA takes 20 scaled selection coefficients, one for each amino acid.
+This differs from fnMutSel, which takes 61 scaled selection coefficients,
+one for each codon.  fnMutSelAA assumes that codons for the same amino acid
+have the same fitness.
 
 A substitution from allele i -> j can be decomposed into
  (1) all individuals initially have state i
@@ -21,21 +22,22 @@ Then the substitution rate Q is then given by
   Q(i,j) = mu(i,j) * Pr(j goes to fixation | i was fixed previously).
 
 The probability of fixation is determined by scaled selection coefficients:
-  w[i] = 2*N*s[i]
+  F[i] = 2*N*s[i]
 and the initial frequency 1/N of allele j.
 
 ## details
 ## authors
 ## see_also
-fnCodonGY94, fnCodonMG94, fnX3, fndNdS, fnMutSelAA
+fnCodonGY94, fnCodonMG94, fnX3, fndNdS, fnMutSel
 
 ## example
         er ~ dnDirichlet( v(1,1,1,1,1,1) )
         nuc_pi ~ dnDirichlet( rep(2.0, 4) )
-        w ~ dnIID(61, dnNormal(0,1))
-        Q := fnMutSel(w, fnX3( fnGTR(er,nuc_pi) ) )   # GTR + X3 + MutSel
+        F ~ dnIID(61, dnNormal(0,1))
+        Q := fnMutSel(F, fnX3( fnGTR(er,nuc_pi) ) )   # GTR + X3 + MutSel
 
 ## references
-- citation: Yang, Z. and R. Nielsen. Mutation-Selection Models of Codon Substitution and Their Use to Estimate
-      Selective Strengths on Codon Usage.  Mol. Biol. Evol. (2008) 25(3):568--579
+- citation: Yang, Z. and R. Nielsen. Mutation-Selection Models of Codon
+      Substitution and Their Use to Estimate Selective Strengths on Codon
+      Usage.  Mol. Biol. Evol. (2008) 25(3):568--579
   doi: https://doi.org/10.1093/molbev/msm284

--- a/help/md/fnX2.md
+++ b/help/md/fnX2.md
@@ -1,0 +1,31 @@
+## name
+fnX2
+
+## title
+Construct a doublet (16x16) rate matrix from a nucleotide rate matrix.
+
+## description
+Constructs a double rate matrix on the 16 nucleotide pairs.
+
+Rates of change from nucleotide i -> j at each doublet position are given by the
+nucleotide rate matrix.  The rate of 2 simultaneous changes is 0.
+
+The X3 function can be used to constructor rate matrices on doublets in a
+modular fashion.
+
+## details
+## authors
+## see_also
+fnX3
+
+## example
+
+        kappa ~ dnLognormal(0,1)
+        nuc_pi ~ dnDirichlet( rep(2.0, 4) )
+        # Mutation rate matrix on RNA stems
+        Q1 := fnX2( fnHKY(kappa, nuc_pi) )
+        F ~ dnIID(16, dnNormal(0,1))
+        # Add selection to the rate matrix
+        Q2 := fnMutSel(F, Q1)
+
+## references

--- a/help/md/fnX3.md
+++ b/help/md/fnX3.md
@@ -10,7 +10,7 @@ Constructs a rate matrix on the 61 non-stop codons (in the standard genetic code
 Rates of change from nucleotide i -> j at each codon position are given by the
 nucleotide rate matrix.  The rate of 2 or 3 simultaneous changes is 0.
 
-The X3 function can be used to constructor other rate matrices in a modular fashion.
+The X3 function can be used to construct other rate matrices in a modular fashion.
 For example:
   (i)  MG94  = F81 + X3 + dNdS
   (ii) MG94K = HKY85 + X3 + dNdS
@@ -33,6 +33,6 @@ fnCodonGY94, fnCodonMG94K, fndNdS
         Q3 := fnX3(fnGTR(er,nuc_pi))      # GTR + X3, or GTR*3
 
 ## references
-- citation: Redelings, BD (2021). RedelingsBAli-Phy version 3: Model-based co-estimation of Alignment
+- citation: Redelings, BD (2021). BAli-Phy version 3: Model-based co-estimation of Alignment
        and Phylogeny.  Bioinformatics (2021) 37(10):3032–3034.
   doi: https://doi.org/10.1093/bioinformatics/btab129

--- a/help/md/fnX3.md
+++ b/help/md/fnX3.md
@@ -1,0 +1,30 @@
+## name
+fnX3
+
+## title
+Construct a codon rate matrix from a nucleotide rate matrix.
+
+## description
+Constructs a rate matrix on the 61 non-stop codons (in the standard genetic code).
+
+Rates of change from nucleotide i -> j at each codon position are given by the
+nucleotide rate matrix.  The rate of 2 or 3 simultaneous changes is 0.
+
+## details
+## authors
+## see_also
+fnCodonGY94, fnCodonMG94K
+
+## example
+
+        kappa ~ dnLognormal(0,1)
+        nuc_pi ~ dnDirichlet( rep(2.0, 4) )
+        Q1 := fnCodonMG94K( kappa, 1.0, nuc_pi )
+        # This is the same.
+        Q2 := fnX3(fnHKY(k,nuc_pi))   # HKY + X3, or HKY*3
+
+        er ~ dnDirichlet( v(1,1,1,1,1,1) )
+        Q3 := fnX3(fnGTR(er,pi))      # GTR + X3, or GTR*3
+
+## references
+   

--- a/help/md/fndNdS.md
+++ b/help/md/fndNdS.md
@@ -21,7 +21,7 @@ For example:
 ## details
 ## authors
 ## see_also
-fnCodonGY94, fnCodonMG94K, fnX3
+fnCodonGY94, fnCodonMG94K, fnX3, fnMutSel
 
 ## example
 

--- a/help/md/fndNdS.md
+++ b/help/md/fndNdS.md
@@ -1,16 +1,19 @@
 ## name
-fnX3
+fndNdS
 
 ## title
-Construct a codon rate matrix from a nucleotide rate matrix.
+Add a dN/dS factor to a codon rate matrix.
 
 ## description
 Constructs a rate matrix on the 61 non-stop codons (in the standard genetic code).
 
-Rates of change from nucleotide i -> j at each codon position are given by the
-nucleotide rate matrix.  The rate of 2 or 3 simultaneous changes is 0.
+   Q(i,j) = Q'(i,j) * omega if aa(i) != aa(j)
+                    * 1     if aa(i) == aa(j)
 
-The X3 function can be used to constructor other rate matrices in a modular fashion.
+where aa(i) gives the amino acid for codon i in the standard genetic code, and
+Q'(i,j) is the input rate matrix on codons.
+
+The dNdS function can be used to construct other rate matrices in a modular fashion.
 For example:
   (i)  MG94  = F81 + X3 + dNdS
   (ii) MG94K = HKY85 + X3 + dNdS
@@ -18,7 +21,7 @@ For example:
 ## details
 ## authors
 ## see_also
-fnCodonGY94, fnCodonMG94K, fndNdS
+fnCodonGY94, fnCodonMG94K, fnX3
 
 ## example
 

--- a/help/md2help.pl
+++ b/help/md2help.pl
@@ -78,7 +78,14 @@ sub parse_entry {
                             my @lines = split(/\n/,$ret);
                             foreach my $line (@lines)
                             {
-                                $line = substr($line,$indent);
+                                if ($indent < length($line))
+                                {
+                                    $line = substr($line,$indent)
+                                }
+                                else
+                                {
+                                    $line = "";
+                                }
                                 $line =~ s/\s*$//s;
                             }
                             $ret = join("\n",@lines);

--- a/projects/meson/generate_sources.sh
+++ b/projects/meson/generate_sources.sh
@@ -14,11 +14,11 @@ echo "${DIR}_sources = files([" > meson.build
 find . -name '*.cpp' |
     sed "s|^|'|" |
     sed "s|$|',|" |
-    grep -v '^\.' |
+    grep -v '/\.' |
     grep -v 'main.cpp' >> meson.build
 find . -name '*.c' |
     sed "s|^|'|" |
     sed "s|$|',|" |
-    grep -v '^\.' >> meson.build
+    grep -v '/\.' >> meson.build
 echo "])" >> meson.build
 echo >> meson.build

--- a/src/core/datatypes/phylogenetics/ratematrix/ConcreteTimeReversibleRateMatrix.h
+++ b/src/core/datatypes/phylogenetics/ratematrix/ConcreteTimeReversibleRateMatrix.h
@@ -22,6 +22,8 @@ namespace RevBayesCore {
 
     public:
         ConcreteTimeReversibleRateMatrix(const std::vector<double>& er, const std::vector<double>& pi);
+        ConcreteTimeReversibleRateMatrix(const MatrixReal& ER, const std::vector<double>& pi);
+
         ConcreteTimeReversibleRateMatrix(const ConcreteTimeReversibleRateMatrix& m) = default;
 
         // RateMatrix functions
@@ -32,6 +34,9 @@ namespace RevBayesCore {
 
         void                                                    update(void);
     };
+
+    std::vector<double> compute_flattened_exchange_rates( const MatrixReal& Q, const std::vector<double>& pi);
+    std::vector<double> flatten_exchange_rates( const MatrixReal& ER );
 }
 
 #endif

--- a/src/core/functions/GenericFunction.h
+++ b/src/core/functions/GenericFunction.h
@@ -133,9 +133,9 @@ namespace RevBayesCore
     template <class F, class ArgTuple>
     auto InvokeFunction(F* func, const ArgTuple& args_tuple)
     {
-        // 1. Get the argument values
+        // 1. Get the argument values -- BY REFERENCE.
         // for each i: get<i>(values) = get<i>(arguments)->getValue()
-        auto values = boost::mp11::tuple_transform([](auto& node) {return node->getValue();}, args_tuple);
+        auto values = boost::mp11::tuple_transform([](auto& node) ->decltype(auto) {return node->getValue();}, args_tuple);
 
         // 2. Then call the function and store the result.
         // *value = func( get<0>(values), get<1>(values), get<2>(values), ...)
@@ -146,9 +146,9 @@ namespace RevBayesCore
     template <class F, class ArgTuple>
     auto InvokeFunction(const F& func, const ArgTuple& args_tuple)
     {
-        // 1. Get the argument values
+        // 1. Get the argument values -- BY REFERENCE.
         // for each i: get<i>(values) = get<i>(arguments)->getValue()
-        auto values = boost::mp11::tuple_transform([](auto& node) {return node->getValue();}, args_tuple);
+        auto values = boost::mp11::tuple_transform([](auto& node) -> decltype(auto) {return node->getValue();}, args_tuple);
 
         // 2. Then call the function and store the result.
         // *value = func( get<0>(values), get<1>(values), get<2>(values), ...)

--- a/src/core/functions/phylogenetics/ratematrix/CppCodonFuncs.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/CppCodonFuncs.cpp
@@ -339,17 +339,39 @@ Simplex MutSelPi(const vector<double>& pi0, const vector<double>& F0)
     return Simplex(pi);
 }
 
+vector<double> aa_to_codon(const vector<double>& x_aa)
+{
+    assert(x_aa.size() == 20);
+
+    vector<double> x_codon(61);
+
+    for(int i=0;i<x_codon.size();i++)
+    {
+        CodonState c = CodonState( CodonState::CODONS[i] );
+        AminoAcidState aa = c.getAminoAcidState();
+        int j = aa.getStateIndex();
+        x_codon[i] = x_aa[j];
+    }
+
+    return x_codon;
+}
+
 CGTR MutSel(const TimeReversibleRateMatrix& Q1, const vector<double>& F)
 {
     auto Q2 = MutSelQ( Q1.getRateMatrix(), F);
 
     auto pi2 = MutSelPi( Q1.getStationaryFrequencies(), F );
 
-    auto Q_out =CGTR( compute_flattened_exchange_rates(Q2,pi2), pi2);
+    auto Q_out = CGTR( compute_flattened_exchange_rates(Q2,pi2), pi2);
 
     Q_out.rescaleToAverageRate(3.0);
 
     return Q_out;
+}
+
+CGTR MutSelAA(const TimeReversibleRateMatrix& Q1, const vector<double>& FAA)
+{
+    return MutSel(Q1, aa_to_codon(FAA) );
 }
 
 

--- a/src/core/functions/phylogenetics/ratematrix/CppCodonFuncs.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/CppCodonFuncs.cpp
@@ -1,0 +1,356 @@
+#include "CppCodonFuncs.h"
+
+#include "AminoAcidState.h"
+#include "CodonState.h"
+
+using std::vector;
+
+namespace RevBayesCore
+{
+
+bool is_transition_mut(int i, int j)
+{
+    assert(i != j);
+
+    if (i > j) std::swap(i,j);
+
+    if (i == 0 and j == 2) return true; // A <-> G
+
+    if (i == 1 and j == 3) return true; // C <-> T
+
+    return false;
+}
+
+bool is_transversion_mut(int i, int j)
+{
+    return not is_transition_mut(i,j);
+}
+
+int n_different_nucs(const vector<unsigned int>& codon_from, const vector<unsigned int>& codon_to)
+{
+    assert(codon_from.size() == 3);
+    assert(codon_to.size() == 3);
+
+    int count = 0;
+    for(int i=0;i<3;i++)
+        if (codon_from[i] != codon_to[i])
+            count++;
+
+    return count;
+}
+
+std::tuple<int,int,int> triplet_single_nuc_mut(const vector<unsigned int>& codon_from, const vector<unsigned int>& codon_to)
+{
+    assert(n_different_nucs(codon_from, codon_to) == 1);
+
+    for(int i=0; i<3; i++)
+    {
+        if (codon_from[i] != codon_to[i])
+            return std::tuple<int,int,int>(codon_from[i], codon_to[i], i);
+    }
+
+    // This should never happen!
+    throw RbException("triplet_single_nuc_mut: codons are the same!  This should never happen.");
+}
+
+Simplex F3x4(const Simplex& nuc_pi1,
+             const Simplex& nuc_pi2,
+             const Simplex& nuc_pi3)
+{
+    using RevBayesCore::CodonState;
+
+    assert(nuc_pi1.size() == 4);
+    assert(nuc_pi2.size() == 4);
+    assert(nuc_pi3.size() == 4);
+
+    std::vector<double> codon_pi(61);
+
+    for(int i=0;i<codon_pi.size();i++)
+    {
+        CodonState c = CodonState( CodonState::CODONS[i] );
+        std::vector<unsigned int> codon = c.getTripletStates();
+        int n1 = codon[0];
+        int n2 = codon[1];
+        int n3 = codon[2];
+
+        codon_pi[i] = nuc_pi1[n1] * nuc_pi2[n2] * nuc_pi3[n3];
+    }
+
+    // This line renormalizes the frequencies to sum to 1.0.
+    return Simplex(codon_pi);
+}
+
+Simplex F1x4(const Simplex& nuc_pi)
+{
+    return F3x4(nuc_pi, nuc_pi, nuc_pi);
+}
+
+MatrixReal singlet_to_triplet_rates(const MatrixReal& q1, const MatrixReal& q2, const MatrixReal& q3)
+{
+    constexpr int num_states = 61;
+    MatrixReal Q(num_states);
+
+    for (size_t i=0; i<num_states; ++i)
+    {
+        CodonState c1 = CodonState( CodonState::CODONS[i] );
+        vector<unsigned int> codon_from = c1.getTripletStates();
+
+        for (size_t j=0; j<num_states; ++j)
+        {
+            CodonState c2 = CodonState( CodonState::CODONS[j] );
+            vector<unsigned int> codon_to = c2.getTripletStates();
+
+            int n_diff_nucs = n_different_nucs(codon_from, codon_to);
+
+            assert(n_diff_nucs >= 0);
+
+            // The rate is zero for more than one nucleotide change.
+            double rate = 0.0;
+
+            if (n_diff_nucs == 1)
+            {
+                auto changed_nucs = triplet_single_nuc_mut(codon_from, codon_to);
+                int from_nuc = std::get<0>(changed_nucs);
+                int to_nuc = std::get<1>(changed_nucs);
+                int pos = std::get<2>(changed_nucs);
+
+                if (pos == 0)
+                    rate = q1[ from_nuc ][ to_nuc ];
+                else if (pos == 1)
+                    rate = q2[ from_nuc ][ to_nuc ];
+                else if (pos == 2)
+                    rate = q3[ from_nuc ][ to_nuc ];
+                else
+                    std::abort(); // this can't happen.
+            }
+
+            Q[i][j] = rate;
+        }
+    }
+
+    return Q;
+}
+
+CGTR X3X3(const TimeReversibleRateMatrix& q1, const TimeReversibleRateMatrix& q2, const TimeReversibleRateMatrix& q3)
+{
+    MatrixReal Q = singlet_to_triplet_rates( q1.getRateMatrix(), q2.getRateMatrix(), q3.getRateMatrix() );
+    vector<double> pi = F3x4( q1.getStationaryFrequencies(), q2.getStationaryFrequencies(), q3.getStationaryFrequencies() );
+
+    auto QQ = CGTR( compute_flattened_exchange_rates(Q,pi), pi);
+    QQ.rescaleToAverageRate(3.0);
+    return QQ;
+}
+
+CGTR X3(const TimeReversibleRateMatrix& q)
+{
+    return X3X3(q,q,q);
+}
+
+MatrixReal dNdS(double omega, const MatrixReal& Q1)
+{
+    constexpr int num_states = 61;
+
+    assert(Q1.getNumberOfRows() == 61);
+    assert(Q1.getNumberOfColumns() == 61);
+
+    MatrixReal Q2 = Q1;
+
+    for (size_t i=0; i<num_states; ++i)
+    {
+        CodonState c1 = CodonState( CodonState::CODONS[i] );
+        vector<unsigned int> codon_from = c1.getTripletStates();
+        AminoAcidState aa_from = c1.getAminoAcidState();
+
+        for (size_t j=0; j<num_states; ++j)
+        {
+            CodonState c2 = CodonState( CodonState::CODONS[j] );
+            vector<unsigned int> codon_to = c2.getTripletStates();
+            AminoAcidState aa_to = c2.getAminoAcidState();
+
+            // A factor of `omega` for an amino-acid difference.
+            if (aa_from != aa_to)  Q2[i][j] *= omega;
+        }
+    }
+
+    return Q2;
+}
+
+CGTR dNdS(double omega, const TimeReversibleRateMatrix& q1)
+{
+    constexpr int num_states = 61;
+
+    auto Q2 = dNdS(omega, q1.getRateMatrix());
+
+    // This doesn't change the stationary frequencies.
+    auto pi = q1.getStationaryFrequencies();
+
+    auto Q3 = CGTR( compute_flattened_exchange_rates(Q2,pi), pi);
+    Q3.rescaleToAverageRate(3.0);
+    return Q3;
+}
+
+CGTR MG94_extended(double omega, const TimeReversibleRateMatrix& qnuc)
+{
+    return dNdS(omega,X3(qnuc));
+}
+
+MatrixReal F81_ER(int n)
+{
+    MatrixReal ER(n);
+    for(int i=0;i<n;i++)
+        for(int j=0;j<n;j++)
+            ER[i][j] = 1.0;
+    return ER;
+}
+
+CGTR F81(const vector<double>& pi)
+{
+    int n = pi.size();
+    return CGTR( flatten_exchange_rates(F81_ER(n)), pi );
+}
+
+MatrixReal HKY85_ER(double k)
+{
+    constexpr int n = 4;
+
+    MatrixReal ER(n);
+    for(int i=0;i<n;i++)
+        for(int j=0;j<n;j++)
+            ER[i][j] = is_transition_mut(i,j) ? k : 1.0;
+
+    return ER;
+}
+
+CGTR HKY85(double k, const vector<double>& pi)
+{
+    auto ER = HKY85_ER(k);
+    return CGTR( RevBayesCore::flatten_exchange_rates(ER), pi);
+}
+
+CGTR MG94(double omega, const vector<double>& pi)
+{
+    assert(pi.size() == 4);
+    auto Q = MG94_extended(omega,F81(pi));
+    Q.rescaleToAverageRate(3.0);
+    return Q;
+}
+
+CGTR MG94K(double k, double omega, const vector<double>& pi)
+{
+    assert(pi.size() == 4);
+    auto Q = MG94_extended(omega,HKY85(k,pi));
+    Q.rescaleToAverageRate(3.0);
+    return Q;
+}
+
+CGTR GY94_extended(const MatrixReal& ER_nuc, double omega, const vector<double>& pi)
+{
+    auto ER_codon = dNdS(omega, singlet_to_triplet_rates(ER_nuc, ER_nuc, ER_nuc));
+
+    auto Q = CGTR( ER_codon, pi);
+    Q.rescaleToAverageRate(3.0);
+    return Q;
+}
+
+CGTR GY94(double kappa, double omega, const vector<double>& pi)
+{
+    return GY94_extended(HKY85_ER(kappa), omega, pi);
+}
+
+double bound(double min, double max, double x)
+{
+    assert(min <= max);
+    if (x < min) return min;
+    if (x > max) return max;
+    return x;
+}
+
+vector<double> bound(double min, double max, vector<double> xs)
+{
+    for(auto& x: xs)
+        x = bound(min, max, x);
+    return xs;
+}
+
+// Q0 w
+// Here S[I,J] = F[J] - F[I] = 2Nf[j] - 2NF[i] = 2N*s[i,j]
+MatrixReal MutSelQ(const MatrixReal& Q0, const vector<double>& F0)
+{
+    assert( Q0.getNumberOfColumns() == Q0.getNumberOfRows() );
+    int n = Q0.getNumberOfColumns();
+
+    auto F = bound(-20, 20, F0);
+
+    assert(F.size() == n);
+
+    MatrixReal Q(n);
+
+    for(int i=0;i<n;i++)
+    {
+	double sum = 0;
+	for(int j=0;j<n;j++)
+	{
+	    if (i==j) continue;
+
+	    double rate = Q0[i][j];
+
+	    // x = wj/wi    log(x)/(1-1/x)
+	    // y = wi/wj   -log(y)/(1-y)
+	    // 1+z = y     -log(1+z)/-z = log1p(z)/z   z = y-1 = (wi/wj)-1
+	    double S = F[j] - F[i];
+	    if (std::abs(S) < 0.0001)
+		rate *= ( 1.0 + S/2 + (S*S)/12 - (S*S*S*S)/720 );
+	    else
+		rate *= -S/expm1(-S);
+
+	    Q[i][j] = rate;
+
+	    sum += rate;
+	}
+	Q[i][i] = -sum;
+    }
+
+    return Q;
+}
+
+double max(const std::vector<double> xs)
+{
+    double m = xs[0];
+    for(int i=1;i<xs.size();i++)
+        m = std::max(m,xs[i]);
+    return m;
+}
+
+// pi0 w
+Simplex MutSelPi(const vector<double>& pi0, const vector<double>& F0)
+{
+    assert(pi0.size() == F0.size());
+
+    auto F = bound(-20, 20, F0);
+
+    // compute frequencies
+    vector<double> pi = pi0;
+
+    double Fmax = max(F);
+
+    for(int i=0; i<pi.size(); i++)
+	pi[i] *= exp(F[i]-Fmax);
+
+    return Simplex(pi);
+}
+
+CGTR MutSel(const TimeReversibleRateMatrix& Q1, const vector<double>& F)
+{
+    auto Q2 = MutSelQ( Q1.getRateMatrix(), F);
+
+    auto pi2 = MutSelPi( Q1.getStationaryFrequencies(), F );
+
+    auto Q_out =CGTR( compute_flattened_exchange_rates(Q2,pi2), pi2);
+
+    Q_out.rescaleToAverageRate(3.0);
+
+    return Q_out;
+}
+
+
+}

--- a/src/core/functions/phylogenetics/ratematrix/CppCodonFuncs.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/CppCodonFuncs.cpp
@@ -373,6 +373,15 @@ CGTR MutSelAA(const vector<double>& FAA, const TimeReversibleRateMatrix& Q)
 {
     return MutSel(aa_to_codon(FAA), Q);
 }
+
+CGTR FMutSel(const std::vector<double>& F, double omega, const TimeReversibleRateMatrix& Q)
+{
+    return dNdS(omega, MutSel(F, X3( Q ))); // Q + MutSel(F) + dNdS(omega)
+}
+
+CGTR FMutSel0(const std::vector<double>& F, double omega, const TimeReversibleRateMatrix& Q)
+{
+    return dNdS(omega, MutSelAA(F, X3( Q ))); // Q + MutSelAA(F) + dNdS(omega)
 }
 
 

--- a/src/core/functions/phylogenetics/ratematrix/CppCodonFuncs.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/CppCodonFuncs.cpp
@@ -356,7 +356,7 @@ vector<double> aa_to_codon(const vector<double>& x_aa)
     return x_codon;
 }
 
-CGTR MutSel(const TimeReversibleRateMatrix& Q1, const vector<double>& F)
+CGTR MutSel(const vector<double>& F, const TimeReversibleRateMatrix& Q1)
 {
     auto Q2 = MutSelQ( Q1.getRateMatrix(), F);
 
@@ -369,9 +369,10 @@ CGTR MutSel(const TimeReversibleRateMatrix& Q1, const vector<double>& F)
     return Q_out;
 }
 
-CGTR MutSelAA(const TimeReversibleRateMatrix& Q1, const vector<double>& FAA)
+CGTR MutSelAA(const vector<double>& FAA, const TimeReversibleRateMatrix& Q)
 {
-    return MutSel(Q1, aa_to_codon(FAA) );
+    return MutSel(aa_to_codon(FAA), Q);
+}
 }
 
 

--- a/src/core/functions/phylogenetics/ratematrix/CppCodonFuncs.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/CppCodonFuncs.cpp
@@ -26,31 +26,30 @@ bool is_transversion_mut(int i, int j)
     return not is_transition_mut(i,j);
 }
 
-int n_different_nucs(const vector<unsigned int>& codon_from, const vector<unsigned int>& codon_to)
+int n_different_nucs(const vector<unsigned int>& states_from, const vector<unsigned int>& states_to)
 {
-    assert(codon_from.size() == 3);
-    assert(codon_to.size() == 3);
+    assert(states_from.size() == states_to.size());
 
     int count = 0;
-    for(int i=0;i<3;i++)
-        if (codon_from[i] != codon_to[i])
+    for(int i=0;i<states_from.size();i++)
+        if (states_from[i] != states_to[i])
             count++;
 
     return count;
 }
 
-std::tuple<int,int,int> triplet_single_nuc_mut(const vector<unsigned int>& codon_from, const vector<unsigned int>& codon_to)
+std::tuple<int,int,int> single_nuc_mut(const vector<unsigned int>& states_from, const vector<unsigned int>& states_to)
 {
-    assert(n_different_nucs(codon_from, codon_to) == 1);
+    assert(n_different_nucs(states_from, states_to) == 1);
 
-    for(int i=0; i<3; i++)
+    for(int i=0; i<states_from.size(); i++)
     {
-        if (codon_from[i] != codon_to[i])
-            return std::tuple<int,int,int>(codon_from[i], codon_to[i], i);
+        if (states_from[i] != states_to[i])
+            return std::tuple<int,int,int>(states_from[i], states_to[i], i);
     }
 
     // This should never happen!
-    throw RbException("triplet_single_nuc_mut: codons are the same!  This should never happen.");
+    throw RbException("single_nuc_mut: codon/doublet/etc states are the same!  This should never happen.");
 }
 
 Simplex F3x4(const Simplex& nuc_pi1,
@@ -109,7 +108,7 @@ MatrixReal singlet_to_triplet_rates(const MatrixReal& q1, const MatrixReal& q2, 
 
             if (n_diff_nucs == 1)
             {
-                auto changed_nucs = triplet_single_nuc_mut(codon_from, codon_to);
+                auto changed_nucs = single_nuc_mut(codon_from, codon_to);
                 int from_nuc = std::get<0>(changed_nucs);
                 int to_nuc = std::get<1>(changed_nucs);
                 int pos = std::get<2>(changed_nucs);

--- a/src/core/functions/phylogenetics/ratematrix/CppCodonFuncs.h
+++ b/src/core/functions/phylogenetics/ratematrix/CppCodonFuncs.h
@@ -43,6 +43,8 @@ namespace RevBayesCore
     CGTR GY94(double kappa, double omega, const std::vector<double>& pi);
 
     CGTR MutSel(const TimeReversibleRateMatrix& Q, const std::vector<double>& F);
+
+    CGTR MutSelAA(const TimeReversibleRateMatrix& Q, const std::vector<double>& F);
 }
 
 

--- a/src/core/functions/phylogenetics/ratematrix/CppCodonFuncs.h
+++ b/src/core/functions/phylogenetics/ratematrix/CppCodonFuncs.h
@@ -1,0 +1,49 @@
+#ifndef CppCodonFuncs_H
+#define CppCodonFuncs_H
+
+#include "Simplex.h"
+#include "MatrixReal.h"
+#include "ConcreteTimeReversibleRateMatrix.h"
+
+namespace RevBayesCore
+{
+    typedef ConcreteTimeReversibleRateMatrix CGTR;
+
+    bool is_transition_mut(int i, int j);
+
+    bool is_transversion_mut(int i, int j);
+
+    int n_different_nucs(const std::vector<unsigned int>& codon_from, const std::vector<unsigned int>& codon_to);
+
+    Simplex F1x4(const RevBayesCore::Simplex& nuc_pi1);
+    Simplex F3x4(const RevBayesCore::Simplex& nuc_pi1, const RevBayesCore::Simplex& nuc_pi2, const RevBayesCore::Simplex& nuc_pi3);
+
+    CGTR X3X3(const TimeReversibleRateMatrix& q1, const TimeReversibleRateMatrix& q2, const TimeReversibleRateMatrix& q3);
+
+    CGTR X3(const TimeReversibleRateMatrix& q);
+
+    MatrixReal dNdS(double omega, const MatrixReal& Q1);
+
+    CGTR dNdS(double omega, const TimeReversibleRateMatrix& q1);
+
+    CGTR MG94_extended(double omega, const TimeReversibleRateMatrix& qnuc);
+
+    CGTR F81(const std::vector<double>& pi);
+
+    MatrixReal HKY85_ER(double k);
+
+    CGTR HKY85(double k, const std::vector<double>& pi);
+
+    CGTR MG94(double omega, const std::vector<double>& pi);
+
+    CGTR MG94K(double k, double omega, const std::vector<double>& pi);
+
+    CGTR GY94_extended(const MatrixReal& ER, double omega, const std::vector<double>& pi);
+
+    CGTR GY94(double kappa, double omega, const std::vector<double>& pi);
+
+    CGTR MutSel(const TimeReversibleRateMatrix& Q, const std::vector<double>& F);
+}
+
+
+#endif

--- a/src/core/functions/phylogenetics/ratematrix/CppCodonFuncs.h
+++ b/src/core/functions/phylogenetics/ratematrix/CppCodonFuncs.h
@@ -45,6 +45,10 @@ namespace RevBayesCore
     CGTR MutSel(const std::vector<double>& F, const TimeReversibleRateMatrix& Q);
 
     CGTR MutSelAA(const std::vector<double>& F, const TimeReversibleRateMatrix& Q);
+
+    CGTR FMutSel(const std::vector<double>& F, double omega, const TimeReversibleRateMatrix& Q);
+
+    CGTR FMutSel0(const std::vector<double>& F, double omega, const TimeReversibleRateMatrix& Q);
 }
 
 

--- a/src/core/functions/phylogenetics/ratematrix/CppCodonFuncs.h
+++ b/src/core/functions/phylogenetics/ratematrix/CppCodonFuncs.h
@@ -42,9 +42,9 @@ namespace RevBayesCore
 
     CGTR GY94(double kappa, double omega, const std::vector<double>& pi);
 
-    CGTR MutSel(const TimeReversibleRateMatrix& Q, const std::vector<double>& F);
+    CGTR MutSel(const std::vector<double>& F, const TimeReversibleRateMatrix& Q);
 
-    CGTR MutSelAA(const TimeReversibleRateMatrix& Q, const std::vector<double>& F);
+    CGTR MutSelAA(const std::vector<double>& F, const TimeReversibleRateMatrix& Q);
 }
 
 

--- a/src/core/functions/phylogenetics/ratematrix/CppDoubletFuncs.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/CppDoubletFuncs.cpp
@@ -1,0 +1,164 @@
+#include "CppDoubletFuncs.h"
+
+#include "AminoAcidState.h"
+#include "DoubletState.h"
+
+using std::vector;
+
+namespace RevBayesCore
+{
+
+std::tuple<int,int,int> single_nuc_mut(const vector<unsigned int>& states_from, const vector<unsigned int>& states_to);
+
+int n_different_nucs(const vector<unsigned int>& states_from, const vector<unsigned int>& states_to);
+
+Simplex F2x4(const Simplex& nuc_pi1,
+             const Simplex& nuc_pi2)
+{
+    using RevBayesCore::DoubletState;
+
+    assert(nuc_pi1.size() == 4);
+    assert(nuc_pi2.size() == 4);
+
+    std::vector<double> doublet_pi(16);
+
+    for(int i=0;i<doublet_pi.size();i++)
+    {
+        DoubletState c = DoubletState( DoubletState::DOUBLETS[i] );
+        std::vector<unsigned int> doublet = c.getDoubletStates();
+        int n1 = doublet[0];
+        int n2 = doublet[1];
+
+        doublet_pi[i] = nuc_pi1[n1] * nuc_pi2[n2];
+    }
+
+    // This line renormalizes the frequencies to sum to 1.0.
+    return Simplex(doublet_pi);
+}
+
+// No F1x4_doublets, because its different than F1x4_Codons
+    
+MatrixReal singlet_to_doublet_rates(const MatrixReal& q1, const MatrixReal& q2)
+{
+    constexpr int num_states = 16;
+    MatrixReal Q(num_states);
+
+    for (size_t i=0; i<num_states; ++i)
+    {
+        DoubletState c1 = DoubletState( DoubletState::DOUBLETS[i] );
+        vector<unsigned int> doublet_from = c1.getDoubletStates();
+
+        for (size_t j=0; j<num_states; ++j)
+        {
+            DoubletState c2 = DoubletState( DoubletState::DOUBLETS[j] );
+            vector<unsigned int> doublet_to = c2.getDoubletStates();
+
+            int n_diff_nucs = n_different_nucs(doublet_from, doublet_to);
+
+            assert(n_diff_nucs >= 0);
+
+            // The rate is zero for more than one nucleotide change.
+            double rate = 0.0;
+
+            if (n_diff_nucs == 1)
+            {
+                auto changed_nucs = single_nuc_mut(doublet_from, doublet_to);
+                int from_nuc = std::get<0>(changed_nucs);
+                int to_nuc = std::get<1>(changed_nucs);
+                int pos = std::get<2>(changed_nucs);
+
+                if (pos == 0)
+                    rate = q1[ from_nuc ][ to_nuc ];
+                else if (pos == 1)
+                    rate = q2[ from_nuc ][ to_nuc ];
+                else
+                    std::abort(); // this can't happen.
+            }
+
+            Q[i][j] = rate;
+        }
+    }
+
+    return Q;
+}
+
+// Unused generic version of F2x4, F3x4
+Simplex FN(const vector<Simplex*>& pis, int num_states, vector<unsigned int>(*get_states)(int))
+{
+    const int n = pis.size();
+    std::vector<double> pi(num_states);
+
+    for(int i=0;i<num_states;i++)
+    {
+        auto states = get_states(i);
+        assert(states.size() == n);
+
+        double freq = 1.0;
+        for(int k=0;k<n;k++)
+            freq *= (*pis[k])[states[k]];
+
+        pi[i] = freq;
+    }
+
+    // This line renormalizes the frequencies to sum to 1.0.
+    return Simplex(pi);
+}
+
+// Unused generic version of singlet_to_{doublet,triplet}_rates
+MatrixReal singlet_to_multi_rates(const vector<MatrixReal*> Qs, int num_states, vector<unsigned int>(*get_states)(int))
+{
+    const int n = Qs.size();
+    MatrixReal Q(num_states);
+
+    for (size_t i=0; i<num_states; ++i)
+    {
+        auto states_from = get_states(i);
+        assert(states_from.size() == n);
+        
+        for (size_t j=0; j<num_states; ++j)
+        {
+            auto states_to = get_states(j);
+            assert(states_to.size() == n);
+
+            int n_diff_states = n_different_nucs(states_from, states_to);
+
+            assert(n_diff_states >= 0);
+
+            // The rate is zero for more than one stateleotide change.
+            double rate = 0.0;
+
+            if (n_diff_states == 1)
+            {
+                auto changed_states = single_nuc_mut(states_from, states_to);
+                int from_state = std::get<0>(changed_states);
+                int to_state = std::get<1>(changed_states);
+                int pos = std::get<2>(changed_states);
+
+                if (pos < 0 or pos >= Qs.size()) std::abort();
+
+                rate = (*Qs[pos])[from_state][to_state];
+            }
+
+            Q[i][j] = rate;
+        }
+    }
+
+    return Q;
+}
+
+CGTR X2X2(const TimeReversibleRateMatrix& q1, const TimeReversibleRateMatrix& q2)
+{
+    MatrixReal Q = singlet_to_doublet_rates( q1.getRateMatrix(), q2.getRateMatrix() );
+    vector<double> pi = F2x4( q1.getStationaryFrequencies(), q2.getStationaryFrequencies() );
+
+    auto QQ = CGTR( compute_flattened_exchange_rates(Q,pi), pi);
+    QQ.rescaleToAverageRate(2.0);
+    return QQ;
+}
+
+CGTR X2(const TimeReversibleRateMatrix& q)
+{
+    return X2X2(q,q);
+}
+
+}

--- a/src/core/functions/phylogenetics/ratematrix/CppDoubletFuncs.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/CppDoubletFuncs.cpp
@@ -17,8 +17,11 @@ Simplex F2x4(const Simplex& nuc_pi1,
 {
     using RevBayesCore::DoubletState;
 
-    assert(nuc_pi1.size() == 4);
-    assert(nuc_pi2.size() == 4);
+    if (nuc_pi1.size() != 4)
+        throw RbException()<<"F2x4: nuc_pi1 must have exactly 4 base frequencies, but got "<<nuc_pi1.size()<<".";
+
+    if (nuc_pi2.size() != 4)
+        throw RbException()<<"F2x4: nuc_pi2 must have exactly 4 base frequencies, but got "<<nuc_pi2.size()<<".";
 
     std::vector<double> doublet_pi(16);
 

--- a/src/core/functions/phylogenetics/ratematrix/CppDoubletFuncs.h
+++ b/src/core/functions/phylogenetics/ratematrix/CppDoubletFuncs.h
@@ -1,0 +1,20 @@
+#ifndef CppCodonFuncs_H
+#define CppCodonFuncs_H
+
+#include "Simplex.h"
+#include "MatrixReal.h"
+#include "ConcreteTimeReversibleRateMatrix.h"
+
+namespace RevBayesCore
+{
+    typedef ConcreteTimeReversibleRateMatrix CGTR;
+
+    Simplex F2x4(const Simplex& nuc_pi1, const Simplex& nuc_pi2);
+
+    CGTR X2X2(const TimeReversibleRateMatrix& q1, const TimeReversibleRateMatrix& q2);
+
+    CGTR X2(const TimeReversibleRateMatrix& q);
+}
+
+
+#endif

--- a/src/core/help/RbHelpDatabase.cpp
+++ b/src/core/help/RbHelpDatabase.cpp
@@ -1240,6 +1240,10 @@ Q := fnHKY(kappa,pi))");
 	help_strings[string("fnMutSel")][string("description")] = string(R"(Constructs a rate matrix from scaled selection coefficients w[i] and
 mutation rate matrix mu(i,j).
 
+fnMutSel takes 61 scaled selection coefficients, one for each codon.
+This differs from fnMutSelAA, which takes 20 scaled selection coefficients,
+one for each amino acid.
+
 A substitution from allele i -> j can be decomposed into
  (1) all individuals initially have state i
  (2) a single individual mutates from i -> j, at rate mu(i,j)
@@ -1257,8 +1261,35 @@ w ~ dnIID(61, dnNormal(0,1))
 Q := fnMutSel(w, fnX3( fnGTR(er,nuc_pi) ) )   # GTR + X3 + MutSel)");
 	help_strings[string("fnMutSel")][string("name")] = string(R"(fnMutSel)");
 	help_references[string("fnMutSel")].push_back(RbHelpReference(R"(Yang, Z. and R. Nielsen. Mutation-Selection Models of Codon Substitution and Their Use to Estimate Selective Strengths on Codon Usage.  Mol. Biol. Evol. (2008) 25(3):568--579)",R"(https://doi.org/10.1093/molbev/msm284 )",R"()"));
-	help_arrays[string("fnMutSel")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94, fnX3, fndNdS)"));
+	help_arrays[string("fnMutSel")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94, fnX3, fndNdS, fnMutSelAA)"));
 	help_strings[string("fnMutSel")][string("title")] = string(R"(Add mutation-selection balance to a rate matrix.)");
+	help_strings[string("fnMutSelAA")][string("description")] = string(R"(Constructs a rate matrix from scaled selection coefficients w[i] and
+mutation rate matrix mu(i,j).
+
+fnMutSelAA takes 20 scaled selection coefficients, one for each amino acid.
+This differs from fnMutSel, which takes 61 scaled selection coefficients,
+one for each codon.  fnMutSelAA assumes that codons for the same amino acid
+have the same fitness.
+
+A substitution from allele i -> j can be decomposed into
+ (1) all individuals initially have state i
+ (2) a single individual mutates from i -> j, at rate mu(i,j)
+ (3) the allele j goes to fixation
+
+Then the substitution rate Q is then given by
+  Q(i,j) = mu(i,j) * Pr(j goes to fixation | i was fixed previously).
+
+The probability of fixation is determined by scaled selection coefficients:
+  w[i] = 2*N*s[i]
+and the initial frequency 1/N of allele j.)");
+	help_strings[string("fnMutSelAA")][string("example")] = string(R"(er ~ dnDirichlet( v(1,1,1,1,1,1) )
+nuc_pi ~ dnDirichlet( rep(2.0, 4) )
+w ~ dnIID(61, dnNormal(0,1))
+Q := fnMutSel(w, fnX3( fnGTR(er,nuc_pi) ) )   # GTR + X3 + MutSel)");
+	help_strings[string("fnMutSelAA")][string("name")] = string(R"(fnMutSelAA)");
+	help_references[string("fnMutSelAA")].push_back(RbHelpReference(R"(Yang, Z. and R. Nielsen. Mutation-Selection Models of Codon Substitution and Their Use to Estimate Selective Strengths on Codon Usage.  Mol. Biol. Evol. (2008) 25(3):568--579)",R"(https://doi.org/10.1093/molbev/msm284 )",R"()"));
+	help_arrays[string("fnMutSelAA")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94, fnX3, fndNdS, fnMutSel)"));
+	help_strings[string("fnMutSelAA")][string("title")] = string(R"(Add mutation-selection balance to a rate matrix -- fitnesses on amino acids)");
 	help_strings[string("fnNormalizedQuantile")][string("name")] = string(R"(fnNormalizedQuantile)");
 	help_strings[string("fnNumUniqueInVector")][string("name")] = string(R"(fnNumUniqueInVector)");
 	help_strings[string("fnOrderedRateMatrix")][string("name")] = string(R"(fnOrderedRateMatrix)");

--- a/src/core/help/RbHelpDatabase.cpp
+++ b/src/core/help/RbHelpDatabase.cpp
@@ -1237,6 +1237,28 @@ Q := fnHKY(kappa,pi))");
 	help_strings[string("fnMixtureCladoProbs")][string("name")] = string(R"(fnMixtureCladoProbs)");
 	help_strings[string("fnMtMam")][string("name")] = string(R"(fnMtMam)");
 	help_strings[string("fnMtRev")][string("name")] = string(R"(fnMtRev)");
+	help_strings[string("fnMutSel")][string("description")] = string(R"(Constructs a rate matrix from scaled selection coefficients w[i] and
+mutation rate matrix mu(i,j).
+
+A substitution from allele i -> j can be decomposed into
+ (1) all individuals initially have state i
+ (2) a single individual mutates from i -> j, at rate mu(i,j)
+ (3) the allele j goes to fixation
+
+Then the substitution rate Q is then given by
+  Q(i,j) = mu(i,j) * Pr(j goes to fixation | i was fixed previously).
+
+The probability of fixation is determined by scaled selection coefficients:
+  w[i] = 2*N*s[i]
+and the initial frequency 1/N of allele j.)");
+	help_strings[string("fnMutSel")][string("example")] = string(R"(er ~ dnDirichlet( v(1,1,1,1,1,1) )
+nuc_pi ~ dnDirichlet( rep(2.0, 4) )
+w ~ dnIID(61, dnNormal(0,1))
+Q := fnMutSel(w, fnX3( fnGTR(er,nuc_pi) ) )   # GTR + X3 + MutSel)");
+	help_strings[string("fnMutSel")][string("name")] = string(R"(fnMutSel)");
+	help_references[string("fnMutSel")].push_back(RbHelpReference(R"(Yang, Z. and R. Nielsen. Mutation-Selection Models of Codon Substitution and Their Use to Estimate Selective Strengths on Codon Usage.  Mol. Biol. Evol. (2008) 25(3):568--579)",R"(https://doi.org/10.1093/molbev/msm284 )",R"()"));
+	help_arrays[string("fnMutSel")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94, fnX3, fndNdS)"));
+	help_strings[string("fnMutSel")][string("title")] = string(R"(Add mutation-selection balance to a rate matrix.)");
 	help_strings[string("fnNormalizedQuantile")][string("name")] = string(R"(fnNormalizedQuantile)");
 	help_strings[string("fnNumUniqueInVector")][string("name")] = string(R"(fnNumUniqueInVector)");
 	help_strings[string("fnOrderedRateMatrix")][string("name")] = string(R"(fnOrderedRateMatrix)");
@@ -1329,7 +1351,7 @@ er ~ dnDirichlet( v(1,1,1,1,1,1) )
 Q3 := fnX3(fnGTR(er,nuc_pi))      # GTR + X3, or GTR*3)");
 	help_strings[string("fndNdS")][string("name")] = string(R"(fndNdS)");
 	help_references[string("fndNdS")].push_back(RbHelpReference(R"(Redelings, BD (2021). RedelingsBAli-Phy version 3: Model-based co-estimation of Alignment and Phylogeny.  Bioinformatics (2021) 37(10):3032–3034.)",R"(https://doi.org/10.1093/bioinformatics/btab129)",R"()"));
-	help_arrays[string("fndNdS")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94K, fnX3)"));
+	help_arrays[string("fndNdS")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94K, fnX3, fnMutSel)"));
 	help_strings[string("fndNdS")][string("title")] = string(R"(Add a dN/dS factor to a codon rate matrix.)");
 	help_strings[string("formatDiscreteCharacterData")][string("name")] = string(R"(formatDiscreteCharacterData)");
 	help_strings[string("gamma")][string("name")] = string(R"(gamma)");

--- a/src/core/help/RbHelpDatabase.cpp
+++ b/src/core/help/RbHelpDatabase.cpp
@@ -1080,29 +1080,6 @@ exists(x))");
 	help_strings[string("fnCoala")][string("name")] = string(R"(fnCoala)");
 	help_references[string("fnCoala")].push_back(RbHelpReference(R"(A branch-heterogeneous model of protein evolution for efficient inference of ancestral sequences. Groussin M, Boussau B, Gouy M. Syst Biol. 2013 Jul;62(4):523-38.)",R"(10.1093/sysbio/syt016)",R"(https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3676677/ )"));
 	help_strings[string("fnCodon")][string("name")] = string(R"(fnCodon)");
-	help_strings[string("fnCodon94K")][string("description")] = string(R"(The Muse-Gaut (1994) codon model, extended with a transition/transversion rate ratio.
-
-A rate matrix on the 61 non-stop codons (in the standard genetic code).
-
-Rates between codons with more than one nucleotide change are equal to 0.
-
-In this model the rate Q(i,j) from i -> j is proportional to the frequency of
-nucleotide in codon j that changed.  This differs from the Goldman-Yang (1994) model,
-where Q(i,j) is proportional to the frequency of the entire codon j.
-
-This version is an extension of the fnCodonMG94 model to add a transition/transversion
-rate ratio.  This makes it more comparable to the Goldman-Yang (1994) model.
-
-Unlike the Goldman-Yang (1994) model, the Muse-Gaut (1994) model does not allow all the codon
-frequencies to vary independently.)");
-	help_strings[string("fnCodon94K")][string("example")] = string(R"(kappa ~ dnLognormal(0,1)
-omega ~ dnUniform(0,1)
-pi ~ dnDirichlet( rep(2.0, 4) )
-Q := fnCodonMG94K( kappa, omega, pi ))");
-	help_strings[string("fnCodon94K")][string("name")] = string(R"(fnCodonMG94K)");
-	help_references[string("fnCodon94K")].push_back(RbHelpReference(R"(Muse, S. and B. Gaut (1994) A likelihood approach for comparing synonymous and nonsynonymous nucleotide substitution rates, with application to the chloroplast genome. Mol. Biol. Evol. (1994) 11 (5):715-724)",R"(https://doi.org/10.1093/oxfordjournals.molbev.a040152 )",R"()"));
-	help_arrays[string("fnCodon94K")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94K)"));
-	help_strings[string("fnCodon94K")][string("title")] = string(R"(The Muse-Gaut (1994) codon rate matrix + K.)");
 	help_strings[string("fnCodonGY94")][string("description")] = string(R"(The Goldman-Yang (1994) codon model.
 
 A rate matrix on the 61 non-stop codons (in the standard genetic code).
@@ -1152,6 +1129,29 @@ Q := fnCodonMG94( omega, pi ))");
 	help_references[string("fnCodonMG94")].push_back(RbHelpReference(R"(Muse, S. and B. Gaut (1994) A likelihood approach for comparing synonymous and nonsynonymous nucleotide substitution rates, with application to the chloroplast genome. Mol. Biol. Evol. (1994) 11 (5):715-724)",R"(https://doi.org/10.1093/oxfordjournals.molbev.a040152 )",R"()"));
 	help_arrays[string("fnCodonMG94")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94K)"));
 	help_strings[string("fnCodonMG94")][string("title")] = string(R"(The Muse-Gaut (1994) codon rate matrix)");
+	help_strings[string("fnCodonMG94K")][string("description")] = string(R"(The Muse-Gaut (1994) codon model, extended with a transition/transversion rate ratio.
+
+A rate matrix on the 61 non-stop codons (in the standard genetic code).
+
+Rates between codons with more than one nucleotide change are equal to 0.
+
+In this model the rate Q(i,j) from i -> j is proportional to the frequency of
+nucleotide in codon j that changed.  This differs from the Goldman-Yang (1994) model,
+where Q(i,j) is proportional to the frequency of the entire codon j.
+
+This version is an extension of the fnCodonMG94 model to add a transition/transversion
+rate ratio.  This makes it more comparable to the Goldman-Yang (1994) model.
+
+Unlike the Goldman-Yang (1994) model, the Muse-Gaut (1994) model does not allow all the codon
+frequencies to vary independently.)");
+	help_strings[string("fnCodonMG94K")][string("example")] = string(R"(kappa ~ dnLognormal(0,1)
+omega ~ dnUniform(0,1)
+pi ~ dnDirichlet( rep(2.0, 4) )
+Q := fnCodonMG94K( kappa, omega, pi ))");
+	help_strings[string("fnCodonMG94K")][string("name")] = string(R"(fnCodonMG94K)");
+	help_references[string("fnCodonMG94K")].push_back(RbHelpReference(R"(Muse, S. and B. Gaut (1994) A likelihood approach for comparing synonymous and nonsynonymous nucleotide substitution rates, with application to the chloroplast genome. Mol. Biol. Evol. (1994) 11 (5):715-724)",R"(https://doi.org/10.1093/oxfordjournals.molbev.a040152 )",R"()"));
+	help_arrays[string("fnCodonMG94K")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94K)"));
+	help_strings[string("fnCodonMG94K")][string("title")] = string(R"(The Muse-Gaut (1994) codon rate matrix + K.)");
 	help_strings[string("fnCovarion")][string("name")] = string(R"(fnCovarion)");
 	help_strings[string("fnCovarionRateMatrix")][string("name")] = string(R"(fnCovarionRateMatrix)");
 	help_strings[string("fnCpRev")][string("name")] = string(R"(fnCpRev)");
@@ -1277,6 +1277,23 @@ Q := fnTrN(kappaAT, kappaCT, ,pi))");
 	help_strings[string("fnVarCovar")][string("name")] = string(R"(fnVarCovar)");
 	help_strings[string("fnWAG")][string("name")] = string(R"(fnWAG)");
 	help_strings[string("fnWattersonsTheta")][string("name")] = string(R"(fnWattersonsTheta)");
+	help_strings[string("fnX3")][string("description")] = string(R"(Constructs a rate matrix on the 61 non-stop codons (in the standard genetic code).
+
+Rates of change from nucleotide i -> j at each codon position are given by the
+nucleotide rate matrix.  The rate of 2 or 3 simultaneous changes is 0.)");
+	help_strings[string("fnX3")][string("example")] = string(R"(
+kappa ~ dnLognormal(0,1)
+nuc_pi ~ dnDirichlet( rep(2.0, 4) )
+Q1 := fnCodonMG94K( kappa, 1.0, nuc_pi )
+# This is the same.
+Q2 := fnX3(fnHKY(k,nuc_pi))   # HKY + X3, or HKY*3
+
+er ~ dnDirichlet( v(1,1,1,1,1,1) )
+Q3 := fnX3(fnGTR(er,pi))      # GTR + X3, or GTR*3)");
+	help_strings[string("fnX3")][string("name")] = string(R"(fnX3)");
+	help_references[string("fnX3")].push_back(RbHelpReference(R"()",R"()",R"()"));
+	help_arrays[string("fnX3")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94K)"));
+	help_strings[string("fnX3")][string("title")] = string(R"(Construct a codon rate matrix from a nucleotide rate matrix.)");
 	help_strings[string("fnassembleContinuousMRF")][string("name")] = string(R"(fnassembleContinuousMRF)");
 	help_strings[string("formatDiscreteCharacterData")][string("name")] = string(R"(formatDiscreteCharacterData)");
 	help_strings[string("gamma")][string("name")] = string(R"(gamma)");

--- a/src/core/help/RbHelpDatabase.cpp
+++ b/src/core/help/RbHelpDatabase.cpp
@@ -1190,6 +1190,16 @@ Q := fnCodonGY94( kappa, omega, fnF1x4(pi) ))");
 	help_strings[string("fnF1x4")][string("name")] = string(R"(fnF1x4)");
 	help_arrays[string("fnF1x4")][string("see_also")].push_back(string(R"(fnGY94, fnF3x4)"));
 	help_strings[string("fnF1x4")][string("title")] = string(R"(The F1x4 codon frequency model)");
+	help_strings[string("fnF2x4")][string("description")] = string(R"(This treats doublet frequencies as a product of independent nucleotide frequencies.)");
+	help_strings[string("fnF2x4")][string("example")] = string(R"(# An RNA stem model with independent base frequencies (from fnF2x4),
+# and simultaneous 2-nucleotide changes allows.
+nuc_pi ~ dnDirichlet( v(2.0, 2.0, 2.0, 2.0) )
+rna_stem_er ~ dnDirichlet( rep(1.0, 16*15/2) )
+rna_stem_pi := fnF2x4(nuc_pi, nuc_pi)
+Q := fnGTR(rna_stem_er, rna_stem_pi))");
+	help_strings[string("fnF2x4")][string("name")] = string(R"(fnF2x4)");
+	help_arrays[string("fnF2x4")][string("see_also")].push_back(string(R"(fnX2)"));
+	help_strings[string("fnF2x4")][string("title")] = string(R"(The F2x4 doublet frequency model)");
 	help_strings[string("fnF3x4")][string("description")] = string(R"(This treats codon frequencies as a product of independent nucleotide frequencies.
 
 Since stop codons are removed from the codon alphabet, frequencies are renormalized
@@ -1327,10 +1337,14 @@ and the initial frequency 1/N of allele j.)");
 	help_strings[string("fnMutSel")][string("example")] = string(R"(er ~ dnDirichlet( v(1,1,1,1,1,1) )
 nuc_pi ~ dnDirichlet( rep(2.0, 4) )
 F ~ dnIID(61, dnNormal(0,1))
-Q := fnMutSel(F, fnX3( fnGTR(er,nuc_pi) ) )   # GTR + X3 + MutSel)");
+Q := fnMutSel(F, fnX3( fnGTR(er,nuc_pi) ) )   # GTR + X3 + MutSel
+
+# A mutation-selection balance model on RNA, with GTR mutation.
+F2 ~ dnIID(16, dnNormal(0,1))
+Q2 := fnMutSel(F2, fnX2( fnGTR(er,nuc_pi) ) ) # GTR + X2 + MutSel)");
 	help_strings[string("fnMutSel")][string("name")] = string(R"(fnMutSel)");
 	help_references[string("fnMutSel")].push_back(RbHelpReference(R"(Yang, Z. and R. Nielsen. Mutation-Selection Models of Codon Substitution and Their Use to Estimate Selective Strengths on Codon Usage.  Mol. Biol. Evol. (2008) 25(3):568--579)",R"(https://doi.org/10.1093/molbev/msm284 )",R"()"));
-	help_arrays[string("fnMutSel")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94, fnX3, fndNdS, fnMutSelAA)"));
+	help_arrays[string("fnMutSel")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94, fnMutSelAA, fnFMutSel, fndNdS)"));
 	help_strings[string("fnMutSel")][string("title")] = string(R"(Add mutation-selection balance to a rate matrix.)");
 	help_strings[string("fnMutSelAA")][string("description")] = string(R"(Constructs a rate matrix from scaled selection coefficients w[i] and
 mutation rate matrix mu(i,j).
@@ -1403,12 +1417,30 @@ Q := fnTrN(kappaAT, kappaCT, ,pi))");
 	help_strings[string("fnVarCovar")][string("name")] = string(R"(fnVarCovar)");
 	help_strings[string("fnWAG")][string("name")] = string(R"(fnWAG)");
 	help_strings[string("fnWattersonsTheta")][string("name")] = string(R"(fnWattersonsTheta)");
+	help_strings[string("fnX2")][string("description")] = string(R"(Constructs a double rate matrix on the 16 nucleotide pairs.
+
+Rates of change from nucleotide i -> j at each doublet position are given by the
+nucleotide rate matrix.  The rate of 2 simultaneous changes is 0.
+
+The X3 function can be used to constructor rate matrices on doublets in a
+modular fashion.)");
+	help_strings[string("fnX2")][string("example")] = string(R"(
+kappa ~ dnLognormal(0,1)
+nuc_pi ~ dnDirichlet( rep(2.0, 4) )
+# Mutation rate matrix on RNA stems
+Q1 := fnX2( fnHKY(kappa, nuc_pi) )
+F ~ dnIID(16, dnNormal(0,1))
+# Add selection to the rate matrix
+Q2 := fnMutSel(F, Q1))");
+	help_strings[string("fnX2")][string("name")] = string(R"(fnX2)");
+	help_arrays[string("fnX2")][string("see_also")].push_back(string(R"(fnX3)"));
+	help_strings[string("fnX2")][string("title")] = string(R"(Construct a doublet (16x16) rate matrix from a nucleotide rate matrix.)");
 	help_strings[string("fnX3")][string("description")] = string(R"(Constructs a rate matrix on the 61 non-stop codons (in the standard genetic code).
 
 Rates of change from nucleotide i -> j at each codon position are given by the
 nucleotide rate matrix.  The rate of 2 or 3 simultaneous changes is 0.
 
-The X3 function can be used to constructor other rate matrices in a modular fashion.
+The X3 function can be used to construct other rate matrices in a modular fashion.
 For example:
   (i)  MG94  = F81 + X3 + dNdS
   (ii) MG94K = HKY85 + X3 + dNdS)");
@@ -1423,7 +1455,7 @@ Q2 := fndNdS(omega,fnX3(fnHKY(kappa,nuc_pi)))   # HKY + X3 + dNdS, or HKY*3 + dN
 er ~ dnDirichlet( v(1,1,1,1,1,1) )
 Q3 := fnX3(fnGTR(er,nuc_pi))      # GTR + X3, or GTR*3)");
 	help_strings[string("fnX3")][string("name")] = string(R"(fnX3)");
-	help_references[string("fnX3")].push_back(RbHelpReference(R"(Redelings, BD (2021). RedelingsBAli-Phy version 3: Model-based co-estimation of Alignment and Phylogeny.  Bioinformatics (2021) 37(10):3032–3034.)",R"(https://doi.org/10.1093/bioinformatics/btab129 )",R"()"));
+	help_references[string("fnX3")].push_back(RbHelpReference(R"(Redelings, BD (2021). BAli-Phy version 3: Model-based co-estimation of Alignment and Phylogeny.  Bioinformatics (2021) 37(10):3032–3034.)",R"(https://doi.org/10.1093/bioinformatics/btab129 )",R"()"));
 	help_arrays[string("fnX3")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94K, fndNdS)"));
 	help_strings[string("fnX3")][string("title")] = string(R"(Construct a codon rate matrix from a nucleotide rate matrix.)");
 	help_strings[string("fnassembleContinuousMRF")][string("name")] = string(R"(fnassembleContinuousMRF)");

--- a/src/core/help/RbHelpDatabase.cpp
+++ b/src/core/help/RbHelpDatabase.cpp
@@ -1204,6 +1204,75 @@ Q := fnCodonGY94( kappa, omega, fnF3x4(pi1, pi2, pi3) ))");
 	help_arrays[string("fnF3x4")][string("see_also")].push_back(string(R"(fnGY94, fnF1x4)"));
 	help_strings[string("fnF3x4")][string("title")] = string(R"(The F3x4 codon frequency model)");
 	help_strings[string("fnF81")][string("name")] = string(R"(fnF81)");
+	help_strings[string("fnFMutSel")][string("description")] = string(R"(Constructs a rate matrix from 61 scaled selection coefficients w[i] and
+a 4x4 nucleotide mutation rate matrix mu(i,j).  In the original paper
+the nucleotide mutation rate matrix is a GTR rate matrix.
+
+The FMutSel0 model differs from FMutSel by constraining all codons for
+the same amino acid to have the same scaled selection coefficient.
+
+The function fnMutSel differs from fnFMutSel by taking a codon mutation
+rate matrix.
+
+A substitution from allele i -> j can be decomposed into
+ (1) all individuals initially have state i
+ (2) a single individual mutates from i -> j, at rate mu(i,j)
+ (3) the allele j goes to fixation
+
+Then the substitution rate Q is then given by
+  Q(i,j) = mu(i,j) * Pr(j goes to fixation | i was fixed previously).
+
+The probability of fixation is determined by scaled selection coefficients:
+  F[i] = 2*N*s[i]
+and the initial frequency 1/N of allele j.)");
+	help_strings[string("fnFMutSel")][string("example")] = string(R"(er ~ dnDirichlet( v(1,1,1,1,1,1) )
+nuc_pi ~ dnDirichlet( rep(2.0, 4) )
+F ~ dnIID(61, dnNormal(0,1))
+omega ~ dnUniform(0,1)
+# The FMutSel model from Yang and Nielsen (2008)
+Q1 := fnFMutSel(F, omega, fnGTR(er, nuc_pi))
+
+# The same -- fMutSel = GTR(er,nuc_pi) + X3 + MutSel(F) + dNdS(omega)
+Q2 := fndNdS(omega, fnMutSel(F, fnX3( fnGTR(er, nuc_pi)))))");
+	help_strings[string("fnFMutSel")][string("name")] = string(R"(fnFMutSel)");
+	help_references[string("fnFMutSel")].push_back(RbHelpReference(R"(Yang, Z. and R. Nielsen. Mutation-Selection Models of Codon Substitution and Their Use to Estimate Selective Strengths on Codon Usage.  Mol. Biol. Evol. (2008) 25(3):568--579)",R"(https://doi.org/10.1093/molbev/msm284 )",R"()"));
+	help_arrays[string("fnFMutSel")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94, fnFMutSel0, fnMutSel)"));
+	help_strings[string("fnFMutSel")][string("title")] = string(R"(The FMutSel model)");
+	help_strings[string("fnFMutSel0")][string("description")] = string(R"(Constructs a rate matrix from 61 scaled selection coefficients w[i] and
+a 4x4 nucleotide mutation rate matrix mu(i,j).  In the original paper
+the nucleotide mutation rate matrix is a GTR rate matrix.
+
+The FMutSel0 model is a restriction of the FMutSel model that constrains
+all codons for the same amino acid to have the same scaled selection
+coefficient.
+
+The function fnMutSelAA differs from fnFMutSel0 by taking a codon mutation
+rate matrix.
+
+A substitution from allele i -> j can be decomposed into
+ (1) all individuals initially have state i
+ (2) a single individual mutates from i -> j, at rate mu(i,j)
+ (3) the allele j goes to fixation
+
+Then the substitution rate Q is then given by
+  Q(i,j) = mu(i,j) * Pr(j goes to fixation | i was fixed previously).
+
+The probability of fixation is determined by scaled selection coefficients:
+  F[i] = 2*N*s[i]
+and the initial frequency 1/N of allele j.)");
+	help_strings[string("fnFMutSel0")][string("example")] = string(R"(er ~ dnDirichlet( v(1,1,1,1,1,1) )
+nuc_pi ~ dnDirichlet( rep(2.0, 4) )
+F ~ dnIID(20, dnNormal(0,1))
+omega ~ dnUniform(0,1)
+# The FMutSel0 model from Yang and Nielsen (2008)
+Q1 := fnFMutSel0(F, omega, fnGTR(er, nuc_pi))
+
+# The same -- fMutSel0 = GTR(er,nuc_pi) + X3 + MutSel(F) + dNdS(omega)
+Q2 := fndNdS(omega, fnMutSelAA(F, fnX3( fnGTR(er, nuc_pi)))))");
+	help_strings[string("fnFMutSel0")][string("name")] = string(R"(fnFMutSel0)");
+	help_references[string("fnFMutSel0")].push_back(RbHelpReference(R"(Yang, Z. and R. Nielsen. Mutation-Selection Models of Codon Substitution and Their Use to Estimate Selective Strengths on Codon Usage.  Mol. Biol. Evol. (2008) 25(3):568--579)",R"(https://doi.org/10.1093/molbev/msm284 )",R"()"));
+	help_arrays[string("fnFMutSel0")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94, fnFMutSel0, fnMutSel)"));
+	help_strings[string("fnFMutSel0")][string("title")] = string(R"(The FMutSel0 model)");
 	help_strings[string("fnFreeBinary")][string("name")] = string(R"(fnFreeBinary)");
 	help_strings[string("fnFreeK")][string("name")] = string(R"(fnFreeK)");
 	help_strings[string("fnFreeSymmetricRateMatrix")][string("name")] = string(R"(fnFreeSymmetricRateMatrix)");
@@ -1253,12 +1322,12 @@ Then the substitution rate Q is then given by
   Q(i,j) = mu(i,j) * Pr(j goes to fixation | i was fixed previously).
 
 The probability of fixation is determined by scaled selection coefficients:
-  w[i] = 2*N*s[i]
+  F[i] = 2*N*s[i]
 and the initial frequency 1/N of allele j.)");
 	help_strings[string("fnMutSel")][string("example")] = string(R"(er ~ dnDirichlet( v(1,1,1,1,1,1) )
 nuc_pi ~ dnDirichlet( rep(2.0, 4) )
-w ~ dnIID(61, dnNormal(0,1))
-Q := fnMutSel(w, fnX3( fnGTR(er,nuc_pi) ) )   # GTR + X3 + MutSel)");
+F ~ dnIID(61, dnNormal(0,1))
+Q := fnMutSel(F, fnX3( fnGTR(er,nuc_pi) ) )   # GTR + X3 + MutSel)");
 	help_strings[string("fnMutSel")][string("name")] = string(R"(fnMutSel)");
 	help_references[string("fnMutSel")].push_back(RbHelpReference(R"(Yang, Z. and R. Nielsen. Mutation-Selection Models of Codon Substitution and Their Use to Estimate Selective Strengths on Codon Usage.  Mol. Biol. Evol. (2008) 25(3):568--579)",R"(https://doi.org/10.1093/molbev/msm284 )",R"()"));
 	help_arrays[string("fnMutSel")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94, fnX3, fndNdS, fnMutSelAA)"));
@@ -1280,12 +1349,12 @@ Then the substitution rate Q is then given by
   Q(i,j) = mu(i,j) * Pr(j goes to fixation | i was fixed previously).
 
 The probability of fixation is determined by scaled selection coefficients:
-  w[i] = 2*N*s[i]
+  F[i] = 2*N*s[i]
 and the initial frequency 1/N of allele j.)");
 	help_strings[string("fnMutSelAA")][string("example")] = string(R"(er ~ dnDirichlet( v(1,1,1,1,1,1) )
 nuc_pi ~ dnDirichlet( rep(2.0, 4) )
-w ~ dnIID(61, dnNormal(0,1))
-Q := fnMutSel(w, fnX3( fnGTR(er,nuc_pi) ) )   # GTR + X3 + MutSel)");
+F ~ dnIID(61, dnNormal(0,1))
+Q := fnMutSel(F, fnX3( fnGTR(er,nuc_pi) ) )   # GTR + X3 + MutSel)");
 	help_strings[string("fnMutSelAA")][string("name")] = string(R"(fnMutSelAA)");
 	help_references[string("fnMutSelAA")].push_back(RbHelpReference(R"(Yang, Z. and R. Nielsen. Mutation-Selection Models of Codon Substitution and Their Use to Estimate Selective Strengths on Codon Usage.  Mol. Biol. Evol. (2008) 25(3):568--579)",R"(https://doi.org/10.1093/molbev/msm284 )",R"()"));
 	help_arrays[string("fnMutSelAA")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94, fnX3, fndNdS, fnMutSel)"));

--- a/src/core/help/RbHelpDatabase.cpp
+++ b/src/core/help/RbHelpDatabase.cpp
@@ -1080,6 +1080,29 @@ exists(x))");
 	help_strings[string("fnCoala")][string("name")] = string(R"(fnCoala)");
 	help_references[string("fnCoala")].push_back(RbHelpReference(R"(A branch-heterogeneous model of protein evolution for efficient inference of ancestral sequences. Groussin M, Boussau B, Gouy M. Syst Biol. 2013 Jul;62(4):523-38.)",R"(10.1093/sysbio/syt016)",R"(https://www.ncbi.nlm.nih.gov/pmc/articles/PMC3676677/ )"));
 	help_strings[string("fnCodon")][string("name")] = string(R"(fnCodon)");
+	help_strings[string("fnCodon94K")][string("description")] = string(R"(The Muse-Gaut (1994) codon model, extended with a transition/transversion rate ratio.
+
+A rate matrix on the 61 non-stop codons (in the standard genetic code).
+
+Rates between codons with more than one nucleotide change are equal to 0.
+
+In this model the rate Q(i,j) from i -> j is proportional to the frequency of
+nucleotide in codon j that changed.  This differs from the Goldman-Yang (1994) model,
+where Q(i,j) is proportional to the frequency of the entire codon j.
+
+This version is an extension of the fnCodonMG94 model to add a transition/transversion
+rate ratio.  This makes it more comparable to the Goldman-Yang (1994) model.
+
+Unlike the Goldman-Yang (1994) model, the Muse-Gaut (1994) model does not allow all the codon
+frequencies to vary independently.)");
+	help_strings[string("fnCodon94K")][string("example")] = string(R"(kappa ~ dnLognormal(0,1)
+omega ~ dnUniform(0,1)
+pi ~ dnDirichlet( rep(2.0, 4) )
+Q := fnCodonMG94K( kappa, omega, pi ))");
+	help_strings[string("fnCodon94K")][string("name")] = string(R"(fnCodonMG94K)");
+	help_references[string("fnCodon94K")].push_back(RbHelpReference(R"(Muse, S. and B. Gaut (1994) A likelihood approach for comparing synonymous and nonsynonymous nucleotide substitution rates, with application to the chloroplast genome. Mol. Biol. Evol. (1994) 11 (5):715-724)",R"(https://doi.org/10.1093/oxfordjournals.molbev.a040152 )",R"()"));
+	help_arrays[string("fnCodon94K")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94K)"));
+	help_strings[string("fnCodon94K")][string("title")] = string(R"(The Muse-Gaut (1994) codon rate matrix + K.)");
 	help_strings[string("fnCodonGY94")][string("description")] = string(R"(The Goldman-Yang (1994) codon model.
 
 A rate matrix on the 61 non-stop codons (in the standard genetic code).
@@ -1107,7 +1130,7 @@ pi3 ~ dnDirichlet( rep(2.0, 4) )
 Q3 := fnCodonGY94( kappa, omega, fnF3x4(pi1, pi2, pi3) ))");
 	help_strings[string("fnCodonGY94")][string("name")] = string(R"(fnCodonGY94)");
 	help_references[string("fnCodonGY94")].push_back(RbHelpReference(R"(Goldman, N. and Z. Yang (1994). A codon-based model of nucleotide substitution for protein-coding DNA sequences. Mol. Biol. Evol. (1994) 11 (5):725-736)",R"(https://doi.org/10.1093/oxfordjournals.molbev.a040153 )",R"()"));
-	help_arrays[string("fnCodonGY94")][string("see_also")].push_back(string(R"(fnF1x4, fnF3x4, fnCodonMG94)"));
+	help_arrays[string("fnCodonGY94")][string("see_also")].push_back(string(R"(fnF1x4, fnF3x4, fnCodonMG94, fnCodonMG94K)"));
 	help_strings[string("fnCodonGY94")][string("title")] = string(R"(The Goldman-Yang (1994) codon rate matrix)");
 	help_strings[string("fnCodonHKY")][string("name")] = string(R"(fnCodonHKY)");
 	help_strings[string("fnCodonMG94")][string("description")] = string(R"(The Muse-Gaut (1994) codon model.
@@ -1127,7 +1150,7 @@ pi ~ dnDirichlet( rep(2.0, 4) )
 Q := fnCodonMG94( omega, pi ))");
 	help_strings[string("fnCodonMG94")][string("name")] = string(R"(fnCodonMG94)");
 	help_references[string("fnCodonMG94")].push_back(RbHelpReference(R"(Muse, S. and B. Gaut (1994) A likelihood approach for comparing synonymous and nonsynonymous nucleotide substitution rates, with application to the chloroplast genome. Mol. Biol. Evol. (1994) 11 (5):715-724)",R"(https://doi.org/10.1093/oxfordjournals.molbev.a040152 )",R"()"));
-	help_arrays[string("fnCodonMG94")][string("see_also")].push_back(string(R"(fnCodonGY94)"));
+	help_arrays[string("fnCodonMG94")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94K)"));
 	help_strings[string("fnCodonMG94")][string("title")] = string(R"(The Muse-Gaut (1994) codon rate matrix)");
 	help_strings[string("fnCovarion")][string("name")] = string(R"(fnCovarion)");
 	help_strings[string("fnCovarionRateMatrix")][string("name")] = string(R"(fnCovarionRateMatrix)");

--- a/src/core/help/RbHelpDatabase.cpp
+++ b/src/core/help/RbHelpDatabase.cpp
@@ -396,9 +396,6 @@ a)");
 	help_strings[string("dnConstrainedNodeOrder")][string("name")] = string(R"(dnConstrainedNodeOrder)");
 	help_strings[string("dnConstrainedTopology")][string("name")] = string(R"(dnConstrainedTopology)");
 	help_strings[string("dnCppNormal")][string("name")] = string(R"(dnCppNormal)");
-    help_strings[string("dnCTMC")][string("name")] = string(R"(dnCTMC)");
-    help_arrays[string("dnCTMC")][string("authors")].push_back(string(R"(Sebastian Hoehna)"));
-    help_strings[string("dnCTMC")][string("description")] = string(R"(A continuous time Markov process along a single branch/population. For this process, there is no branching process involved. We simply let the sequence evolve according to the rate matrix for a given amount of time. This process is used to model single population demographies.)");
 	help_strings[string("dnDPP")][string("name")] = string(R"(dnDPP)");
 	help_strings[string("dnDecomposedInvWishart")][string("name")] = string(R"(dnDecomposedInvWishart)");
 	help_arrays[string("dnDirichlet")][string("authors")].push_back(string(R"(Sebastian Hoehna)"));
@@ -1110,9 +1107,28 @@ pi3 ~ dnDirichlet( rep(2.0, 4) )
 Q3 := fnCodonGY94( kappa, omega, fnF3x4(pi1, pi2, pi3) ))");
 	help_strings[string("fnCodonGY94")][string("name")] = string(R"(fnCodonGY94)");
 	help_references[string("fnCodonGY94")].push_back(RbHelpReference(R"(Goldman, N. and Z. Yang (1994). A codon-based model of nucleotide substitution for protein-coding DNA sequences. Mol. Biol. Evol. (1994) 11 (5):725-736)",R"(https://doi.org/10.1093/oxfordjournals.molbev.a040153 )",R"()"));
-	help_arrays[string("fnCodonGY94")][string("see_also")].push_back(string(R"(fnF1x4, fnF3x4)"));
+	help_arrays[string("fnCodonGY94")][string("see_also")].push_back(string(R"(fnF1x4, fnF3x4, fnCodonMG94)"));
 	help_strings[string("fnCodonGY94")][string("title")] = string(R"(The Goldman-Yang (1994) codon rate matrix)");
 	help_strings[string("fnCodonHKY")][string("name")] = string(R"(fnCodonHKY)");
+	help_strings[string("fnCodonMG94")][string("description")] = string(R"(The Muse-Gaut (1994) codon model.
+
+A rate matrix on the 61 non-stop codons (in the standard genetic code).
+
+Rates between codons with more than one nucleotide change are equal to 0.
+
+In this model the rate Q(i,j) from i -> j is proportional to the frequency of
+nucleotide in codon j that changed.  This differs from the Goldman-Yang (1994) model,
+where Q(i,j) is proportional to the frequency of the entire codon j.
+
+Unlike the Goldman-Yang (1994) model, the Muse-Gaut (1994) model does not allow all the codon
+frequencies to vary independently.)");
+	help_strings[string("fnCodonMG94")][string("example")] = string(R"(omega ~ dnUniform(0,1)
+pi ~ dnDirichlet( rep(2.0, 4) )
+Q := fnCodonMG94( omega, pi ))");
+	help_strings[string("fnCodonMG94")][string("name")] = string(R"(fnCodonMG94)");
+	help_references[string("fnCodonMG94")].push_back(RbHelpReference(R"(Muse, S. and B. Gaut (1994) A likelihood approach for comparing synonymous and nonsynonymous nucleotide substitution rates, with application to the chloroplast genome. Mol. Biol. Evol. (1994) 11 (5):715-724)",R"(https://doi.org/10.1093/oxfordjournals.molbev.a040152 )",R"()"));
+	help_arrays[string("fnCodonMG94")][string("see_also")].push_back(string(R"(fnCodonGY94)"));
+	help_strings[string("fnCodonMG94")][string("title")] = string(R"(The Muse-Gaut (1994) codon rate matrix)");
 	help_strings[string("fnCovarion")][string("name")] = string(R"(fnCovarion)");
 	help_strings[string("fnCovarionRateMatrix")][string("name")] = string(R"(fnCovarionRateMatrix)");
 	help_strings[string("fnCpRev")][string("name")] = string(R"(fnCpRev)");

--- a/src/core/utils/RbException.cpp
+++ b/src/core/utils/RbException.cpp
@@ -70,10 +70,13 @@ void RbException::print(std::ostream &o) const
     o << error_type << ":\t" << message;
 }
 
-void RbException::setMessage(std::string msg)
+void RbException::setMessage(const std::string& msg)
 {
-
     message = msg;
 }
 
 
+void RbException::prepend(const std::string& prefix)
+{
+    message = prefix + message;
+}

--- a/src/core/utils/RbException.h
+++ b/src/core/utils/RbException.h
@@ -3,7 +3,7 @@
 
 
 #include <iostream>
-
+#include <sstream>
 
 class RbException {
 
@@ -21,15 +21,28 @@ class RbException {
 
         // Regular functions
         ExceptionType               getExceptionType(void) const;                           //!< Get exception type
-        void                        setMessage(std::string msg);
+        void                        setMessage(const std::string& msg);
         std::string                 getMessage(void) const;
+        void                        prepend(const std::string& s);
         void                        print(std::ostream &o) const;                           //!< Print the exception
-     
+
+        template <typename T>
+        RbException&                operator<<(const T&);
+
     private:
 	    ExceptionType               exception_type;                                         //!< Exception type
 	    std::string                 message;                                                //!< Error message
     
 };
+
+template <typename T>
+RbException& RbException::operator<<(const T& t) {
+  std::ostringstream oss;
+  oss<<message<<t;
+  message = oss.str();
+  return *this;
+}
+
 
 #endif
 

--- a/src/revlanguage/functions/phylogenetics/frequencies/Func_F1x4.cpp
+++ b/src/revlanguage/functions/phylogenetics/frequencies/Func_F1x4.cpp
@@ -1,4 +1,5 @@
 #include "Func_F1x4.h"
+#include "CppCodonFuncs.h"
 
 #include "RealPos.h"
 #include "RlDeterministicNode.h"
@@ -17,34 +18,6 @@
 #include "CodonState.h"
 
 using namespace RevLanguage;
-
-// We need to distinguish RevBayesCore::Simplex from RevLanguage::Simplex
-typedef RevBayesCore::Simplex CSimplex;
-
-// TODO: We really should just call the F3x4 function.
-//       But where would we put it?
-CSimplex F1x4(const CSimplex& nuc_pi)
-{
-    using RevBayesCore::CodonState;
-
-    assert(nuc_pi.size() == 4);
-
-    std::vector<double> codon_pi(61);
-
-    for(int i=0;i<codon_pi.size();i++)
-    {
-        CodonState c = CodonState( CodonState::CODONS[i] );
-        std::vector<unsigned int> codon = c.getTripletStates();
-        int n1 = codon[0];
-        int n2 = codon[1];
-        int n3 = codon[2];
-
-        codon_pi[i] = nuc_pi[n1] * nuc_pi[n2] * nuc_pi[n3];
-    }
-
-    // This line renormalizes the frequencies to sum to 1.0.
-    return CSimplex(codon_pi);
-}
 
 /**
  * The clone function is a convenience function to create proper copies of inherited objected.
@@ -67,7 +40,7 @@ RevBayesCore::TypedFunction< RevBayesCore::Simplex >* Func_F1x4::createFunction(
         throw RbException("The fnF1x4 function takes 4 base frequencies.");
     }
 
-    return RevBayesCore::generic_function_ptr( F1x4, bf );
+    return RevBayesCore::generic_function_ptr( RevBayesCore::F1x4, bf );
 }
 
 

--- a/src/revlanguage/functions/phylogenetics/frequencies/Func_F2x4.cpp
+++ b/src/revlanguage/functions/phylogenetics/frequencies/Func_F2x4.cpp
@@ -1,0 +1,111 @@
+#include "Func_F2x4.h"
+#include "CppDoubletFuncs.h"
+
+#include "RealPos.h"
+#include "RlDeterministicNode.h"
+#include "RlRateMatrix.h"
+#include "RlSimplex.h"
+#include "GenericFunction.h"
+#include "TypedDagNode.h"
+#include "Argument.h"
+#include "ArgumentRule.h"
+#include "ArgumentRules.h"
+#include "RbException.h"
+#include "RevVariable.h"
+#include "RlFunction.h"
+#include "Simplex.h"
+#include "TypeSpec.h"
+#include "CodonState.h"
+
+
+using namespace RevLanguage;
+
+/**
+ * The clone function is a convenience function to create proper copies of inherited objected.
+ * E.g. a.clone() will create a clone of the correct type even if 'a' is of derived type 'b'.
+ *
+ * \return A new copy of the process.
+ */
+Func_F2x4* Func_F2x4::clone( void ) const
+{
+    return new Func_F2x4( *this );
+}
+
+typedef RevBayesCore::Simplex CSimplex;
+
+RevBayesCore::TypedFunction< CSimplex >* Func_F2x4::createFunction( void ) const
+{
+    RevBayesCore::TypedDagNode< CSimplex >* bf1 = static_cast<const Simplex &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode< CSimplex >* bf2 = static_cast<const Simplex &>( this->args[1].getVariable()->getRevObject() ).getDagNode();
+
+    if ( bf1->getValue().size() != 4 )
+    {
+        throw RbException("The fnF2x4:baseFrequencies1: must have exactly 4 base frequencies!.");
+    }
+
+    if ( bf2->getValue().size() != 4 )
+    {
+        throw RbException("The fnF2x4:baseFrequencies2: must have exactly 4 base frequencies!.");
+    }
+
+    return RevBayesCore::generic_function_ptr( RevBayesCore::F2x4, bf1, bf2 );
+}
+
+
+/* Get argument rules */
+const ArgumentRules& Func_F2x4::getArgumentRules( void ) const
+{
+
+    static ArgumentRules argumentRules = ArgumentRules();
+    static bool          rules_set = false;
+
+    if ( !rules_set )
+    {
+        argumentRules.push_back( new ArgumentRule( "baseFrequencies1", Simplex::getClassTypeSpec(), "The stationary frequencies of the 1st nucleotide.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        argumentRules.push_back( new ArgumentRule( "baseFrequencies2", Simplex::getClassTypeSpec(), "The stationary frequencies of the 2nd nucleotide.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+
+        rules_set = true;
+    }
+
+    return argumentRules;
+}
+
+
+const std::string& Func_F2x4::getClassType(void)
+{
+
+    static std::string rev_type = "Simplex";
+
+    return rev_type;
+}
+
+
+/* Get class type spec describing type of object */
+const TypeSpec& Func_F2x4::getClassTypeSpec(void)
+{
+
+    static TypeSpec rev_type_spec = TypeSpec( getClassType(), new TypeSpec( Function::getClassTypeSpec() ) );
+
+    return rev_type_spec;
+}
+
+
+/**
+ * Get the primary Rev name for this function.
+ */
+std::string Func_F2x4::getFunctionName( void ) const
+{
+    // create a name variable that is the same for all instance of this class
+    std::string f_name = "fnF2x4";
+
+    return f_name;
+}
+
+
+const TypeSpec& Func_F2x4::getTypeSpec( void ) const
+{
+
+    static TypeSpec type_spec = getClassTypeSpec();
+
+    return type_spec;
+}

--- a/src/revlanguage/functions/phylogenetics/frequencies/Func_F2x4.cpp
+++ b/src/revlanguage/functions/phylogenetics/frequencies/Func_F2x4.cpp
@@ -35,18 +35,8 @@ typedef RevBayesCore::Simplex CSimplex;
 
 RevBayesCore::TypedFunction< CSimplex >* Func_F2x4::createFunction( void ) const
 {
-    RevBayesCore::TypedDagNode< CSimplex >* bf1 = static_cast<const Simplex &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
-    RevBayesCore::TypedDagNode< CSimplex >* bf2 = static_cast<const Simplex &>( this->args[1].getVariable()->getRevObject() ).getDagNode();
-
-    if ( bf1->getValue().size() != 4 )
-    {
-        throw RbException("The fnF2x4:baseFrequencies1: must have exactly 4 base frequencies!.");
-    }
-
-    if ( bf2->getValue().size() != 4 )
-    {
-        throw RbException("The fnF2x4:baseFrequencies2: must have exactly 4 base frequencies!.");
-    }
+    RevBayesCore::TypedDagNode< CSimplex >* bf1 = dynamic_cast<const Simplex &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode< CSimplex >* bf2 = dynamic_cast<const Simplex &>( this->args[1].getVariable()->getRevObject() ).getDagNode();
 
     return RevBayesCore::generic_function_ptr( RevBayesCore::F2x4, bf1, bf2 );
 }

--- a/src/revlanguage/functions/phylogenetics/frequencies/Func_F2x4.h
+++ b/src/revlanguage/functions/phylogenetics/frequencies/Func_F2x4.h
@@ -1,0 +1,56 @@
+#ifndef Func_F2x4_H
+#define Func_F2x4_H
+
+#include <string>
+#include <iosfwd>
+#include <vector>
+
+#include "RlSimplex.h"
+#include "RlRateMatrix.h"
+#include "RlTypedFunction.h"
+#include "DeterministicNode.h"
+#include "DynamicNode.h"
+#include "RateGenerator.h"
+#include "RevPtr.h"
+#include "RlDeterministicNode.h"
+#include "TypedDagNode.h"
+#include "TypedFunction.h"
+
+namespace RevLanguage {
+class ArgumentRules;
+class TypeSpec;
+
+    /**
+     * The RevLanguage wrapper for the F2x4 rate matrix function.
+     *
+     * The RevLanguage wrapper
+     * + connects the variables/parameters of the function to the F2x4Function object
+     *   (see F2x4Func.{h,cpp})
+     * + the F2x4Func object then creates a Simplex object.
+     *
+     * @copyright Copyright 2021-
+     * @author Benjamin D. Redelings
+     * @since 2021-11-24, version 1.0
+     *
+     */
+    class Func_F2x4 : public TypedFunction< Simplex > {
+
+    public:
+        // Basic utility functions
+        Func_F2x4*                                                          clone(void) const;                                          //!< Clone the object
+        static const std::string&                                           getClassType(void);                                         //!< Get Rev type
+        static const TypeSpec&                                              getClassTypeSpec(void);                                     //!< Get class type spec
+        std::string                                                         getFunctionName(void) const;                                //!< Get the primary name of the function in Rev
+        const TypeSpec&                                                     getTypeSpec(void) const;                                    //!< Get the type spec of the instance
+
+        // Function functions you have to override
+        RevBayesCore::TypedFunction< RevBayesCore::Simplex >*               createFunction(void) const;                                 //!< Create a function object
+        const ArgumentRules&                                                getArgumentRules(void) const;                               //!< Get argument rules
+
+    };
+
+}
+
+#endif
+
+

--- a/src/revlanguage/functions/phylogenetics/frequencies/Func_F3x4.cpp
+++ b/src/revlanguage/functions/phylogenetics/frequencies/Func_F3x4.cpp
@@ -1,4 +1,5 @@
 #include "Func_F3x4.h"
+#include "CppCodonFuncs.h"
 
 #include "RealPos.h"
 #include "RlDeterministicNode.h"
@@ -19,37 +20,6 @@
 
 using namespace RevLanguage;
 
-// We need to distinguish RevBayesCore::Simplex from RevLanguage::Simplex
-typedef RevBayesCore::Simplex CSimplex;
-
-CSimplex F3x4(const CSimplex& nuc_pi1,
-              const CSimplex& nuc_pi2,
-              const CSimplex& nuc_pi3)
-{
-    using RevBayesCore::CodonState;
-
-    assert(nuc_pi1.size() == 4);
-    assert(nuc_pi2.size() == 4);
-    assert(nuc_pi3.size() == 4);
-
-    std::vector<double> codon_pi(61);
-
-    for(int i=0;i<codon_pi.size();i++)
-    {
-        CodonState c = CodonState( CodonState::CODONS[i] );
-        std::vector<unsigned int> codon = c.getTripletStates();
-        int n1 = codon[0];
-        int n2 = codon[1];
-        int n3 = codon[2];
-
-        codon_pi[i] = nuc_pi1[n1] * nuc_pi2[n2] * nuc_pi3[n3];
-    }
-
-    // This line renormalizes the frequencies to sum to 1.0.
-    return CSimplex(codon_pi);
-}
-
-
 /**
  * The clone function is a convenience function to create proper copies of inherited objected.
  * E.g. a.clone() will create a clone of the correct type even if 'a' is of derived type 'b'.
@@ -61,6 +31,7 @@ Func_F3x4* Func_F3x4::clone( void ) const
     return new Func_F3x4( *this );
 }
 
+typedef RevBayesCore::Simplex CSimplex;
 
 RevBayesCore::TypedFunction< CSimplex >* Func_F3x4::createFunction( void ) const
 {
@@ -83,7 +54,7 @@ RevBayesCore::TypedFunction< CSimplex >* Func_F3x4::createFunction( void ) const
         throw RbException("The fnF3x4:baseFrequencies3: must have exactly 4 base frequencies!.");
     }
 
-    return RevBayesCore::generic_function_ptr( F3x4, bf1, bf2, bf3 );
+    return RevBayesCore::generic_function_ptr( RevBayesCore::F3x4, bf1, bf2, bf3 );
 }
 
 

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_FMutSel0RateMatrix.cpp
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_FMutSel0RateMatrix.cpp
@@ -1,0 +1,121 @@
+#include "Func_FMutSel0RateMatrix.h"
+#include "CppCodonFuncs.h"
+
+#include "Real.h"
+#include "ModelVector.h"
+#include "RlDeterministicNode.h"
+#include "RlRateMatrix.h"
+#include "RlSimplex.h"
+#include "GenericFunction.h"
+#include "TypedDagNode.h"
+#include "Argument.h"
+#include "ArgumentRule.h"
+#include "ArgumentRules.h"
+#include "RbException.h"
+#include "RevVariable.h"
+#include "RlFunction.h"
+#include "Simplex.h"
+#include "TypeSpec.h"
+
+#include "ConcreteTimeReversibleRateMatrix.h"
+
+using namespace RevLanguage;
+
+using std::vector;
+
+RevBayesCore::ConcreteTimeReversibleRateMatrix* FMutSel0Func(const vector<double>& aa_fitnesses, double omega, const RevBayesCore::RateGenerator& q_)
+{
+    auto q = dynamic_cast<const RevBayesCore::TimeReversibleRateMatrix*>(&q_);
+
+    if (aa_fitnesses.size() != 20)
+        throw RbException("fnFMutSel0: there should be 20 fitnesses for the 20 amino acids");
+
+    if (not q)
+        throw RbException("fnFMutSel0: the argument must be a time-reversible rate matrix.");
+
+    if (q->getRateMatrix().getNumberOfColumns() != 4)
+        throw RbException("fnFMutSel0: the nucleotide mutation rate matrix should be 4x4.");
+
+    return RevBayesCore::FMutSel0(aa_fitnesses, omega, *q).clone();
+}
+
+
+/**
+ * The clone function is a convenience function to create proper copies of inherited objected.
+ * E.g. a.clone() will create a clone of the correct type even if 'a' is of derived type 'b'.
+ *
+ * \return A new copy of the process.
+ */
+Func_FMutSel0RateMatrix* Func_FMutSel0RateMatrix::clone( void ) const
+{
+    return new Func_FMutSel0RateMatrix( *this );
+}
+
+
+RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >* Func_FMutSel0RateMatrix::createFunction( void ) const
+{
+    RevBayesCore::TypedDagNode< RevBayesCore::RbVector<double> >* fitnesses = static_cast<const ModelVector<Real> &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode< double >* omega = static_cast<const RealPos &>( this->args[1].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode< RevBayesCore::RateGenerator >* mu_nuc = static_cast<const RateGenerator &>( this->args[2].getVariable()->getRevObject() ).getDagNode();
+
+    return RevBayesCore::generic_function_ptr2< RevBayesCore::RateGenerator >( FMutSel0Func, fitnesses, omega, mu_nuc );
+}
+
+
+/* Get argument rules */
+const ArgumentRules& Func_FMutSel0RateMatrix::getArgumentRules( void ) const
+{
+    static ArgumentRules argumentRules = ArgumentRules();
+    static bool          rules_set = false;
+
+    if ( !rules_set )
+    {
+        argumentRules.push_back( new ArgumentRule( "fitnesses", ModelVector<Real>::getClassTypeSpec(), "Scaled selection coefficients 2Ns for 20 amino acids.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        argumentRules.push_back( new ArgumentRule( "omega"    , RealPos::getClassTypeSpec(), "The dN / dS rate ratio.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        argumentRules.push_back( new ArgumentRule( "submodel" , RateMatrix::getClassTypeSpec(), "Nucleotide mutation rate matrix.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+
+        rules_set = true;
+    }
+
+    return argumentRules;
+}
+
+
+const std::string& Func_FMutSel0RateMatrix::getClassType(void)
+{
+
+    static std::string rev_type = "Func_FMutSel0RateMatrix";
+
+    return rev_type;
+}
+
+
+/* Get class type spec describing type of object */
+const TypeSpec& Func_FMutSel0RateMatrix::getClassTypeSpec(void)
+{
+
+    static TypeSpec rev_type_spec = TypeSpec( getClassType(), new TypeSpec( Function::getClassTypeSpec() ) );
+
+    return rev_type_spec;
+}
+
+
+/**
+ * Get the primary Rev name for this function.
+ */
+std::string Func_FMutSel0RateMatrix::getFunctionName( void ) const
+{
+    // create a name variable that is the same for all instance of this class
+    std::string f_name = "fnFMutSel0";
+
+    return f_name;
+}
+
+
+const TypeSpec& Func_FMutSel0RateMatrix::getTypeSpec( void ) const
+{
+
+    static TypeSpec type_spec = getClassTypeSpec();
+
+    return type_spec;
+}

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_FMutSel0RateMatrix.h
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_FMutSel0RateMatrix.h
@@ -1,0 +1,53 @@
+#ifndef Func_FMutSel0RateMatrix_H
+#define Func_FMutSel0RateMatrix_H
+
+#include <string>
+#include <iosfwd>
+#include <vector>
+
+#include "RlRateMatrix.h"
+#include "RlTypedFunction.h"
+#include "DeterministicNode.h"
+#include "DynamicNode.h"
+#include "RateGenerator.h"
+#include "RevPtr.h"
+#include "RlDeterministicNode.h"
+#include "TypedDagNode.h"
+#include "TypedFunction.h"
+
+namespace RevLanguage {
+class ArgumentRules;
+class TypeSpec;
+
+    /**
+     * The RevLanguage wrapper of the FMutSel0 rate matrix function.
+     *
+     *
+     * @copyright Copyright 2022-
+     * @author Benjamin D. Redelings
+     * @since 2022-02-12, version 1.0
+     *
+     */
+    class Func_FMutSel0RateMatrix : public TypedFunction<RateMatrix> {
+
+    public:
+        Func_FMutSel0RateMatrix() = default;
+
+        // Basic utility functions
+        Func_FMutSel0RateMatrix*                                            clone(void) const;                                          //!< Clone the object
+        static const std::string&                                           getClassType(void);                                         //!< Get Rev type
+        static const TypeSpec&                                              getClassTypeSpec(void);                                     //!< Get class type spec
+        std::string                                                         getFunctionName(void) const;                                //!< Get the primary name of the function in Rev
+        const TypeSpec&                                                     getTypeSpec(void) const;                                    //!< Get the type spec of the instance
+
+        // Function functions you have to override
+        RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >*         createFunction(void) const;                                 //!< Create a function object
+        const ArgumentRules&                                                getArgumentRules(void) const;                               //!< Get argument rules
+
+    };
+
+}
+
+#endif
+
+

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_FMutSelRateMatrix.cpp
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_FMutSelRateMatrix.cpp
@@ -1,0 +1,121 @@
+#include "Func_FMutSelRateMatrix.h"
+#include "CppCodonFuncs.h"
+
+#include "Real.h"
+#include "ModelVector.h"
+#include "RlDeterministicNode.h"
+#include "RlRateMatrix.h"
+#include "RlSimplex.h"
+#include "GenericFunction.h"
+#include "TypedDagNode.h"
+#include "Argument.h"
+#include "ArgumentRule.h"
+#include "ArgumentRules.h"
+#include "RbException.h"
+#include "RevVariable.h"
+#include "RlFunction.h"
+#include "Simplex.h"
+#include "TypeSpec.h"
+
+#include "ConcreteTimeReversibleRateMatrix.h"
+
+using namespace RevLanguage;
+
+using std::vector;
+
+RevBayesCore::ConcreteTimeReversibleRateMatrix* FMutSelFunc(const vector<double>& fitnesses, double omega, const RevBayesCore::RateGenerator& q_)
+{
+    if (fitnesses.size() != 61)
+        throw RbException("fnFMutSel: there should be 61 fitnesses for the 61 non-stop codons");
+
+    auto q = dynamic_cast<const RevBayesCore::TimeReversibleRateMatrix*>(&q_);
+
+    if (not q)
+        throw RbException("fnFMutSel: the argument must be a time-reversible rate matrix.");
+
+    if (q->getRateMatrix().getNumberOfColumns() != 4)
+        throw RbException("fnfMutSel: the nucleotide mutation rate matrix should be 4x4.");
+
+    return RevBayesCore::FMutSel(fitnesses, omega, *q).clone();
+}
+
+
+/**
+ * The clone function is a convenience function to create proper copies of inherited objected.
+ * E.g. a.clone() will create a clone of the correct type even if 'a' is of derived type 'b'.
+ *
+ * \return A new copy of the process.
+ */
+Func_FMutSelRateMatrix* Func_FMutSelRateMatrix::clone( void ) const
+{
+    return new Func_FMutSelRateMatrix( *this );
+}
+
+
+RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >* Func_FMutSelRateMatrix::createFunction( void ) const
+{
+    RevBayesCore::TypedDagNode< RevBayesCore::RbVector<double> >* fitnesses = static_cast<const ModelVector<Real> &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode< double >* omega = static_cast<const RealPos &>( this->args[1].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode< RevBayesCore::RateGenerator >* mu_nuc = static_cast<const RateGenerator &>( this->args[2].getVariable()->getRevObject() ).getDagNode();
+
+    return RevBayesCore::generic_function_ptr2< RevBayesCore::RateGenerator >( FMutSelFunc, fitnesses, omega, mu_nuc );
+}
+
+
+/* Get argument rules */
+const ArgumentRules& Func_FMutSelRateMatrix::getArgumentRules( void ) const
+{
+    static ArgumentRules argumentRules = ArgumentRules();
+    static bool          rules_set = false;
+
+    if ( !rules_set )
+    {
+        argumentRules.push_back( new ArgumentRule( "fitnesses", ModelVector<Real>::getClassTypeSpec(), "Scaled selection coefficients 2Ns for 61 codons.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        argumentRules.push_back( new ArgumentRule( "omega"    , RealPos::getClassTypeSpec(), "The dN / dS rate ratio.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        argumentRules.push_back( new ArgumentRule( "submodel" , RateMatrix::getClassTypeSpec(), "Nucleotide mutation rate matrix.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+
+        rules_set = true;
+    }
+
+    return argumentRules;
+}
+
+
+const std::string& Func_FMutSelRateMatrix::getClassType(void)
+{
+
+    static std::string rev_type = "Func_FMutSelRateMatrix";
+
+    return rev_type;
+}
+
+
+/* Get class type spec describing type of object */
+const TypeSpec& Func_FMutSelRateMatrix::getClassTypeSpec(void)
+{
+
+    static TypeSpec rev_type_spec = TypeSpec( getClassType(), new TypeSpec( Function::getClassTypeSpec() ) );
+
+    return rev_type_spec;
+}
+
+
+/**
+ * Get the primary Rev name for this function.
+ */
+std::string Func_FMutSelRateMatrix::getFunctionName( void ) const
+{
+    // create a name variable that is the same for all instance of this class
+    std::string f_name = "fnFMutSel";
+
+    return f_name;
+}
+
+
+const TypeSpec& Func_FMutSelRateMatrix::getTypeSpec( void ) const
+{
+
+    static TypeSpec type_spec = getClassTypeSpec();
+
+    return type_spec;
+}

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_FMutSelRateMatrix.h
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_FMutSelRateMatrix.h
@@ -1,0 +1,53 @@
+#ifndef Func_FMutSelRateMatrix_H
+#define Func_FMutSelRateMatrix_H
+
+#include <string>
+#include <iosfwd>
+#include <vector>
+
+#include "RlRateMatrix.h"
+#include "RlTypedFunction.h"
+#include "DeterministicNode.h"
+#include "DynamicNode.h"
+#include "RateGenerator.h"
+#include "RevPtr.h"
+#include "RlDeterministicNode.h"
+#include "TypedDagNode.h"
+#include "TypedFunction.h"
+
+namespace RevLanguage {
+class ArgumentRules;
+class TypeSpec;
+
+    /**
+     * The RevLanguage wrapper of the FMutSel rate matrix function.
+     *
+     *
+     * @copyright Copyright 2022-
+     * @author Benjamin D. Redelings
+     * @since 2022-02-12, version 1.0
+     *
+     */
+    class Func_FMutSelRateMatrix : public TypedFunction<RateMatrix> {
+
+    public:
+        Func_FMutSelRateMatrix() = default;
+
+        // Basic utility functions
+        Func_FMutSelRateMatrix*                                             clone(void) const;                                          //!< Clone the object
+        static const std::string&                                           getClassType(void);                                         //!< Get Rev type
+        static const TypeSpec&                                              getClassTypeSpec(void);                                     //!< Get class type spec
+        std::string                                                         getFunctionName(void) const;                                //!< Get the primary name of the function in Rev
+        const TypeSpec&                                                     getTypeSpec(void) const;                                    //!< Get the type spec of the instance
+
+        // Function functions you have to override
+        RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >*         createFunction(void) const;                                 //!< Create a function object
+        const ArgumentRules&                                                getArgumentRules(void) const;                               //!< Get argument rules
+
+    };
+
+}
+
+#endif
+
+

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_MuseGaut94KRateMatrix.cpp
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_MuseGaut94KRateMatrix.cpp
@@ -1,0 +1,111 @@
+#include "Func_MuseGaut94KRateMatrix.h"
+#include "CppCodonFuncs.h"
+
+#include "RealPos.h"
+#include "RlDeterministicNode.h"
+#include "RlRateMatrix.h"
+#include "RlSimplex.h"
+#include "GenericFunction.h"
+#include "TypedDagNode.h"
+#include "Argument.h"
+#include "ArgumentRule.h"
+#include "ArgumentRules.h"
+#include "RbException.h"
+#include "RevVariable.h"
+#include "RlFunction.h"
+#include "Simplex.h"
+#include "TypeSpec.h"
+
+#include "ConcreteTimeReversibleRateMatrix.h"
+
+using namespace RevLanguage;
+
+RevBayesCore::ConcreteTimeReversibleRateMatrix* CodonMG94K(double kappa, double omega, const RevBayesCore::Simplex& base_freqs)
+{
+    if (base_freqs.size() != 4)
+        throw RbException("The fnCodonMG94K dN/dS rate matrix requires exactly 4 base frequencies.");
+
+    return RevBayesCore::MG94K(kappa, omega, base_freqs).clone();
+}
+
+
+/**
+ * The clone function is a convenience function to create proper copies of inherited objected.
+ * E.g. a.clone() will create a clone of the correct type even if 'a' is of derived type 'b'.
+ *
+ * \return A new copy of the process.
+ */
+Func_MuseGaut94KRateMatrix* Func_MuseGaut94KRateMatrix::clone( void ) const
+{
+    return new Func_MuseGaut94KRateMatrix( *this );
+}
+
+
+RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >* Func_MuseGaut94KRateMatrix::createFunction( void ) const
+{
+    RevBayesCore::TypedDagNode< double >* ka = static_cast<const RealPos &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode< double >* om = static_cast<const RealPos &>( this->args[1].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode< RevBayesCore::Simplex >* bf = static_cast<const Simplex &>( this->args[2].getVariable()->getRevObject() ).getDagNode();
+
+    return RevBayesCore::generic_function_ptr2< RevBayesCore::RateGenerator >( CodonMG94K, ka, om, bf );
+}
+
+
+/* Get argument rules */
+const ArgumentRules& Func_MuseGaut94KRateMatrix::getArgumentRules( void ) const
+{
+
+    static ArgumentRules argumentRules = ArgumentRules();
+    static bool          rules_set = false;
+
+    if ( !rules_set )
+    {
+        argumentRules.push_back( new ArgumentRule( "kappa"          , RealPos::getClassTypeSpec(), "The transition-transversion rate ratio.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        argumentRules.push_back( new ArgumentRule( "omega"          , RealPos::getClassTypeSpec(), "The dN / dS rate ratio.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        argumentRules.push_back( new ArgumentRule( "baseFrequencies", Simplex::getClassTypeSpec(), "The stationary frequencies of the nucleotides.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+
+        rules_set = true;
+    }
+
+    return argumentRules;
+}
+
+
+const std::string& Func_MuseGaut94KRateMatrix::getClassType(void)
+{
+
+    static std::string rev_type = "Func_MuseGaut94KRateMatrix";
+
+    return rev_type;
+}
+
+
+/* Get class type spec describing type of object */
+const TypeSpec& Func_MuseGaut94KRateMatrix::getClassTypeSpec(void)
+{
+
+    static TypeSpec rev_type_spec = TypeSpec( getClassType(), new TypeSpec( Function::getClassTypeSpec() ) );
+
+    return rev_type_spec;
+}
+
+
+/**
+ * Get the primary Rev name for this function.
+ */
+std::string Func_MuseGaut94KRateMatrix::getFunctionName( void ) const
+{
+    // create a name variable that is the same for all instance of this class
+    std::string f_name = "fnCodonMG94K";
+
+    return f_name;
+}
+
+
+const TypeSpec& Func_MuseGaut94KRateMatrix::getTypeSpec( void ) const
+{
+
+    static TypeSpec type_spec = getClassTypeSpec();
+
+    return type_spec;
+}

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_MuseGaut94KRateMatrix.h
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_MuseGaut94KRateMatrix.h
@@ -1,0 +1,53 @@
+#ifndef Func_MuseGaut94KRateMatrix_H
+#define Func_MuseGaut94KRateMatrix_H
+
+#include <string>
+#include <iosfwd>
+#include <vector>
+
+#include "RlRateMatrix.h"
+#include "RlTypedFunction.h"
+#include "DeterministicNode.h"
+#include "DynamicNode.h"
+#include "RateGenerator.h"
+#include "RevPtr.h"
+#include "RlDeterministicNode.h"
+#include "TypedDagNode.h"
+#include "TypedFunction.h"
+
+namespace RevLanguage {
+class ArgumentRules;
+class TypeSpec;
+
+    /**
+     * The RevLanguage wrapper of the Goldman-Yang (1994K) rate matrix function.
+     *
+     *
+     * @copyright Copyright 2021-
+     * @author Benjamin D. Redelings
+     * @since 2022-02-12, version 1.0
+     *
+     */
+    class Func_MuseGaut94KRateMatrix : public TypedFunction<RateMatrix> {
+
+    public:
+        Func_MuseGaut94KRateMatrix() = default;
+
+        // Basic utility functions
+        Func_MuseGaut94KRateMatrix*                                         clone(void) const;                                          //!< Clone the object
+        static const std::string&                                           getClassType(void);                                         //!< Get Rev type
+        static const TypeSpec&                                              getClassTypeSpec(void);                                     //!< Get class type spec
+        std::string                                                         getFunctionName(void) const;                                //!< Get the primary name of the function in Rev
+        const TypeSpec&                                                     getTypeSpec(void) const;                                    //!< Get the type spec of the instance
+
+        // Function functions you have to override
+        RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >*         createFunction(void) const;                                 //!< Create a function object
+        const ArgumentRules&                                                getArgumentRules(void) const;                               //!< Get argument rules
+
+    };
+
+}
+
+#endif
+
+

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_MuseGaut94KRateMatrix.h
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_MuseGaut94KRateMatrix.h
@@ -20,7 +20,7 @@ class ArgumentRules;
 class TypeSpec;
 
     /**
-     * The RevLanguage wrapper of the Goldman-Yang (1994K) rate matrix function.
+     * The RevLanguage wrapper of the Muse-Gaut (1994K) rate matrix function.
      *
      *
      * @copyright Copyright 2021-

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_MuseGaut94RateMatrix.cpp
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_MuseGaut94RateMatrix.cpp
@@ -1,0 +1,109 @@
+#include "Func_MuseGaut94RateMatrix.h"
+#include "CppCodonFuncs.h"
+
+#include "RealPos.h"
+#include "RlDeterministicNode.h"
+#include "RlRateMatrix.h"
+#include "RlSimplex.h"
+#include "GenericFunction.h"
+#include "TypedDagNode.h"
+#include "Argument.h"
+#include "ArgumentRule.h"
+#include "ArgumentRules.h"
+#include "RbException.h"
+#include "RevVariable.h"
+#include "RlFunction.h"
+#include "Simplex.h"
+#include "TypeSpec.h"
+
+#include "ConcreteTimeReversibleRateMatrix.h"
+
+using namespace RevLanguage;
+
+RevBayesCore::ConcreteTimeReversibleRateMatrix* CodonMG94(double omega, const RevBayesCore::Simplex& base_freqs)
+{
+    if (base_freqs.size() != 4)
+        throw RbException("The fnCodonMG94 dN/dS rate matrix requires exactly 4 base frequencies.");
+
+    return RevBayesCore::MG94(omega, base_freqs).clone();
+}
+
+
+/**
+ * The clone function is a convenience function to create proper copies of inherited objected.
+ * E.g. a.clone() will create a clone of the correct type even if 'a' is of derived type 'b'.
+ *
+ * \return A new copy of the process.
+ */
+Func_MuseGaut94RateMatrix* Func_MuseGaut94RateMatrix::clone( void ) const
+{
+    return new Func_MuseGaut94RateMatrix( *this );
+}
+
+
+RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >* Func_MuseGaut94RateMatrix::createFunction( void ) const
+{
+    RevBayesCore::TypedDagNode< double >* om = static_cast<const RealPos &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode< RevBayesCore::Simplex >* bf = static_cast<const Simplex &>( this->args[1].getVariable()->getRevObject() ).getDagNode();
+
+    return RevBayesCore::generic_function_ptr2< RevBayesCore::RateGenerator >( CodonMG94, om, bf );
+}
+
+
+/* Get argument rules */
+const ArgumentRules& Func_MuseGaut94RateMatrix::getArgumentRules( void ) const
+{
+
+    static ArgumentRules argumentRules = ArgumentRules();
+    static bool          rules_set = false;
+
+    if ( !rules_set )
+    {
+        argumentRules.push_back( new ArgumentRule( "omega"          , RealPos::getClassTypeSpec(), "The dN / dS rate ratio.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        argumentRules.push_back( new ArgumentRule( "baseFrequencies", Simplex::getClassTypeSpec(), "The stationary frequencies of the nucleotides.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+
+        rules_set = true;
+    }
+
+    return argumentRules;
+}
+
+
+const std::string& Func_MuseGaut94RateMatrix::getClassType(void)
+{
+
+    static std::string rev_type = "Func_MuseGaut94RateMatrix";
+
+    return rev_type;
+}
+
+
+/* Get class type spec describing type of object */
+const TypeSpec& Func_MuseGaut94RateMatrix::getClassTypeSpec(void)
+{
+
+    static TypeSpec rev_type_spec = TypeSpec( getClassType(), new TypeSpec( Function::getClassTypeSpec() ) );
+
+    return rev_type_spec;
+}
+
+
+/**
+ * Get the primary Rev name for this function.
+ */
+std::string Func_MuseGaut94RateMatrix::getFunctionName( void ) const
+{
+    // create a name variable that is the same for all instance of this class
+    std::string f_name = "fnCodonMG94";
+
+    return f_name;
+}
+
+
+const TypeSpec& Func_MuseGaut94RateMatrix::getTypeSpec( void ) const
+{
+
+    static TypeSpec type_spec = getClassTypeSpec();
+
+    return type_spec;
+}

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_MuseGaut94RateMatrix.h
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_MuseGaut94RateMatrix.h
@@ -20,7 +20,7 @@ class ArgumentRules;
 class TypeSpec;
 
     /**
-     * The RevLanguage wrapper of the Goldman-Yang (1994) rate matrix function.
+     * The RevLanguage wrapper of the Muse-Gaut (1994) rate matrix function.
      *
      *
      * @copyright Copyright 2021-

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_MuseGaut94RateMatrix.h
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_MuseGaut94RateMatrix.h
@@ -1,0 +1,53 @@
+#ifndef Func_MuseGaut94RateMatrix_H
+#define Func_MuseGaut94RateMatrix_H
+
+#include <string>
+#include <iosfwd>
+#include <vector>
+
+#include "RlRateMatrix.h"
+#include "RlTypedFunction.h"
+#include "DeterministicNode.h"
+#include "DynamicNode.h"
+#include "RateGenerator.h"
+#include "RevPtr.h"
+#include "RlDeterministicNode.h"
+#include "TypedDagNode.h"
+#include "TypedFunction.h"
+
+namespace RevLanguage {
+class ArgumentRules;
+class TypeSpec;
+
+    /**
+     * The RevLanguage wrapper of the Goldman-Yang (1994) rate matrix function.
+     *
+     *
+     * @copyright Copyright 2021-
+     * @author Benjamin D. Redelings
+     * @since 2022-02-12, version 1.0
+     *
+     */
+    class Func_MuseGaut94RateMatrix : public TypedFunction<RateMatrix> {
+
+    public:
+        Func_MuseGaut94RateMatrix() = default;
+
+        // Basic utility functions
+        Func_MuseGaut94RateMatrix*                                          clone(void) const;                                          //!< Clone the object
+        static const std::string&                                           getClassType(void);                                         //!< Get Rev type
+        static const TypeSpec&                                              getClassTypeSpec(void);                                     //!< Get class type spec
+        std::string                                                         getFunctionName(void) const;                                //!< Get the primary name of the function in Rev
+        const TypeSpec&                                                     getTypeSpec(void) const;                                    //!< Get the type spec of the instance
+
+        // Function functions you have to override
+        RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >*         createFunction(void) const;                                 //!< Create a function object
+        const ArgumentRules&                                                getArgumentRules(void) const;                               //!< Get argument rules
+
+    };
+
+}
+
+#endif
+
+

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_MutSelAARateMatrix.cpp
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_MutSelAARateMatrix.cpp
@@ -21,8 +21,11 @@
 
 using namespace RevLanguage;
 
-RevBayesCore::ConcreteTimeReversibleRateMatrix* MutSelAAFunc(const RevBayesCore::RbVector<double> codon_fitnesses, const RevBayesCore::RateGenerator& q_)
+RevBayesCore::ConcreteTimeReversibleRateMatrix* MutSelAAFunc(const RevBayesCore::RbVector<double> aa_fitnesses, const RevBayesCore::RateGenerator& q_)
 {
+    if (aa_fitnesses.size() != 20)
+        throw RbException("fnFMutSel0: there should be 20 fitnesses for the 20 amino acids");
+
     auto q = dynamic_cast<const RevBayesCore::TimeReversibleRateMatrix*>(&q_);
 
     if (not q)
@@ -31,7 +34,7 @@ RevBayesCore::ConcreteTimeReversibleRateMatrix* MutSelAAFunc(const RevBayesCore:
     if (q->getRateMatrix().getNumberOfColumns() != 61)
         throw RbException("The dN/dS rate matrix should be 61x61.");
     
-    return RevBayesCore::MutSelAA(codon_fitnesses, *q).clone();
+    return RevBayesCore::MutSelAA(aa_fitnesses, *q).clone();
 }
 
 

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_MutSelAARateMatrix.cpp
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_MutSelAARateMatrix.cpp
@@ -1,4 +1,4 @@
-#include "Func_MutSelRateMatrix.h"
+#include "Func_MutSelAARateMatrix.h"
 #include "CppCodonFuncs.h"
 
 #include "Real.h"
@@ -21,17 +21,17 @@
 
 using namespace RevLanguage;
 
-RevBayesCore::ConcreteTimeReversibleRateMatrix* MutSelFunc(const RevBayesCore::RbVector<double> codon_fitnesses, const RevBayesCore::RateGenerator& q_)
+RevBayesCore::ConcreteTimeReversibleRateMatrix* MutSelAAFunc(const RevBayesCore::RbVector<double> codon_fitnesses, const RevBayesCore::RateGenerator& q_)
 {
     auto q = dynamic_cast<const RevBayesCore::TimeReversibleRateMatrix*>(&q_);
 
     if (not q)
-        throw RbException("fnMutSel: the argument must be a time-reversible rate matrix.");
+        throw RbException("fnMutSelAA: the argument must be a time-reversible rate matrix.");
 
     if (q->getRateMatrix().getNumberOfColumns() != 61)
         throw RbException("The dN/dS rate matrix should be 61x61.");
     
-    return RevBayesCore::MutSel(codon_fitnesses, *q).clone();
+    return RevBayesCore::MutSelAA(codon_fitnesses, *q).clone();
 }
 
 
@@ -41,23 +41,23 @@ RevBayesCore::ConcreteTimeReversibleRateMatrix* MutSelFunc(const RevBayesCore::R
  *
  * \return A new copy of the process.
  */
-Func_MutSelRateMatrix* Func_MutSelRateMatrix::clone( void ) const
+Func_MutSelAARateMatrix* Func_MutSelAARateMatrix::clone( void ) const
 {
-    return new Func_MutSelRateMatrix( *this );
+    return new Func_MutSelAARateMatrix( *this );
 }
 
 
-RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >* Func_MutSelRateMatrix::createFunction( void ) const
+RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >* Func_MutSelAARateMatrix::createFunction( void ) const
 {
     RevBayesCore::TypedDagNode< RevBayesCore::RbVector<double> >* f = static_cast<const ModelVector<Real> &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
     RevBayesCore::TypedDagNode< RevBayesCore::RateGenerator >* q = static_cast<const RateGenerator &>( this->args[1].getVariable()->getRevObject() ).getDagNode();
 
-    return RevBayesCore::generic_function_ptr2< RevBayesCore::RateGenerator >( MutSelFunc, f, q );
+    return RevBayesCore::generic_function_ptr2< RevBayesCore::RateGenerator >( MutSelAAFunc, f, q );
 }
 
 
 /* Get argument rules */
-const ArgumentRules& Func_MutSelRateMatrix::getArgumentRules( void ) const
+const ArgumentRules& Func_MutSelAARateMatrix::getArgumentRules( void ) const
 {
 
     static ArgumentRules argumentRules = ArgumentRules();
@@ -65,7 +65,7 @@ const ArgumentRules& Func_MutSelRateMatrix::getArgumentRules( void ) const
 
     if ( !rules_set )
     {
-        argumentRules.push_back( new ArgumentRule( "fitnesses", ModelVector<Real>::getClassTypeSpec(), "Codon fitnesses.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        argumentRules.push_back( new ArgumentRule( "fitnesses", ModelVector<Real>::getClassTypeSpec(), "Amino acid fitnesses.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
         argumentRules.push_back( new ArgumentRule( "submodel", RateMatrix::getClassTypeSpec(), "Codon rate matrix.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
 
         rules_set = true;
@@ -75,17 +75,17 @@ const ArgumentRules& Func_MutSelRateMatrix::getArgumentRules( void ) const
 }
 
 
-const std::string& Func_MutSelRateMatrix::getClassType(void)
+const std::string& Func_MutSelAARateMatrix::getClassType(void)
 {
 
-    static std::string rev_type = "Func_MutSelRateMatrix";
+    static std::string rev_type = "Func_MutSelAARateMatrix";
 
     return rev_type;
 }
 
 
 /* Get class type spec describing type of object */
-const TypeSpec& Func_MutSelRateMatrix::getClassTypeSpec(void)
+const TypeSpec& Func_MutSelAARateMatrix::getClassTypeSpec(void)
 {
 
     static TypeSpec rev_type_spec = TypeSpec( getClassType(), new TypeSpec( Function::getClassTypeSpec() ) );
@@ -97,16 +97,16 @@ const TypeSpec& Func_MutSelRateMatrix::getClassTypeSpec(void)
 /**
  * Get the primary Rev name for this function.
  */
-std::string Func_MutSelRateMatrix::getFunctionName( void ) const
+std::string Func_MutSelAARateMatrix::getFunctionName( void ) const
 {
     // create a name variable that is the same for all instance of this class
-    std::string f_name = "fnMutSel";
+    std::string f_name = "fnMutSelAA";
 
     return f_name;
 }
 
 
-const TypeSpec& Func_MutSelRateMatrix::getTypeSpec( void ) const
+const TypeSpec& Func_MutSelAARateMatrix::getTypeSpec( void ) const
 {
 
     static TypeSpec type_spec = getClassTypeSpec();

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_MutSelAARateMatrix.h
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_MutSelAARateMatrix.h
@@ -20,7 +20,7 @@ class ArgumentRules;
 class TypeSpec;
 
     /**
-     * The RevLanguage wrapper of the Goldman-Yang (1994) rate matrix function.
+     * The RevLanguage wrapper of the MutSelAA rate matrix function.
      *
      *
      * @copyright Copyright 2021-

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_MutSelAARateMatrix.h
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_MutSelAARateMatrix.h
@@ -1,0 +1,53 @@
+#ifndef Func_MutSelAARateMatrix_H
+#define Func_MutSelAARateMatrix_H
+
+#include <string>
+#include <iosfwd>
+#include <vector>
+
+#include "RlRateMatrix.h"
+#include "RlTypedFunction.h"
+#include "DeterministicNode.h"
+#include "DynamicNode.h"
+#include "RateGenerator.h"
+#include "RevPtr.h"
+#include "RlDeterministicNode.h"
+#include "TypedDagNode.h"
+#include "TypedFunction.h"
+
+namespace RevLanguage {
+class ArgumentRules;
+class TypeSpec;
+
+    /**
+     * The RevLanguage wrapper of the Goldman-Yang (1994) rate matrix function.
+     *
+     *
+     * @copyright Copyright 2021-
+     * @author Benjamin D. Redelings
+     * @since 2022-02-12, version 1.0
+     *
+     */
+    class Func_MutSelAARateMatrix : public TypedFunction<RateMatrix> {
+
+    public:
+        Func_MutSelAARateMatrix() = default;
+
+        // Basic utility functions
+        Func_MutSelAARateMatrix*                                            clone(void) const;                                          //!< Clone the object
+        static const std::string&                                           getClassType(void);                                         //!< Get Rev type
+        static const TypeSpec&                                              getClassTypeSpec(void);                                     //!< Get class type spec
+        std::string                                                         getFunctionName(void) const;                                //!< Get the primary name of the function in Rev
+        const TypeSpec&                                                     getTypeSpec(void) const;                                    //!< Get the type spec of the instance
+
+        // Function functions you have to override
+        RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >*         createFunction(void) const;                                 //!< Create a function object
+        const ArgumentRules&                                                getArgumentRules(void) const;                               //!< Get argument rules
+
+    };
+
+}
+
+#endif
+
+

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_MutSelRateMatrix.cpp
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_MutSelRateMatrix.cpp
@@ -21,8 +21,13 @@
 
 using namespace RevLanguage;
 
-RevBayesCore::ConcreteTimeReversibleRateMatrix* MutSelFunc(const RevBayesCore::RbVector<double> codon_fitnesses, const RevBayesCore::RateGenerator& q_)
+RevBayesCore::ConcreteTimeReversibleRateMatrix* MutSelFunc(const RevBayesCore::RbVector<double> fitnesses, const RevBayesCore::RateGenerator& q_)
 {
+    const int n = q_.getNumberOfStates();
+
+    if (fitnesses.size() != n)
+        throw RbException("fnMutSel: there should be " + std::to_string(n) + " fitnesses.");
+
     auto q = dynamic_cast<const RevBayesCore::TimeReversibleRateMatrix*>(&q_);
 
     if (not q)
@@ -31,7 +36,7 @@ RevBayesCore::ConcreteTimeReversibleRateMatrix* MutSelFunc(const RevBayesCore::R
     if (q->getRateMatrix().getNumberOfColumns() != 61)
         throw RbException("The dN/dS rate matrix should be 61x61.");
     
-    return RevBayesCore::MutSel(codon_fitnesses, *q).clone();
+    return RevBayesCore::MutSel(fitnesses, *q).clone();
 }
 
 
@@ -65,8 +70,8 @@ const ArgumentRules& Func_MutSelRateMatrix::getArgumentRules( void ) const
 
     if ( !rules_set )
     {
-        argumentRules.push_back( new ArgumentRule( "fitnesses", ModelVector<Real>::getClassTypeSpec(), "Codon fitnesses.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
-        argumentRules.push_back( new ArgumentRule( "submodel", RateMatrix::getClassTypeSpec(), "Codon rate matrix.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        argumentRules.push_back( new ArgumentRule( "fitnesses", ModelVector<Real>::getClassTypeSpec(), "Fitnesses.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        argumentRules.push_back( new ArgumentRule( "submodel", RateMatrix::getClassTypeSpec(), "Mutation rate matrix.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
 
         rules_set = true;
     }

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_MutSelRateMatrix.cpp
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_MutSelRateMatrix.cpp
@@ -1,0 +1,116 @@
+#include "Func_MutSelRateMatrix.h"
+#include "CppCodonFuncs.h"
+
+#include "Real.h"
+#include "ModelVector.h"
+#include "RlDeterministicNode.h"
+#include "RlRateMatrix.h"
+#include "RlSimplex.h"
+#include "GenericFunction.h"
+#include "TypedDagNode.h"
+#include "Argument.h"
+#include "ArgumentRule.h"
+#include "ArgumentRules.h"
+#include "RbException.h"
+#include "RevVariable.h"
+#include "RlFunction.h"
+#include "Simplex.h"
+#include "TypeSpec.h"
+
+#include "ConcreteTimeReversibleRateMatrix.h"
+
+using namespace RevLanguage;
+
+RevBayesCore::ConcreteTimeReversibleRateMatrix* MutSelFunc(const RevBayesCore::RbVector<double> codon_fitnesses, const RevBayesCore::RateGenerator& q_)
+{
+    auto q = dynamic_cast<const RevBayesCore::TimeReversibleRateMatrix*>(&q_);
+
+    if (not q)
+        throw RbException("fnMutSel: the argument must be a time-reversible rate matrix.");
+
+    if (q->getRateMatrix().getNumberOfColumns() != 61)
+        throw RbException("The dN/dS rate matrix should be 61x61.");
+    
+    std::vector<double> ws = codon_fitnesses;
+    return RevBayesCore::MutSel(*q, ws).clone();
+}
+
+
+/**
+ * The clone function is a convenience function to create proper copies of inherited objected.
+ * E.g. a.clone() will create a clone of the correct type even if 'a' is of derived type 'b'.
+ *
+ * \return A new copy of the process.
+ */
+Func_MutSelRateMatrix* Func_MutSelRateMatrix::clone( void ) const
+{
+    return new Func_MutSelRateMatrix( *this );
+}
+
+
+RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >* Func_MutSelRateMatrix::createFunction( void ) const
+{
+    RevBayesCore::TypedDagNode< RevBayesCore::RbVector<double> >* f = static_cast<const ModelVector<Real> &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode< RevBayesCore::RateGenerator >* q = static_cast<const RateGenerator &>( this->args[1].getVariable()->getRevObject() ).getDagNode();
+
+    return RevBayesCore::generic_function_ptr2< RevBayesCore::RateGenerator >( MutSelFunc, f, q );
+}
+
+
+/* Get argument rules */
+const ArgumentRules& Func_MutSelRateMatrix::getArgumentRules( void ) const
+{
+
+    static ArgumentRules argumentRules = ArgumentRules();
+    static bool          rules_set = false;
+
+    if ( !rules_set )
+    {
+        argumentRules.push_back( new ArgumentRule( "fitnesses", ModelVector<Real>::getClassTypeSpec(), "Codon fitnesses.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        argumentRules.push_back( new ArgumentRule( "submodel", RateMatrix::getClassTypeSpec(), "Codon rate matrix.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+
+        rules_set = true;
+    }
+
+    return argumentRules;
+}
+
+
+const std::string& Func_MutSelRateMatrix::getClassType(void)
+{
+
+    static std::string rev_type = "Func_MutSelRateMatrix";
+
+    return rev_type;
+}
+
+
+/* Get class type spec describing type of object */
+const TypeSpec& Func_MutSelRateMatrix::getClassTypeSpec(void)
+{
+
+    static TypeSpec rev_type_spec = TypeSpec( getClassType(), new TypeSpec( Function::getClassTypeSpec() ) );
+
+    return rev_type_spec;
+}
+
+
+/**
+ * Get the primary Rev name for this function.
+ */
+std::string Func_MutSelRateMatrix::getFunctionName( void ) const
+{
+    // create a name variable that is the same for all instance of this class
+    std::string f_name = "fnMutSel";
+
+    return f_name;
+}
+
+
+const TypeSpec& Func_MutSelRateMatrix::getTypeSpec( void ) const
+{
+
+    static TypeSpec type_spec = getClassTypeSpec();
+
+    return type_spec;
+}

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_MutSelRateMatrix.cpp
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_MutSelRateMatrix.cpp
@@ -33,9 +33,6 @@ RevBayesCore::ConcreteTimeReversibleRateMatrix* MutSelFunc(const RevBayesCore::R
     if (not q)
         throw RbException("fnMutSel: the argument must be a time-reversible rate matrix.");
 
-    if (q->getRateMatrix().getNumberOfColumns() != 61)
-        throw RbException("The dN/dS rate matrix should be 61x61.");
-    
     return RevBayesCore::MutSel(fitnesses, *q).clone();
 }
 

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_MutSelRateMatrix.h
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_MutSelRateMatrix.h
@@ -20,7 +20,7 @@ class ArgumentRules;
 class TypeSpec;
 
     /**
-     * The RevLanguage wrapper of the Goldman-Yang (1994) rate matrix function.
+     * The RevLanguage wrapper of the MutSel rate matrix function.
      *
      *
      * @copyright Copyright 2021-

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_MutSelRateMatrix.h
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_MutSelRateMatrix.h
@@ -1,0 +1,53 @@
+#ifndef Func_MutSelRateMatrix_H
+#define Func_MutSelRateMatrix_H
+
+#include <string>
+#include <iosfwd>
+#include <vector>
+
+#include "RlRateMatrix.h"
+#include "RlTypedFunction.h"
+#include "DeterministicNode.h"
+#include "DynamicNode.h"
+#include "RateGenerator.h"
+#include "RevPtr.h"
+#include "RlDeterministicNode.h"
+#include "TypedDagNode.h"
+#include "TypedFunction.h"
+
+namespace RevLanguage {
+class ArgumentRules;
+class TypeSpec;
+
+    /**
+     * The RevLanguage wrapper of the Goldman-Yang (1994) rate matrix function.
+     *
+     *
+     * @copyright Copyright 2021-
+     * @author Benjamin D. Redelings
+     * @since 2022-02-12, version 1.0
+     *
+     */
+    class Func_MutSelRateMatrix : public TypedFunction<RateMatrix> {
+
+    public:
+        Func_MutSelRateMatrix() = default;
+
+        // Basic utility functions
+        Func_MutSelRateMatrix*                                                clone(void) const;                                          //!< Clone the object
+        static const std::string&                                           getClassType(void);                                         //!< Get Rev type
+        static const TypeSpec&                                              getClassTypeSpec(void);                                     //!< Get class type spec
+        std::string                                                         getFunctionName(void) const;                                //!< Get the primary name of the function in Rev
+        const TypeSpec&                                                     getTypeSpec(void) const;                                    //!< Get the type spec of the instance
+
+        // Function functions you have to override
+        RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >*         createFunction(void) const;                                 //!< Create a function object
+        const ArgumentRules&                                                getArgumentRules(void) const;                               //!< Get argument rules
+
+    };
+
+}
+
+#endif
+
+

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_X2RateMatrix.cpp
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_X2RateMatrix.cpp
@@ -1,0 +1,112 @@
+#include "Func_X2RateMatrix.h"
+#include "CppDoubletFuncs.h"
+
+#include "RealPos.h"
+#include "RlDeterministicNode.h"
+#include "RlRateMatrix.h"
+#include "RlSimplex.h"
+#include "GenericFunction.h"
+#include "TypedDagNode.h"
+#include "Argument.h"
+#include "ArgumentRule.h"
+#include "ArgumentRules.h"
+#include "RbException.h"
+#include "RevVariable.h"
+#include "RlFunction.h"
+#include "Simplex.h"
+#include "TypeSpec.h"
+
+#include "ConcreteTimeReversibleRateMatrix.h"
+
+using namespace RevLanguage;
+
+RevBayesCore::ConcreteTimeReversibleRateMatrix* X2Func(const RevBayesCore::RateGenerator& nuc_q_)
+{
+    auto nuc_q = dynamic_cast<const RevBayesCore::TimeReversibleRateMatrix*>(&nuc_q_);
+
+    if (not nuc_q)
+        throw RbException("fnX2: the argument must be a time-reversible rate matrix.");
+
+    if (nuc_q->getRateMatrix().getNumberOfColumns() != 4)
+        throw RbException("The nucleotide rate matrix should be 4x4.");
+
+    return RevBayesCore::X2(*nuc_q).clone();
+}
+
+
+/**
+ * The clone function is a convenience function to create proper copies of inherited objected.
+ * E.g. a.clone() will create a clone of the correct type even if 'a' is of derived type 'b'.
+ *
+ * \return A new copy of the process.
+ */
+Func_X2RateMatrix* Func_X2RateMatrix::clone( void ) const
+{
+    return new Func_X2RateMatrix( *this );
+}
+
+
+RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >* Func_X2RateMatrix::createFunction( void ) const
+{
+    RevBayesCore::TypedDagNode< RevBayesCore::RateGenerator >* nuc_q = static_cast<const RateGenerator &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
+
+    return RevBayesCore::generic_function_ptr2< RevBayesCore::RateGenerator >( X2Func, nuc_q );
+}
+
+
+/* Get argument rules */
+const ArgumentRules& Func_X2RateMatrix::getArgumentRules( void ) const
+{
+
+    static ArgumentRules argumentRules = ArgumentRules();
+    static bool          rules_set = false;
+
+    if ( !rules_set )
+    {
+        argumentRules.push_back( new ArgumentRule( "submodel", RateMatrix::getClassTypeSpec(), "Nucleotide rate matrix.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+
+        rules_set = true;
+    }
+
+    return argumentRules;
+}
+
+
+const std::string& Func_X2RateMatrix::getClassType(void)
+{
+
+    static std::string rev_type = "Func_X2RateMatrix";
+
+    return rev_type;
+}
+
+
+/* Get class type spec describing type of object */
+const TypeSpec& Func_X2RateMatrix::getClassTypeSpec(void)
+{
+
+    static TypeSpec rev_type_spec = TypeSpec( getClassType(), new TypeSpec( Function::getClassTypeSpec() ) );
+
+    return rev_type_spec;
+}
+
+
+/**
+ * Get the primary Rev name for this function.
+ */
+std::string Func_X2RateMatrix::getFunctionName( void ) const
+{
+    // create a name variable that is the same for all instance of this class
+    std::string f_name = "fnX2";
+
+    return f_name;
+}
+
+
+const TypeSpec& Func_X2RateMatrix::getTypeSpec( void ) const
+{
+
+    static TypeSpec type_spec = getClassTypeSpec();
+
+    return type_spec;
+}

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_X2RateMatrix.h
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_X2RateMatrix.h
@@ -1,0 +1,53 @@
+#ifndef Func_X2RateMatrix_H
+#define Func_X2RateMatrix_H
+
+#include <string>
+#include <iosfwd>
+#include <vector>
+
+#include "RlRateMatrix.h"
+#include "RlTypedFunction.h"
+#include "DeterministicNode.h"
+#include "DynamicNode.h"
+#include "RateGenerator.h"
+#include "RevPtr.h"
+#include "RlDeterministicNode.h"
+#include "TypedDagNode.h"
+#include "TypedFunction.h"
+
+namespace RevLanguage {
+class ArgumentRules;
+class TypeSpec;
+
+    /**
+     * The RevLanguage wrapper of the Goldman-Yang (1994) rate matrix function.
+     *
+     *
+     * @copyright Copyright 2021-
+     * @author Benjamin D. Redelings
+     * @since 2022-02-12, version 1.0
+     *
+     */
+    class Func_X2RateMatrix : public TypedFunction<RateMatrix> {
+
+    public:
+        Func_X2RateMatrix() = default;
+
+        // Basic utility functions
+        Func_X2RateMatrix*                                                  clone(void) const;                                          //!< Clone the object
+        static const std::string&                                           getClassType(void);                                         //!< Get Rev type
+        static const TypeSpec&                                              getClassTypeSpec(void);                                     //!< Get class type spec
+        std::string                                                         getFunctionName(void) const;                                //!< Get the primary name of the function in Rev
+        const TypeSpec&                                                     getTypeSpec(void) const;                                    //!< Get the type spec of the instance
+
+        // Function functions you have to override
+        RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >*         createFunction(void) const;                                 //!< Create a function object
+        const ArgumentRules&                                                getArgumentRules(void) const;                               //!< Get argument rules
+
+    };
+
+}
+
+#endif
+
+

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_X2RateMatrix.h
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_X2RateMatrix.h
@@ -20,7 +20,7 @@ class ArgumentRules;
 class TypeSpec;
 
     /**
-     * The RevLanguage wrapper of the Goldman-Yang (1994) rate matrix function.
+     * The RevLanguage wrapper of X2 rate matrix function.
      *
      *
      * @copyright Copyright 2021-

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_X3RateMatrix.cpp
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_X3RateMatrix.cpp
@@ -1,0 +1,112 @@
+#include "Func_X3RateMatrix.h"
+#include "CppCodonFuncs.h"
+
+#include "RealPos.h"
+#include "RlDeterministicNode.h"
+#include "RlRateMatrix.h"
+#include "RlSimplex.h"
+#include "GenericFunction.h"
+#include "TypedDagNode.h"
+#include "Argument.h"
+#include "ArgumentRule.h"
+#include "ArgumentRules.h"
+#include "RbException.h"
+#include "RevVariable.h"
+#include "RlFunction.h"
+#include "Simplex.h"
+#include "TypeSpec.h"
+
+#include "ConcreteTimeReversibleRateMatrix.h"
+
+using namespace RevLanguage;
+
+RevBayesCore::ConcreteTimeReversibleRateMatrix* X3Func(const RevBayesCore::RateGenerator& nuc_q_)
+{
+    auto nuc_q = dynamic_cast<const RevBayesCore::TimeReversibleRateMatrix*>(&nuc_q_);
+
+    if (not nuc_q)
+        throw RbException("fnX3: the argument must be a time-reversible rate matrix.");
+
+    if (nuc_q->getRateMatrix().getNumberOfColumns() != 4)
+        throw RbException("The nucleotide rate matrix should be 4x4.");
+
+    return RevBayesCore::X3(*nuc_q).clone();
+}
+
+
+/**
+ * The clone function is a convenience function to create proper copies of inherited objected.
+ * E.g. a.clone() will create a clone of the correct type even if 'a' is of derived type 'b'.
+ *
+ * \return A new copy of the process.
+ */
+Func_X3RateMatrix* Func_X3RateMatrix::clone( void ) const
+{
+    return new Func_X3RateMatrix( *this );
+}
+
+
+RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >* Func_X3RateMatrix::createFunction( void ) const
+{
+    RevBayesCore::TypedDagNode< RevBayesCore::RateGenerator >* nuc_q = static_cast<const RateGenerator &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
+
+    return RevBayesCore::generic_function_ptr2< RevBayesCore::RateGenerator >( X3Func, nuc_q );
+}
+
+
+/* Get argument rules */
+const ArgumentRules& Func_X3RateMatrix::getArgumentRules( void ) const
+{
+
+    static ArgumentRules argumentRules = ArgumentRules();
+    static bool          rules_set = false;
+
+    if ( !rules_set )
+    {
+        argumentRules.push_back( new ArgumentRule( "submodel", RateMatrix::getClassTypeSpec(), "Nucleotide rate matrix.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+
+        rules_set = true;
+    }
+
+    return argumentRules;
+}
+
+
+const std::string& Func_X3RateMatrix::getClassType(void)
+{
+
+    static std::string rev_type = "Func_X3RateMatrix";
+
+    return rev_type;
+}
+
+
+/* Get class type spec describing type of object */
+const TypeSpec& Func_X3RateMatrix::getClassTypeSpec(void)
+{
+
+    static TypeSpec rev_type_spec = TypeSpec( getClassType(), new TypeSpec( Function::getClassTypeSpec() ) );
+
+    return rev_type_spec;
+}
+
+
+/**
+ * Get the primary Rev name for this function.
+ */
+std::string Func_X3RateMatrix::getFunctionName( void ) const
+{
+    // create a name variable that is the same for all instance of this class
+    std::string f_name = "fnX3";
+
+    return f_name;
+}
+
+
+const TypeSpec& Func_X3RateMatrix::getTypeSpec( void ) const
+{
+
+    static TypeSpec type_spec = getClassTypeSpec();
+
+    return type_spec;
+}

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_X3RateMatrix.h
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_X3RateMatrix.h
@@ -20,7 +20,7 @@ class ArgumentRules;
 class TypeSpec;
 
     /**
-     * The RevLanguage wrapper of the Goldman-Yang (1994) rate matrix function.
+     * The RevLanguage wrapper of the X3 rate matrix function.
      *
      *
      * @copyright Copyright 2021-

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_X3RateMatrix.h
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_X3RateMatrix.h
@@ -1,0 +1,53 @@
+#ifndef Func_X3RateMatrix_H
+#define Func_X3RateMatrix_H
+
+#include <string>
+#include <iosfwd>
+#include <vector>
+
+#include "RlRateMatrix.h"
+#include "RlTypedFunction.h"
+#include "DeterministicNode.h"
+#include "DynamicNode.h"
+#include "RateGenerator.h"
+#include "RevPtr.h"
+#include "RlDeterministicNode.h"
+#include "TypedDagNode.h"
+#include "TypedFunction.h"
+
+namespace RevLanguage {
+class ArgumentRules;
+class TypeSpec;
+
+    /**
+     * The RevLanguage wrapper of the Goldman-Yang (1994) rate matrix function.
+     *
+     *
+     * @copyright Copyright 2021-
+     * @author Benjamin D. Redelings
+     * @since 2022-02-12, version 1.0
+     *
+     */
+    class Func_X3RateMatrix : public TypedFunction<RateMatrix> {
+
+    public:
+        Func_X3RateMatrix() = default;
+
+        // Basic utility functions
+        Func_X3RateMatrix*                                                  clone(void) const;                                          //!< Clone the object
+        static const std::string&                                           getClassType(void);                                         //!< Get Rev type
+        static const TypeSpec&                                              getClassTypeSpec(void);                                     //!< Get class type spec
+        std::string                                                         getFunctionName(void) const;                                //!< Get the primary name of the function in Rev
+        const TypeSpec&                                                     getTypeSpec(void) const;                                    //!< Get the type spec of the instance
+
+        // Function functions you have to override
+        RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >*         createFunction(void) const;                                 //!< Create a function object
+        const ArgumentRules&                                                getArgumentRules(void) const;                               //!< Get argument rules
+
+    };
+
+}
+
+#endif
+
+

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_dNdSRateMatrix.cpp
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_dNdSRateMatrix.cpp
@@ -1,0 +1,114 @@
+#include "Func_dNdSRateMatrix.h"
+#include "CppCodonFuncs.h"
+
+#include "RealPos.h"
+#include "RlDeterministicNode.h"
+#include "RlRateMatrix.h"
+#include "RlSimplex.h"
+#include "GenericFunction.h"
+#include "TypedDagNode.h"
+#include "Argument.h"
+#include "ArgumentRule.h"
+#include "ArgumentRules.h"
+#include "RbException.h"
+#include "RevVariable.h"
+#include "RlFunction.h"
+#include "Simplex.h"
+#include "TypeSpec.h"
+
+#include "ConcreteTimeReversibleRateMatrix.h"
+
+using namespace RevLanguage;
+
+RevBayesCore::ConcreteTimeReversibleRateMatrix* dNdSFunc(double omega, const RevBayesCore::RateGenerator& nuc_q_)
+{
+    auto nuc_q = dynamic_cast<const RevBayesCore::TimeReversibleRateMatrix*>(&nuc_q_);
+
+    if (not nuc_q)
+        throw RbException("fndNdS: the argument must be a time-reversible rate matrix.");
+
+    if (nuc_q->getRateMatrix().getNumberOfColumns() != 61)
+        throw RbException("The dN/dS rate matrix should be 61x61.");
+
+    return RevBayesCore::dNdS(omega, *nuc_q).clone();
+}
+
+
+/**
+ * The clone function is a convenience function to create proper copies of inherited objected.
+ * E.g. a.clone() will create a clone of the correct type even if 'a' is of derived type 'b'.
+ *
+ * \return A new copy of the process.
+ */
+Func_dNdSRateMatrix* Func_dNdSRateMatrix::clone( void ) const
+{
+    return new Func_dNdSRateMatrix( *this );
+}
+
+
+RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >* Func_dNdSRateMatrix::createFunction( void ) const
+{
+    RevBayesCore::TypedDagNode< double >* omega = static_cast<const RealPos &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode< RevBayesCore::RateGenerator >* nuc_q = static_cast<const RateGenerator &>( this->args[1].getVariable()->getRevObject() ).getDagNode();
+
+    return RevBayesCore::generic_function_ptr2< RevBayesCore::RateGenerator >( dNdSFunc, omega, nuc_q );
+}
+
+
+/* Get argument rules */
+const ArgumentRules& Func_dNdSRateMatrix::getArgumentRules( void ) const
+{
+
+    static ArgumentRules argumentRules = ArgumentRules();
+    static bool          rules_set = false;
+
+    if ( !rules_set )
+    {
+        argumentRules.push_back( new ArgumentRule( "omega"          , RealPos::getClassTypeSpec(), "The dN / dS rate ratio.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        argumentRules.push_back( new ArgumentRule( "submodel", RateMatrix::getClassTypeSpec(), "Singlet (i.e. nucleotide) rate matrix.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+
+        rules_set = true;
+    }
+
+    return argumentRules;
+}
+
+
+const std::string& Func_dNdSRateMatrix::getClassType(void)
+{
+
+    static std::string rev_type = "Func_dNdSRateMatrix";
+
+    return rev_type;
+}
+
+
+/* Get class type spec describing type of object */
+const TypeSpec& Func_dNdSRateMatrix::getClassTypeSpec(void)
+{
+
+    static TypeSpec rev_type_spec = TypeSpec( getClassType(), new TypeSpec( Function::getClassTypeSpec() ) );
+
+    return rev_type_spec;
+}
+
+
+/**
+ * Get the primary Rev name for this function.
+ */
+std::string Func_dNdSRateMatrix::getFunctionName( void ) const
+{
+    // create a name variable that is the same for all instance of this class
+    std::string f_name = "fndNdS";
+
+    return f_name;
+}
+
+
+const TypeSpec& Func_dNdSRateMatrix::getTypeSpec( void ) const
+{
+
+    static TypeSpec type_spec = getClassTypeSpec();
+
+    return type_spec;
+}

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_dNdSRateMatrix.h
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_dNdSRateMatrix.h
@@ -1,0 +1,53 @@
+#ifndef Func_dNdSRateMatrix_H
+#define Func_dNdSRateMatrix_H
+
+#include <string>
+#include <iosfwd>
+#include <vector>
+
+#include "RlRateMatrix.h"
+#include "RlTypedFunction.h"
+#include "DeterministicNode.h"
+#include "DynamicNode.h"
+#include "RateGenerator.h"
+#include "RevPtr.h"
+#include "RlDeterministicNode.h"
+#include "TypedDagNode.h"
+#include "TypedFunction.h"
+
+namespace RevLanguage {
+class ArgumentRules;
+class TypeSpec;
+
+    /**
+     * The RevLanguage wrapper of the Goldman-Yang (1994) rate matrix function.
+     *
+     *
+     * @copyright Copyright 2021-
+     * @author Benjamin D. Redelings
+     * @since 2022-02-12, version 1.0
+     *
+     */
+    class Func_dNdSRateMatrix : public TypedFunction<RateMatrix> {
+
+    public:
+        Func_dNdSRateMatrix() = default;
+
+        // Basic utility functions
+        Func_dNdSRateMatrix*                                                clone(void) const;                                          //!< Clone the object
+        static const std::string&                                           getClassType(void);                                         //!< Get Rev type
+        static const TypeSpec&                                              getClassTypeSpec(void);                                     //!< Get class type spec
+        std::string                                                         getFunctionName(void) const;                                //!< Get the primary name of the function in Rev
+        const TypeSpec&                                                     getTypeSpec(void) const;                                    //!< Get the type spec of the instance
+
+        // Function functions you have to override
+        RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >*         createFunction(void) const;                                 //!< Create a function object
+        const ArgumentRules&                                                getArgumentRules(void) const;                               //!< Get argument rules
+
+    };
+
+}
+
+#endif
+
+

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_dNdSRateMatrix.h
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_dNdSRateMatrix.h
@@ -20,7 +20,7 @@ class ArgumentRules;
 class TypeSpec;
 
     /**
-     * The RevLanguage wrapper of the Goldman-Yang (1994) rate matrix function.
+     * The RevLanguage wrapper of the dNdS rate matrix function.
      *
      *
      * @copyright Copyright 2021-

--- a/src/revlanguage/workspace/RbRegister_Func.cpp
+++ b/src/revlanguage/workspace/RbRegister_Func.cpp
@@ -136,6 +136,7 @@
 #include "Func_X3RateMatrix.h"
 #include "Func_dNdSRateMatrix.h"
 #include "Func_MutSelRateMatrix.h"
+#include "Func_MutSelAARateMatrix.h"
 
 #include "Func_covarionRateMatrix.h"
 #include "Func_covarion.h"
@@ -314,6 +315,7 @@ void RevLanguage::Workspace::initializeFuncGlobalWorkspace(void)
         addFunction( new Func_X3RateMatrix()                                );
         addFunction( new Func_dNdSRateMatrix()                              );
         addFunction( new Func_MutSelRateMatrix()                            );
+        addFunction( new Func_MutSelAARateMatrix()                          );
 
         addFunction( new Func_covarionRateMatrix()                          );
         addFunction( new Func_covarion()                                    );

--- a/src/revlanguage/workspace/RbRegister_Func.cpp
+++ b/src/revlanguage/workspace/RbRegister_Func.cpp
@@ -121,6 +121,7 @@
 /* Frequency functions (in folder "functions/phylogenetics/frequencies") */
 #include "Func_F1x4.h"
 #include "Func_F3x4.h"
+#include "Func_F2x4.h"
 
 /* Rate matrix functions (in folder "functions/phylogenetics/ratematrix") */
 #include "Func_BinaryMutationCoalescentRateMatrix.h"
@@ -139,6 +140,8 @@
 #include "Func_FMutSel0RateMatrix.h"
 #include "Func_MutSelRateMatrix.h"
 #include "Func_MutSelAARateMatrix.h"
+
+#include "Func_X2RateMatrix.h"
 
 #include "Func_covarionRateMatrix.h"
 #include "Func_covarion.h"
@@ -321,6 +324,8 @@ void RevLanguage::Workspace::initializeFuncGlobalWorkspace(void)
         addFunction( new Func_MutSelRateMatrix()                            );
         addFunction( new Func_MutSelAARateMatrix()                          );
 
+        addFunction( new Func_X2RateMatrix()                                );
+
         addFunction( new Func_covarionRateMatrix()                          );
         addFunction( new Func_covarion()                                    );
         addFunction( new Func_cpRev()                                       );
@@ -366,6 +371,7 @@ void RevLanguage::Workspace::initializeFuncGlobalWorkspace(void)
         /* frequency functions (in folder "function/phylogenetics/frequencies" */
         addFunction( new Func_F1x4()                                        );
         addFunction( new Func_F3x4()                                        );
+        addFunction( new Func_F2x4()                                        );
 
         /* rate maps used for data augmentation (in folder "functions/evolution/ratemap") */
         addFunction( new Func_adjacentRateModifier() );

--- a/src/revlanguage/workspace/RbRegister_Func.cpp
+++ b/src/revlanguage/workspace/RbRegister_Func.cpp
@@ -135,6 +135,7 @@
 #include "Func_MuseGaut94KRateMatrix.h"
 #include "Func_X3RateMatrix.h"
 #include "Func_dNdSRateMatrix.h"
+#include "Func_MutSelRateMatrix.h"
 
 #include "Func_covarionRateMatrix.h"
 #include "Func_covarion.h"
@@ -312,6 +313,7 @@ void RevLanguage::Workspace::initializeFuncGlobalWorkspace(void)
         addFunction( new Func_MuseGaut94KRateMatrix()                       );
         addFunction( new Func_X3RateMatrix()                                );
         addFunction( new Func_dNdSRateMatrix()                              );
+        addFunction( new Func_MutSelRateMatrix()                            );
 
         addFunction( new Func_covarionRateMatrix()                          );
         addFunction( new Func_covarion()                                    );

--- a/src/revlanguage/workspace/RbRegister_Func.cpp
+++ b/src/revlanguage/workspace/RbRegister_Func.cpp
@@ -131,6 +131,7 @@
 #include "Func_codonSynonymousNonsynonymousHKYRateMatrix.h"
 #include "Func_GoldmanYang94RateMatrix.h"
 #include "Func_MuseGaut94RateMatrix.h"
+#include "Func_MuseGaut94KRateMatrix.h"
 #include "Func_covarionRateMatrix.h"
 #include "Func_covarion.h"
 #include "Func_cpRev.h"
@@ -299,10 +300,13 @@ void RevLanguage::Workspace::initializeFuncGlobalWorkspace(void)
         addFunction( new Func_blosum62()                                    );
         addFunction( new Func_chromosomes()                                 );
         addFunction( new Func_chromosomesPloidy()                           );
+
         addFunction( new Func_codonSynonymousNonsynonymousRateMatrix()      );
         addFunction( new Func_codonSynonymousNonsynonymousHKYRateMatrix()   );
         addFunction( new Func_GoldmanYang94RateMatrix()                     );
         addFunction( new Func_MuseGaut94RateMatrix()                        );
+        addFunction( new Func_MuseGaut94KRateMatrix()                       );
+
         addFunction( new Func_covarionRateMatrix()                          );
         addFunction( new Func_covarion()                                    );
         addFunction( new Func_cpRev()                                       );

--- a/src/revlanguage/workspace/RbRegister_Func.cpp
+++ b/src/revlanguage/workspace/RbRegister_Func.cpp
@@ -135,6 +135,8 @@
 #include "Func_MuseGaut94KRateMatrix.h"
 #include "Func_X3RateMatrix.h"
 #include "Func_dNdSRateMatrix.h"
+#include "Func_FMutSelRateMatrix.h"
+#include "Func_FMutSel0RateMatrix.h"
 #include "Func_MutSelRateMatrix.h"
 #include "Func_MutSelAARateMatrix.h"
 
@@ -314,6 +316,8 @@ void RevLanguage::Workspace::initializeFuncGlobalWorkspace(void)
         addFunction( new Func_MuseGaut94KRateMatrix()                       );
         addFunction( new Func_X3RateMatrix()                                );
         addFunction( new Func_dNdSRateMatrix()                              );
+        addFunction( new Func_FMutSelRateMatrix()                           );
+        addFunction( new Func_FMutSel0RateMatrix()                          );
         addFunction( new Func_MutSelRateMatrix()                            );
         addFunction( new Func_MutSelAARateMatrix()                          );
 

--- a/src/revlanguage/workspace/RbRegister_Func.cpp
+++ b/src/revlanguage/workspace/RbRegister_Func.cpp
@@ -129,6 +129,7 @@
 #include "Func_chromosomesPloidy.h"
 #include "Func_codonSynonymousNonsynonymousRateMatrix.h"
 #include "Func_codonSynonymousNonsynonymousHKYRateMatrix.h"
+#include "Func_X3RateMatrix.h"
 #include "Func_GoldmanYang94RateMatrix.h"
 #include "Func_MuseGaut94RateMatrix.h"
 #include "Func_MuseGaut94KRateMatrix.h"
@@ -306,6 +307,7 @@ void RevLanguage::Workspace::initializeFuncGlobalWorkspace(void)
         addFunction( new Func_GoldmanYang94RateMatrix()                     );
         addFunction( new Func_MuseGaut94RateMatrix()                        );
         addFunction( new Func_MuseGaut94KRateMatrix()                       );
+        addFunction( new Func_X3RateMatrix()                                );
 
         addFunction( new Func_covarionRateMatrix()                          );
         addFunction( new Func_covarion()                                    );

--- a/src/revlanguage/workspace/RbRegister_Func.cpp
+++ b/src/revlanguage/workspace/RbRegister_Func.cpp
@@ -130,6 +130,7 @@
 #include "Func_codonSynonymousNonsynonymousRateMatrix.h"
 #include "Func_codonSynonymousNonsynonymousHKYRateMatrix.h"
 #include "Func_GoldmanYang94RateMatrix.h"
+#include "Func_MuseGaut94RateMatrix.h"
 #include "Func_covarionRateMatrix.h"
 #include "Func_covarion.h"
 #include "Func_cpRev.h"
@@ -301,6 +302,7 @@ void RevLanguage::Workspace::initializeFuncGlobalWorkspace(void)
         addFunction( new Func_codonSynonymousNonsynonymousRateMatrix()      );
         addFunction( new Func_codonSynonymousNonsynonymousHKYRateMatrix()   );
         addFunction( new Func_GoldmanYang94RateMatrix()                     );
+        addFunction( new Func_MuseGaut94RateMatrix()                        );
         addFunction( new Func_covarionRateMatrix()                          );
         addFunction( new Func_covarion()                                    );
         addFunction( new Func_cpRev()                                       );

--- a/src/revlanguage/workspace/RbRegister_Func.cpp
+++ b/src/revlanguage/workspace/RbRegister_Func.cpp
@@ -127,12 +127,15 @@
 #include "Func_blosum62.h"
 #include "Func_chromosomes.h"
 #include "Func_chromosomesPloidy.h"
+
 #include "Func_codonSynonymousNonsynonymousRateMatrix.h"
 #include "Func_codonSynonymousNonsynonymousHKYRateMatrix.h"
-#include "Func_X3RateMatrix.h"
 #include "Func_GoldmanYang94RateMatrix.h"
 #include "Func_MuseGaut94RateMatrix.h"
 #include "Func_MuseGaut94KRateMatrix.h"
+#include "Func_X3RateMatrix.h"
+#include "Func_dNdSRateMatrix.h"
+
 #include "Func_covarionRateMatrix.h"
 #include "Func_covarion.h"
 #include "Func_cpRev.h"
@@ -308,6 +311,7 @@ void RevLanguage::Workspace::initializeFuncGlobalWorkspace(void)
         addFunction( new Func_MuseGaut94RateMatrix()                        );
         addFunction( new Func_MuseGaut94KRateMatrix()                       );
         addFunction( new Func_X3RateMatrix()                                );
+        addFunction( new Func_dNdSRateMatrix()                              );
 
         addFunction( new Func_covarionRateMatrix()                          );
         addFunction( new Func_covarion()                                    );


### PR DESCRIPTION
This PR adds new functions for codon models
* fnCodonMG94 = Muse-Gaut '94
* fnCodonMG94K = Muse-Gaut '94 + transition/transition ratio
* fnFMutSel = mutation-selection model with selection coefficients on codons
* fnFMutSel0 = mutation-selection model with selection coefficients on amino acids
* fnX3 = construct a codon rate matrix from a nucleotide rate matrix
* fndNdS = add a factor of omega for non-synonymous substitutions to a codon rate matrix
* fnMutSel = construct a mutation-selection balance rate matrix with scaled selection coefficients w[i] = 2*N*s[i]
* fnMutSelAA = construct a mutation-selection balance rate matrix with scaled selection coefficients on amino acids

The last few can be used to construct codon models in a modular fashion.  For example, the standard fMutSel model is equivalent to `fndNdS(omega, fnMutSel(F, fnX3( fnGTR( er, nuc_pi ) ) ) )`.  We can describe this model as `GTR(er,nu_pi) + X3 + MutSel(F) + dNdS(omega)` or just `GTR+X3+MutSel+dNdS`.

It also adds two functions for Doublet models (i.e. for RNA stems):
* fnX2 = create a rate matrix on Doublets (nucleotide pairs)
* fnF2x4 = create  frequencies on Doublets from independent frequencies on first nuc and second nuc.

You can make a rate matrix on RNA stems by adding selection to a matrix for RNA loops by doing e.g.:
```
       er ~ dnDirichlet( v(1,1,1,1,1,1) )
       nuc_pi ~ dnDirichlet( rep(2.0, 4) )
       nuc_Q := fnGTR(er,nuc_pi)
       F ~ dnIID(16, dnNormal(0,1))
       stem_Q := fnMutSel(F, fnX2( nuc_Q) ) # GTR + X2 + MutSel
```
