### PR TITLE
Update make_winroot.sh, describe cross-builds in README.md, and fix RevStudio build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -194,8 +194,9 @@ jobs:
       run: |
         /usr/local/bin/meson build ${GITHUB_WORKSPACE} --prefix=${GITHUB_WORKSPACE}/wincrossbuild --cross-file=win64-cross.txt
         /usr/local/bin/ninja -C build install
-        cp /usr/lib/gcc/x86_64-w64-mingw32/*-win32/libgcc_s_seh-1.dll ${GITHUB_WORKSPACE}/wincrossbuild/bin
-        cp /usr/lib/gcc/x86_64-w64-mingw32/*-win32/libstdc++-6.dll ${GITHUB_WORKSPACE}/wincrossbuild/bin
+        cp /usr/lib/gcc/x86_64-w64-mingw32/*-posix/libgcc_s_seh-1.dll ${GITHUB_WORKSPACE}/wincrossbuild/bin
+        cp /usr/lib/gcc/x86_64-w64-mingw32/*-posix/libstdc++-6.dll ${GITHUB_WORKSPACE}/wincrossbuild/bin
+        cp /usr/lib/gcc/x86_64-w64-mingw32/*-posix/libssp-0.dll ${GITHUB_WORKSPACE}/wincrossbuild/bin
         cp /home/runner/win_root/mingw64/bin/libboost_*.dll ${GITHUB_WORKSPACE}/wincrossbuild/bin
         cp /home/runner/win_root/mingw64/bin/libwinpthread-1.dll ${GITHUB_WORKSPACE}/wincrossbuild/bin
         cp /home/runner/win_root/mingw64/bin/libopenlibm.dll ${GITHUB_WORKSPACE}/wincrossbuild/bin

--- a/projects/meson/README.md
+++ b/projects/meson/README.md
@@ -122,6 +122,8 @@ ninja -C build-gtk install
 
    This command should also generate a "cross-file" that contains info for cross-compiling to windows.
 
+   If you want to compile the GUI version for windows, add `-gtk true` to the command to `make_winroot.sh`.
+
 2. Compile Revbayes
 
    ```
@@ -131,24 +133,29 @@ ninja -C build-gtk install
    ninja -C build install
    ```
 
-   The `rb.exe` binary will end up in `~/winrb/bin`.
+   The binary will end up in `~/winrb/bin`.
+
+   If you want to compile the GUI version for windows, add `-Dstudio=true` to the meson command line.
 
 3. Copy DLLs that the binary needs to the same directory
 
    ```
-   cp /usr/lib/gcc/x86_64-w64-mingw32/*-win32/libgcc_s_seh-1.dll ~/winrb/bin
-   cp /usr/lib/gcc/x86_64-w64-mingw32/*-win32/libstdc++-6.dll    ~/winrb/bin
-   cp ~/win_root/mingw64/bin/libboost*.dll                       ~/winrb/bin
-   cp ~/win_root/mingw64/bin/libwinpthread-1.dll                 ~/winrb/bin
-   cp ~/win_root/mingw64/bin/libopenlibm.dll                     ~/winrb/bin
+   cp /usr/lib/gcc/x86_64-w64-mingw32/*-posix/libgcc_s_seh-1.dll ~/winrb/bin
+   cp /usr/lib/gcc/x86_64-w64-mingw32/*-posix/libstdc++-6.dll    ~/winrb/bin
+   cp /usr/lib/gcc/x86_64-w64-mingw32/*-posix/libssp-0.dll       ~/winrb/bin
+   cp ~/win_root/mingw64/bin/*.dll                               ~/winrb/bin
    ```
 
    This may be a bit fragile.  The paths for the first two DLLs are for Debian/Ubuntu, but could
    be somewhere else on other systems.
 
+   Note that we need the `*-win32/` versions of `libgcc_s_seh-1.dll` and `libstdc++-6.dll` and not the
+   `*-posix/` versions because we are using the mingw `libwinpthread-1.dll`.
+
    If you run `rb.exe` and it cannot find a DLL, it will tell you the first one that it cannot find.
 
 Note that this same procedure is shown in the `release.yml` workflow.
+
 
 ## Troubleshooting:
 

--- a/projects/meson/README.md
+++ b/projects/meson/README.md
@@ -111,6 +111,45 @@ meson build-gtk -Dstudio=true -Dprefix=$HOME/Applications/revbayes-gui
 ninja -C build-gtk install
 ```
 
+## Cross-compiling (Linux -> Windows)
+
+1. Create a fake windows root directory and download windows libraries from MINGW64.
+
+   ```
+   cd projects/meson/
+   ./make_winroot.sh -ccache true
+   ```
+
+   This command should also generate a "cross-file" that contains info for cross-compiling to windows.
+
+2. Compile Revbayes
+
+   ```
+   cd projects/meson
+   ./generate.sh
+   meson build ../../ --prefix=${HOME}/winrb  --cross-file=win64-cross.txt
+   ninja -C build install
+   ```
+
+   The `rb.exe` binary will end up in `~/winrb/bin`.
+
+3. Copy DLLs that the binary needs to the same directory
+
+   ```
+   cp /usr/lib/gcc/x86_64-w64-mingw32/*-posix/libgcc_s_seh-1.dll ~/winrb/bin
+   cp /usr/lib/gcc/x86_64-w64-mingw32/*-posix/libstdc++-6.dll    ~/winrb/bin
+   cp ~/win_root/mingw64/bin/libboost*.dll                       ~/winrb/bin
+   cp ~/win_root/mingw64/bin/libwinpthread-1.dll                 ~/winrb/bin
+   cp ~/win_root/mingw64/bin/libopenlibm.dll                     ~/winrb/bin
+   ```
+
+   This may be a bit fragile.  The paths for the first two DLLs are for Debian/Ubuntu, but could
+   be somewhere else on other systems.
+
+   If you run `rb.exe` and it cannot find a DLL, it will tell you the first one that it cannot find.
+
+Note that this same procedure is shown in the `release.yml` workflow.
+
 ## Troubleshooting:
 
 * `rb: command not found`

--- a/projects/meson/README.md
+++ b/projects/meson/README.md
@@ -136,8 +136,8 @@ ninja -C build-gtk install
 3. Copy DLLs that the binary needs to the same directory
 
    ```
-   cp /usr/lib/gcc/x86_64-w64-mingw32/*-posix/libgcc_s_seh-1.dll ~/winrb/bin
-   cp /usr/lib/gcc/x86_64-w64-mingw32/*-posix/libstdc++-6.dll    ~/winrb/bin
+   cp /usr/lib/gcc/x86_64-w64-mingw32/*-win32/libgcc_s_seh-1.dll ~/winrb/bin
+   cp /usr/lib/gcc/x86_64-w64-mingw32/*-win32/libstdc++-6.dll    ~/winrb/bin
    cp ~/win_root/mingw64/bin/libboost*.dll                       ~/winrb/bin
    cp ~/win_root/mingw64/bin/libwinpthread-1.dll                 ~/winrb/bin
    cp ~/win_root/mingw64/bin/libopenlibm.dll                     ~/winrb/bin

--- a/projects/meson/make_winroot.sh
+++ b/projects/meson/make_winroot.sh
@@ -9,6 +9,7 @@ while echo $1 | grep ^- > /dev/null; do
 -h                              : print this help and exit.
 -ccache          <true|false>   : set to true to add ccache to crossfile.
 -download        <true|false>   : download MINGW packages.
+-gtk             <true|false>   : include GTK2 packages.
 
 Example:
   ./make_winroot.sh -help true'
@@ -34,16 +35,16 @@ CROSSNAME=win64-cross.txt
 echo
 echo "2. Writing cross file to '${CROSSNAME}'"
 
-if [ "$ccache" = "true" ]; then
+if [ "$ccache" != "false" ]; then
     COMPILER_LINES=$(cat <<EOF
-c = ['ccache', '/usr/bin/x86_64-w64-mingw32-gcc']
-cpp = ['ccache', '/usr/bin/x86_64-w64-mingw32-g++']
+c = ['ccache', '/usr/bin/x86_64-w64-mingw32-gcc-posix']
+cpp = ['ccache', '/usr/bin/x86_64-w64-mingw32-g++-posix']
 EOF
 )
 else
     COMPILER_LINES=$(cat <<EOF
-c = '/usr/bin/x86_64-w64-mingw32-gcc'
-cpp = '/usr/bin/x86_64-w64-mingw32-g++'
+c = '/usr/bin/x86_64-w64-mingw32-gcc-posix'
+cpp = '/usr/bin/x86_64-w64-mingw32-g++-posix'
 EOF
 )
 fi
@@ -87,18 +88,69 @@ else
     echo "3. Installing packages to ${SYSROOT}"
     echo
 cd ${SYSROOT}
-PKGS="boost-1.75.0-2 libwinpthread-git-9.0.0.6090.ad98746a-1 openlibm-0.7.5-1"
+
+# Note that the use of gcc-posix and g++-posix means that we need
+# *-posix/libgcc_s_seh-1.dll and *-posix2/libstdc++-6.dll instead
+# of the *-win32/ versions.
+
+PKGS="boost-1.75.0-2
+libwinpthread-git-9.0.0.6090.ad98746a-1
+openlibm-0.7.5-1
+"
+
+if [ "${gtk}" = "true" ] ; then
+    PKGS="$PKGS
+    atk-2.36.0-2
+    brotli-1.0.9-4
+    bzip2-1.0.8-2
+    cairo-1.16.0-3
+    expat-2.4.6-1
+    fontconfig-2.13.96-1
+    freetype-2.11.1-2
+    fribidi-1.0.11-1
+    gdk-pixbuf2-2.42.6-2
+    gettext-0.21-3
+    glib2-2.70.4-1
+    graphite2-1.3.14-2
+    gtk2-2.24.33-4
+    harfbuzz-3.4.0-1
+    iconv-1.16-2
+    jasper-2.0.33-1
+    libdatrie-0.2.13-1
+    libffi-3.3-4
+    libiconv-1.16-2
+    libjpeg-turbo-2.1.3-1
+    libpng-1.6.37-6
+    libthai-0.1.29-1
+    libtiff-4.3.0-7
+    pango-1.50.4-1
+    pcre-8.45-1
+    pixman-0.40.0-2
+    xz-5.2.5-2
+    zlib-1.2.11-9
+"
+fi
+
 for PKG in ${PKGS} ; do
     FILE=mingw-w64-x86_64-${PKG}-any.pkg.tar.zst
-    rm -f ${FILE}
-    wget --no-verbose --show-progress http://repo.msys2.org/mingw/x86_64/${FILE}
-    if tar -I zstd -xf ${FILE} ; then
-        rm ${FILE}
+    if [ -e "${FILE}" ] ; then
+        echo "   ${PKG} already downloaded and installed."
     else
-        echo
-        echo "Perhaps the decompression program zstd is not installed?"
-        echo "Try 'sudo apt install zstd'."
-        exit
+        URL="http://repo.msys2.org/mingw/x86_64/${FILE}"
+        if ! wget --no-verbose --show-progress "${URL}" ; then
+            echo "Failed to download ${URL}"
+            exit
+        fi
+        if tar -I zstd -xf ${FILE} ; then
+            echo "${PKG} installed"
+        else
+            rm ${FILE}
+            echo "Failed to install ${PKG}"
+            echo
+            echo "Perhaps the decompression program zstd is not installed?"
+            echo "Try 'sudo apt install zstd'."
+            exit
+        fi
     fi
 done
 fi

--- a/projects/meson/make_winroot.sh
+++ b/projects/meson/make_winroot.sh
@@ -7,7 +7,8 @@ while echo $1 | grep ^- > /dev/null; do
     then
         echo 'Command line options are:
 -h                              : print this help and exit.
--ccache          <true|false>   : set to true to add ccache to crossfile
+-ccache          <true|false>   : set to true to add ccache to crossfile.
+-download        <true|false>   : download MINGW packages.
 
 Example:
   ./make_winroot.sh -help true'
@@ -28,20 +29,11 @@ echo "1. Writing sysroot dir ${SYSROOT}"
 mkdir -p "${SYSROOT}"
 mkdir -p "${SYSROOT}/bin"
 
-# 2. Generate pkg-config wrapper
-echo
-echo "2. Generating pkg-config wrapper"
-cat > "${SYSROOT}/bin/pkg-config" <<EOF
-#!/bin/bash
-export PKG_CONFIG_SYSROOT_DIR=${SYSROOT}
-export PKG_CONFIG_LIBDIR=${SYSROOT}/mingw64/lib/pkgconfig
-
-eval pkg-config "\$@"
-EOF
-chmod +x "${SYSROOT}/bin/pkg-config"
-
-# 3. Generate cross file
+# 2. Generate cross file
 CROSSNAME=win64-cross.txt
+echo
+echo "2. Writing cross file to '${CROSSNAME}'"
+
 if [ "$ccache" = "true" ]; then
     COMPILER_LINES=$(cat <<EOF
 c = ['ccache', '/usr/bin/x86_64-w64-mingw32-gcc']
@@ -56,24 +48,26 @@ EOF
 )
 fi
 
-echo
-echo "3. Writing cross file to '${CROSSNAME}'"
 cat > "${CROSSNAME}" <<EOF
 [binaries]
 ${COMPILER_LINES}
 ar = '/usr/bin/x86_64-w64-mingw32-ar'
 strip = '/usr/bin/x86_64-w64-mingw32-strip'
-pkgconfig = '${SYSROOT}/bin/pkg-config'
+pkgconfig = '/usr/bin/pkg-config'
 exe_wrapper = 'wine64' # A command used to run generated executables.
 
-# We need these compiler args to find BOOST, which doesn't use pkg-config
-[properties]
+# why do we still need these? shouldn't they get added automatically if we find boost?
+[built-in options]
 c_args = ['-I${SYSROOT}/mingw64/include']
 c_link_args = ['-L${SYSROOT}/mingw64/lib']
 
 cpp_args = ['-I${SYSROOT}/mingw64/include']
 cpp_link_args = ['-L${SYSROOT}/mingw64/lib']
- 
+
+[properties]
+sys_root = '${SYSROOT}'
+pkg_config_libdir = '${SYSROOT}/mingw64/lib/pkgconfig'
+boost_root = '${SYSROOT}/mingw64'
 
 [host_machine]
 system = 'windows'
@@ -82,19 +76,32 @@ cpu = 'x86_64'
 endian = 'little'
 EOF
 
-# 4. Download packages
-echo
-echo "4. Installing packages to ${SYSROOT}"
-echo
+# 3. Download packages
+if [ "$download" = "false" ] ; then
+    echo
+    echo "(3.) Skipping installation of packages to ${SYSROOT}."
+    echo
+else
+
+    echo
+    echo "3. Installing packages to ${SYSROOT}"
+    echo
 cd ${SYSROOT}
 PKGS="boost-1.75.0-2 libwinpthread-git-9.0.0.6090.ad98746a-1 openlibm-0.7.5-1"
 for PKG in ${PKGS} ; do
     FILE=mingw-w64-x86_64-${PKG}-any.pkg.tar.zst
     rm -f ${FILE}
     wget --no-verbose --show-progress http://repo.msys2.org/mingw/x86_64/${FILE}
-    tar -I zstd -xf ${FILE}
-    rm ${FILE}
+    if tar -I zstd -xf ${FILE} ; then
+        rm ${FILE}
+    else
+        echo
+        echo "Perhaps the decompression program zstd is not installed?"
+        echo "Try 'sudo apt install zstd'."
+        exit
+    fi
 done
+fi
 
 echo
 echo "Done."


### PR DESCRIPTION
This updates the `make_winroot.sh` script and allows building RevStudio again:
* We no longer need to generate a `pkg-config` wrapper with modern versions of meson.
* `c_args` and `cpp_args` should be in section [built-in options] now.
* give helpful error message if `zstd` cannot be found to decompress the packages
* adds an option to not download packages if you just want to regenerate win64-cross.txt
* avoid redownloading MINGW packages that have already been downloaded
* download packages MINGW packages for GTK if asked (needed for RevStudio)
* switch from `x86_64-w64-mingw32-gcc` to `x86_64-w64-mingw32-gcc-posix` to use POSIX threads (needed for RevStudio)
* general cleanups