### PR TITLE
Change readTreeTrace() to avoid creation of 0-length traces

### DIFF
--- a/src/revlanguage/functions/io/Func_readTreeTrace.cpp
+++ b/src/revlanguage/functions/io/Func_readTreeTrace.cpp
@@ -207,18 +207,38 @@ RevPtr<RevVariable> Func_readTreeTrace::execute( void )
 
         for(size_t i = 0; i < rv->getValue().size(); i++)
         {
-            (*rv)[i].getValue().setBurnin(burnin);
+            if (burnin >= long( (*rv)[i].getValue().size() ) )
+            {
+                throw RbException("Burnin is greater than or equal to the number of trees in the trace. Please specify a smaller burnin instead.");
+            }
+            else
+            {
+                (*rv)[i].getValue().setBurnin(burnin);
+            }
         }
     }
     else
     {
         double burninFrac = static_cast<const Probability &>(b).getValue();
-
-        for(size_t i = 0; i < rv->getValue().size(); i++)
+            
+        // A probability of 1 will be re-interpreted as an integer to avoid creating a trace of length 0
+        if (burninFrac == 1.0)
         {
-            burnin = long( floor( rv->getValue()[i].getValue().size()*burninFrac ) );
+            burnin = 1;
 
-            (*rv)[i].getValue().setBurnin(burnin);
+            for(size_t i = 0; i < rv->getValue().size(); i++)
+            {
+                (*rv)[i].getValue().setBurnin(burnin);
+            }
+        }
+        else
+        {
+            for(size_t i = 0; i < rv->getValue().size(); i++)
+            {
+                burnin = long( floor( rv->getValue()[i].getValue().size()*burninFrac ) );
+
+                (*rv)[i].getValue().setBurnin(burnin);
+            }
         }
     }
 


### PR DESCRIPTION
Currently, `readTreeTrace()` allows the user to specify a burnin argument such that the resulting trace is of length 0 (either by passing a Probability of 1, or an Integer equal to the number of trees in the trace). This results in the failure of several member methods of class `TraceTree` (e.g., `computePairwiseRFDistances`), and of functions that take a tree trace as an argument (e.g., `mccTree()`, `mapTree()`). Since traces of length 0 are presumably never desirable, it seems easier to prevent their creation in the first place. Here, this is done by checking for the two cases above and (1) reinterpreting 1 as a number of samples (rather than a fraction) in the former case, or (2) throwing an error in the latter case.