### PR TITLE
Codon model argument order

### DIFF
--- a/help/md/fnFMutSel.md
+++ b/help/md/fnFMutSel.md
@@ -38,10 +38,10 @@ fnCodonGY94, fnCodonMG94, fnFMutSel0, fnMutSel
         F ~ dnIID(61, dnNormal(0,1))
         omega ~ dnUniform(0,1)
         # The FMutSel model from Yang and Nielsen (2008)        
-        Q1 := fnFMutSel(F, omega, fnGTR(er, nuc_pi))
+        Q1 := fnFMutSel(fnGTR(er, nuc_pi), F, omega)
 
         # The same -- fMutSel = GTR(er,nuc_pi) + X3 + MutSel(F) + dNdS(omega)
-        Q2 := fndNdS(omega, fnMutSel(F, fnX3( fnGTR(er, nuc_pi))))
+        Q2 := fndNdS(fnMutSel(F, fnX3(fnGTR(er, nuc_pi))), omega)
 
 ## references
 - citation: Yang, Z. and R. Nielsen. Mutation-Selection Models of Codon Substitution and Their Use to Estimate

--- a/help/md/fnFMutSel0.md
+++ b/help/md/fnFMutSel0.md
@@ -39,10 +39,10 @@ fnCodonGY94, fnCodonMG94, fnFMutSel0, fnMutSel
         F ~ dnIID(20, dnNormal(0,1))
         omega ~ dnUniform(0,1)
         # The FMutSel0 model from Yang and Nielsen (2008)        
-        Q1 := fnFMutSel0(F, omega, fnGTR(er, nuc_pi))
+        Q1 := fnFMutSel0(fnGTR(er, nuc_pi), F, omega)
 
         # The same -- fMutSel0 = GTR(er,nuc_pi) + X3 + MutSel(F) + dNdS(omega)
-        Q2 := fndNdS(omega, fnMutSelAA(F, fnX3( fnGTR(er, nuc_pi))))
+        Q2 := fndNdS( fnMutSelAA( fnX3( fnGTR(er, nuc_pi)), F), omega)
 
 ## references
 - citation: Yang, Z. and R. Nielsen. Mutation-Selection Models of Codon Substitution and Their Use to Estimate

--- a/help/md/fnMutSel.md
+++ b/help/md/fnMutSel.md
@@ -33,11 +33,11 @@ fnCodonGY94, fnCodonMG94, fnMutSelAA, fnFMutSel, fndNdS
         er ~ dnDirichlet( v(1,1,1,1,1,1) )
         nuc_pi ~ dnDirichlet( rep(2.0, 4) )
         F ~ dnIID(61, dnNormal(0,1))
-        Q := fnMutSel(F, fnX3( fnGTR(er,nuc_pi) ) )   # GTR + X3 + MutSel
+        Q := fnMutSel(fnX3(fnGTR(er, nuc_pi) ), F)       # GTR + X3 + MutSel
 
         # A mutation-selection balance model on RNA, with GTR mutation.
         F2 ~ dnIID(16, dnNormal(0,1))
-        Q2 := fnMutSel(F2, fnX2( fnGTR(er,nuc_pi) ) ) # GTR + X2 + MutSel
+        Q2 := fnMutSel(fnX2(fnGTR(er,nuc_pi) ), F2)      # GTR + X2 + MutSel
 
 ## references
 - citation: Yang, Z. and R. Nielsen. Mutation-Selection Models of Codon Substitution and Their Use to Estimate

--- a/help/md/fnMutSelAA.md
+++ b/help/md/fnMutSelAA.md
@@ -33,8 +33,8 @@ fnCodonGY94, fnCodonMG94, fnX3, fndNdS, fnMutSel
 ## example
         er ~ dnDirichlet( v(1,1,1,1,1,1) )
         nuc_pi ~ dnDirichlet( rep(2.0, 4) )
-        F ~ dnIID(61, dnNormal(0,1))
-        Q := fnMutSel(F, fnX3( fnGTR(er,nuc_pi) ) )   # GTR + X3 + MutSel
+        F ~ dnIID(20, dnNormal(0,1))
+        Q := fnMutSelAA(fnX3(fnGTR(er, nuc_pi)), F)
 
 ## references
 - citation: Yang, Z. and R. Nielsen. Mutation-Selection Models of Codon

--- a/help/md/fnX2.md
+++ b/help/md/fnX2.md
@@ -26,6 +26,6 @@ fnX3
         Q1 := fnX2( fnHKY(kappa, nuc_pi) )
         F ~ dnIID(16, dnNormal(0,1))
         # Add selection to the rate matrix
-        Q2 := fnMutSel(F, Q1)
+        Q2 := fnMutSel(Q1, F)
 
 ## references

--- a/help/md/fnX3.md
+++ b/help/md/fnX3.md
@@ -27,10 +27,10 @@ fnCodonGY94, fnCodonMG94K, fndNdS
         nuc_pi ~ dnDirichlet( rep(2.0, 4) )
         Q1 := fnCodonMG94K( kappa, omega, nuc_pi )
         # This is the same.
-        Q2 := fndNdS(omega,fnX3(fnHKY(kappa,nuc_pi)))   # HKY + X3 + dNdS, or HKY*3 + dNdS
+        Q2 := fndNdS(fnX3(fnHKY(kappa, nuc_pi)), omega)          # HKY + X3 + dNdS, or HKY*3 + dNdS
 
         er ~ dnDirichlet( v(1,1,1,1,1,1) )
-        Q3 := fnX3(fnGTR(er,nuc_pi))      # GTR + X3, or GTR*3
+        Q3 := fnX3(fnGTR(er, nuc_pi))      # GTR + X3, or GTR*3
 
 ## references
 - citation: Redelings, BD (2021). BAli-Phy version 3: Model-based co-estimation of Alignment

--- a/help/md/fndNdS.md
+++ b/help/md/fndNdS.md
@@ -30,12 +30,13 @@ fnCodonGY94, fnCodonMG94K, fnX3, fnMutSel
         nuc_pi ~ dnDirichlet( rep(2.0, 4) )
         Q1 := fnCodonMG94K( kappa, omega, nuc_pi )
         # This is the same.
-        Q2 := fndNdS(omega,fnX3(fnHKY(kappa,nuc_pi)))   # HKY + X3 + dNdS, or HKY*3 + dNdS
+        Q2 := fndNdS(fnX3(fnHKY(kappa, nuc_pi)), omega)        # HKY + X3 + dNdS,
+                                                               #   or HKY*3 + dNdS
 
         er ~ dnDirichlet( v(1,1,1,1,1,1) )
-        Q3 := fnX3(fnGTR(er,nuc_pi))      # GTR + X3, or GTR*3
+        Q3 := fndNdS(fnX3(fnGTR(er, nuc_pi)), omega)         # GTR + X3 + dNdS
 
 ## references
-- citation: Redelings, BD (2021). RedelingsBAli-Phy version 3: Model-based co-estimation of Alignment
+- citation: Redelings, BD (2021). BAli-Phy version 3: Model-based co-estimation of Alignment
        and Phylogeny.  Bioinformatics (2021) 37(10):3032–3034.
   doi: https://doi.org/10.1093/bioinformatics/btab129

--- a/src/core/functions/phylogenetics/ratematrix/CppCodonFuncs.cpp
+++ b/src/core/functions/phylogenetics/ratematrix/CppCodonFuncs.cpp
@@ -10,8 +10,6 @@ namespace RevBayesCore
 
 bool is_transition_mut(int i, int j)
 {
-    assert(i != j);
-
     if (i > j) std::swap(i,j);
 
     if (i == 0 and j == 2) return true; // A <-> G
@@ -23,7 +21,7 @@ bool is_transition_mut(int i, int j)
 
 bool is_transversion_mut(int i, int j)
 {
-    return not is_transition_mut(i,j);
+    return (i != j) and not is_transition_mut(i,j);
 }
 
 int n_different_nucs(const vector<unsigned int>& states_from, const vector<unsigned int>& states_to)

--- a/src/core/help/RbHelpDatabase.cpp
+++ b/src/core/help/RbHelpDatabase.cpp
@@ -1240,10 +1240,10 @@ nuc_pi ~ dnDirichlet( rep(2.0, 4) )
 F ~ dnIID(61, dnNormal(0,1))
 omega ~ dnUniform(0,1)
 # The FMutSel model from Yang and Nielsen (2008)
-Q1 := fnFMutSel(F, omega, fnGTR(er, nuc_pi))
+Q1 := fnFMutSel(fnGTR(er, nuc_pi), F, omega)
 
 # The same -- fMutSel = GTR(er,nuc_pi) + X3 + MutSel(F) + dNdS(omega)
-Q2 := fndNdS(omega, fnMutSel(F, fnX3( fnGTR(er, nuc_pi)))))");
+Q2 := fndNdS(fnMutSel(F, fnX3(fnGTR(er, nuc_pi))), omega))");
 	help_strings[string("fnFMutSel")][string("name")] = string(R"(fnFMutSel)");
 	help_references[string("fnFMutSel")].push_back(RbHelpReference(R"(Yang, Z. and R. Nielsen. Mutation-Selection Models of Codon Substitution and Their Use to Estimate Selective Strengths on Codon Usage.  Mol. Biol. Evol. (2008) 25(3):568--579)",R"(https://doi.org/10.1093/molbev/msm284 )",R"()"));
 	help_arrays[string("fnFMutSel")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94, fnFMutSel0, fnMutSel)"));
@@ -1275,10 +1275,10 @@ nuc_pi ~ dnDirichlet( rep(2.0, 4) )
 F ~ dnIID(20, dnNormal(0,1))
 omega ~ dnUniform(0,1)
 # The FMutSel0 model from Yang and Nielsen (2008)
-Q1 := fnFMutSel0(F, omega, fnGTR(er, nuc_pi))
+Q1 := fnFMutSel0(fnGTR(er, nuc_pi), F, omega)
 
 # The same -- fMutSel0 = GTR(er,nuc_pi) + X3 + MutSel(F) + dNdS(omega)
-Q2 := fndNdS(omega, fnMutSelAA(F, fnX3( fnGTR(er, nuc_pi)))))");
+Q2 := fndNdS( fnMutSelAA( fnX3( fnGTR(er, nuc_pi)), F), omega))");
 	help_strings[string("fnFMutSel0")][string("name")] = string(R"(fnFMutSel0)");
 	help_references[string("fnFMutSel0")].push_back(RbHelpReference(R"(Yang, Z. and R. Nielsen. Mutation-Selection Models of Codon Substitution and Their Use to Estimate Selective Strengths on Codon Usage.  Mol. Biol. Evol. (2008) 25(3):568--579)",R"(https://doi.org/10.1093/molbev/msm284 )",R"()"));
 	help_arrays[string("fnFMutSel0")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94, fnFMutSel0, fnMutSel)"));
@@ -1337,11 +1337,11 @@ and the initial frequency 1/N of allele j.)");
 	help_strings[string("fnMutSel")][string("example")] = string(R"(er ~ dnDirichlet( v(1,1,1,1,1,1) )
 nuc_pi ~ dnDirichlet( rep(2.0, 4) )
 F ~ dnIID(61, dnNormal(0,1))
-Q := fnMutSel(F, fnX3( fnGTR(er,nuc_pi) ) )   # GTR + X3 + MutSel
+Q := fnMutSel(fnX3(fnGTR(er, nuc_pi) ), F)       # GTR + X3 + MutSel
 
 # A mutation-selection balance model on RNA, with GTR mutation.
 F2 ~ dnIID(16, dnNormal(0,1))
-Q2 := fnMutSel(F2, fnX2( fnGTR(er,nuc_pi) ) ) # GTR + X2 + MutSel)");
+Q2 := fnMutSel(fnX2(fnGTR(er,nuc_pi) ), F2)      # GTR + X2 + MutSel)");
 	help_strings[string("fnMutSel")][string("name")] = string(R"(fnMutSel)");
 	help_references[string("fnMutSel")].push_back(RbHelpReference(R"(Yang, Z. and R. Nielsen. Mutation-Selection Models of Codon Substitution and Their Use to Estimate Selective Strengths on Codon Usage.  Mol. Biol. Evol. (2008) 25(3):568--579)",R"(https://doi.org/10.1093/molbev/msm284 )",R"()"));
 	help_arrays[string("fnMutSel")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94, fnMutSelAA, fnFMutSel, fndNdS)"));
@@ -1367,8 +1367,8 @@ The probability of fixation is determined by scaled selection coefficients:
 and the initial frequency 1/N of allele j.)");
 	help_strings[string("fnMutSelAA")][string("example")] = string(R"(er ~ dnDirichlet( v(1,1,1,1,1,1) )
 nuc_pi ~ dnDirichlet( rep(2.0, 4) )
-F ~ dnIID(61, dnNormal(0,1))
-Q := fnMutSel(F, fnX3( fnGTR(er,nuc_pi) ) )   # GTR + X3 + MutSel)");
+F ~ dnIID(20, dnNormal(0,1))
+Q := fnMutSelAA(fnX3(fnGTR(er, nuc_pi)), F))");
 	help_strings[string("fnMutSelAA")][string("name")] = string(R"(fnMutSelAA)");
 	help_references[string("fnMutSelAA")].push_back(RbHelpReference(R"(Yang, Z. and R. Nielsen. Mutation-Selection Models of Codon Substitution and Their Use to Estimate Selective Strengths on Codon Usage.  Mol. Biol. Evol. (2008) 25(3):568--579)",R"(https://doi.org/10.1093/molbev/msm284 )",R"()"));
 	help_arrays[string("fnMutSelAA")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94, fnX3, fndNdS, fnMutSel)"));
@@ -1431,7 +1431,7 @@ nuc_pi ~ dnDirichlet( rep(2.0, 4) )
 Q1 := fnX2( fnHKY(kappa, nuc_pi) )
 F ~ dnIID(16, dnNormal(0,1))
 # Add selection to the rate matrix
-Q2 := fnMutSel(F, Q1))");
+Q2 := fnMutSel(Q1, F))");
 	help_strings[string("fnX2")][string("name")] = string(R"(fnX2)");
 	help_arrays[string("fnX2")][string("see_also")].push_back(string(R"(fnX3)"));
 	help_strings[string("fnX2")][string("title")] = string(R"(Construct a doublet (16x16) rate matrix from a nucleotide rate matrix.)");
@@ -1450,10 +1450,10 @@ omega ~ dnUniform(0,1)
 nuc_pi ~ dnDirichlet( rep(2.0, 4) )
 Q1 := fnCodonMG94K( kappa, omega, nuc_pi )
 # This is the same.
-Q2 := fndNdS(omega,fnX3(fnHKY(kappa,nuc_pi)))   # HKY + X3 + dNdS, or HKY*3 + dNdS
+Q2 := fndNdS(fnX3(fnHKY(kappa, nuc_pi)), omega)          # HKY + X3 + dNdS, or HKY*3 + dNdS
 
 er ~ dnDirichlet( v(1,1,1,1,1,1) )
-Q3 := fnX3(fnGTR(er,nuc_pi))      # GTR + X3, or GTR*3)");
+Q3 := fnX3(fnGTR(er, nuc_pi))      # GTR + X3, or GTR*3)");
 	help_strings[string("fnX3")][string("name")] = string(R"(fnX3)");
 	help_references[string("fnX3")].push_back(RbHelpReference(R"(Redelings, BD (2021). BAli-Phy version 3: Model-based co-estimation of Alignment and Phylogeny.  Bioinformatics (2021) 37(10):3032–3034.)",R"(https://doi.org/10.1093/bioinformatics/btab129 )",R"()"));
 	help_arrays[string("fnX3")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94K, fndNdS)"));
@@ -1477,12 +1477,13 @@ omega ~ dnUniform(0,1)
 nuc_pi ~ dnDirichlet( rep(2.0, 4) )
 Q1 := fnCodonMG94K( kappa, omega, nuc_pi )
 # This is the same.
-Q2 := fndNdS(omega,fnX3(fnHKY(kappa,nuc_pi)))   # HKY + X3 + dNdS, or HKY*3 + dNdS
+Q2 := fndNdS(fnX3(fnHKY(kappa, nuc_pi)), omega)        # HKY + X3 + dNdS,
+                                                       #   or HKY*3 + dNdS
 
 er ~ dnDirichlet( v(1,1,1,1,1,1) )
-Q3 := fnX3(fnGTR(er,nuc_pi))      # GTR + X3, or GTR*3)");
+Q3 := fndNdS(fnX3(fnGTR(er, nuc_pi)), omega)         # GTR + X3 + dNdS)");
 	help_strings[string("fndNdS")][string("name")] = string(R"(fndNdS)");
-	help_references[string("fndNdS")].push_back(RbHelpReference(R"(Redelings, BD (2021). RedelingsBAli-Phy version 3: Model-based co-estimation of Alignment and Phylogeny.  Bioinformatics (2021) 37(10):3032–3034.)",R"(https://doi.org/10.1093/bioinformatics/btab129)",R"()"));
+	help_references[string("fndNdS")].push_back(RbHelpReference(R"(Redelings, BD (2021). BAli-Phy version 3: Model-based co-estimation of Alignment and Phylogeny.  Bioinformatics (2021) 37(10):3032–3034.)",R"(https://doi.org/10.1093/bioinformatics/btab129)",R"()"));
 	help_arrays[string("fndNdS")][string("see_also")].push_back(string(R"(fnCodonGY94, fnCodonMG94K, fnX3, fnMutSel)"));
 	help_strings[string("fndNdS")][string("title")] = string(R"(Add a dN/dS factor to a codon rate matrix.)");
 	help_strings[string("formatDiscreteCharacterData")][string("name")] = string(R"(formatDiscreteCharacterData)");

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_FMutSel0RateMatrix.cpp
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_FMutSel0RateMatrix.cpp
@@ -54,9 +54,9 @@ Func_FMutSel0RateMatrix* Func_FMutSel0RateMatrix::clone( void ) const
 
 RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >* Func_FMutSel0RateMatrix::createFunction( void ) const
 {
-    RevBayesCore::TypedDagNode< RevBayesCore::RbVector<double> >* fitnesses = static_cast<const ModelVector<Real> &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
-    RevBayesCore::TypedDagNode< double >* omega = static_cast<const RealPos &>( this->args[1].getVariable()->getRevObject() ).getDagNode();
-    RevBayesCore::TypedDagNode< RevBayesCore::RateGenerator >* mu_nuc = static_cast<const RateGenerator &>( this->args[2].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode< RevBayesCore::RateGenerator >* mu_nuc = static_cast<const RateGenerator &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode< RevBayesCore::RbVector<double> >* fitnesses = static_cast<const ModelVector<Real> &>( this->args[1].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode< double >* omega = static_cast<const RealPos &>( this->args[2].getVariable()->getRevObject() ).getDagNode();
 
     return RevBayesCore::generic_function_ptr2< RevBayesCore::RateGenerator >( FMutSel0Func, fitnesses, omega, mu_nuc );
 }
@@ -70,9 +70,9 @@ const ArgumentRules& Func_FMutSel0RateMatrix::getArgumentRules( void ) const
 
     if ( !rules_set )
     {
+        argumentRules.push_back( new ArgumentRule( "submodel" , RateMatrix::getClassTypeSpec(), "Nucleotide mutation rate matrix.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
         argumentRules.push_back( new ArgumentRule( "fitnesses", ModelVector<Real>::getClassTypeSpec(), "Scaled selection coefficients 2Ns for 20 amino acids.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
         argumentRules.push_back( new ArgumentRule( "omega"    , RealPos::getClassTypeSpec(), "The dN / dS rate ratio.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
-        argumentRules.push_back( new ArgumentRule( "submodel" , RateMatrix::getClassTypeSpec(), "Nucleotide mutation rate matrix.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
 
         rules_set = true;
     }

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_FMutSelRateMatrix.cpp
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_FMutSelRateMatrix.cpp
@@ -54,9 +54,9 @@ Func_FMutSelRateMatrix* Func_FMutSelRateMatrix::clone( void ) const
 
 RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >* Func_FMutSelRateMatrix::createFunction( void ) const
 {
-    RevBayesCore::TypedDagNode< RevBayesCore::RbVector<double> >* fitnesses = static_cast<const ModelVector<Real> &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
-    RevBayesCore::TypedDagNode< double >* omega = static_cast<const RealPos &>( this->args[1].getVariable()->getRevObject() ).getDagNode();
-    RevBayesCore::TypedDagNode< RevBayesCore::RateGenerator >* mu_nuc = static_cast<const RateGenerator &>( this->args[2].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode< RevBayesCore::RateGenerator >* mu_nuc = static_cast<const RateGenerator &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode< RevBayesCore::RbVector<double> >* fitnesses = static_cast<const ModelVector<Real> &>( this->args[1].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode< double >* omega = static_cast<const RealPos &>( this->args[2].getVariable()->getRevObject() ).getDagNode();
 
     return RevBayesCore::generic_function_ptr2< RevBayesCore::RateGenerator >( FMutSelFunc, fitnesses, omega, mu_nuc );
 }
@@ -70,9 +70,9 @@ const ArgumentRules& Func_FMutSelRateMatrix::getArgumentRules( void ) const
 
     if ( !rules_set )
     {
+        argumentRules.push_back( new ArgumentRule( "submodel" , RateMatrix::getClassTypeSpec(), "Nucleotide mutation rate matrix.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
         argumentRules.push_back( new ArgumentRule( "fitnesses", ModelVector<Real>::getClassTypeSpec(), "Scaled selection coefficients 2Ns for 61 codons.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
         argumentRules.push_back( new ArgumentRule( "omega"    , RealPos::getClassTypeSpec(), "The dN / dS rate ratio.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
-        argumentRules.push_back( new ArgumentRule( "submodel" , RateMatrix::getClassTypeSpec(), "Nucleotide mutation rate matrix.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
 
         rules_set = true;
     }

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_MutSelAARateMatrix.cpp
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_MutSelAARateMatrix.cpp
@@ -52,8 +52,8 @@ Func_MutSelAARateMatrix* Func_MutSelAARateMatrix::clone( void ) const
 
 RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >* Func_MutSelAARateMatrix::createFunction( void ) const
 {
-    RevBayesCore::TypedDagNode< RevBayesCore::RbVector<double> >* f = static_cast<const ModelVector<Real> &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
-    RevBayesCore::TypedDagNode< RevBayesCore::RateGenerator >* q = static_cast<const RateGenerator &>( this->args[1].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode< RevBayesCore::RateGenerator >* q = static_cast<const RateGenerator &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode< RevBayesCore::RbVector<double> >* f = static_cast<const ModelVector<Real> &>( this->args[1].getVariable()->getRevObject() ).getDagNode();
 
     return RevBayesCore::generic_function_ptr2< RevBayesCore::RateGenerator >( MutSelAAFunc, f, q );
 }
@@ -68,8 +68,8 @@ const ArgumentRules& Func_MutSelAARateMatrix::getArgumentRules( void ) const
 
     if ( !rules_set )
     {
-        argumentRules.push_back( new ArgumentRule( "fitnesses", ModelVector<Real>::getClassTypeSpec(), "Amino acid fitnesses.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
         argumentRules.push_back( new ArgumentRule( "submodel", RateMatrix::getClassTypeSpec(), "Codon rate matrix.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        argumentRules.push_back( new ArgumentRule( "fitnesses", ModelVector<Real>::getClassTypeSpec(), "Amino acid fitnesses.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
 
         rules_set = true;
     }

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_MutSelRateMatrix.cpp
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_MutSelRateMatrix.cpp
@@ -51,8 +51,8 @@ Func_MutSelRateMatrix* Func_MutSelRateMatrix::clone( void ) const
 
 RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >* Func_MutSelRateMatrix::createFunction( void ) const
 {
-    RevBayesCore::TypedDagNode< RevBayesCore::RbVector<double> >* f = static_cast<const ModelVector<Real> &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
-    RevBayesCore::TypedDagNode< RevBayesCore::RateGenerator >* q = static_cast<const RateGenerator &>( this->args[1].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode< RevBayesCore::RateGenerator >* q = static_cast<const RateGenerator &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode< RevBayesCore::RbVector<double> >* f = static_cast<const ModelVector<Real> &>( this->args[1].getVariable()->getRevObject() ).getDagNode();
 
     return RevBayesCore::generic_function_ptr2< RevBayesCore::RateGenerator >( MutSelFunc, f, q );
 }
@@ -67,8 +67,8 @@ const ArgumentRules& Func_MutSelRateMatrix::getArgumentRules( void ) const
 
     if ( !rules_set )
     {
-        argumentRules.push_back( new ArgumentRule( "fitnesses", ModelVector<Real>::getClassTypeSpec(), "Fitnesses.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
         argumentRules.push_back( new ArgumentRule( "submodel", RateMatrix::getClassTypeSpec(), "Mutation rate matrix.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        argumentRules.push_back( new ArgumentRule( "fitnesses", ModelVector<Real>::getClassTypeSpec(), "Fitnesses.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
 
         rules_set = true;
     }

--- a/src/revlanguage/functions/phylogenetics/ratematrix/Func_dNdSRateMatrix.cpp
+++ b/src/revlanguage/functions/phylogenetics/ratematrix/Func_dNdSRateMatrix.cpp
@@ -48,8 +48,8 @@ Func_dNdSRateMatrix* Func_dNdSRateMatrix::clone( void ) const
 
 RevBayesCore::TypedFunction< RevBayesCore::RateGenerator >* Func_dNdSRateMatrix::createFunction( void ) const
 {
-    RevBayesCore::TypedDagNode< double >* omega = static_cast<const RealPos &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
-    RevBayesCore::TypedDagNode< RevBayesCore::RateGenerator >* nuc_q = static_cast<const RateGenerator &>( this->args[1].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode< RevBayesCore::RateGenerator >* nuc_q = static_cast<const RateGenerator &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode< double >* omega = static_cast<const RealPos &>( this->args[1].getVariable()->getRevObject() ).getDagNode();
 
     return RevBayesCore::generic_function_ptr2< RevBayesCore::RateGenerator >( dNdSFunc, omega, nuc_q );
 }
@@ -64,8 +64,8 @@ const ArgumentRules& Func_dNdSRateMatrix::getArgumentRules( void ) const
 
     if ( !rules_set )
     {
-        argumentRules.push_back( new ArgumentRule( "omega"          , RealPos::getClassTypeSpec(), "The dN / dS rate ratio.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
         argumentRules.push_back( new ArgumentRule( "submodel", RateMatrix::getClassTypeSpec(), "Singlet (i.e. nucleotide) rate matrix.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        argumentRules.push_back( new ArgumentRule( "omega"          , RealPos::getClassTypeSpec(), "The dN / dS rate ratio.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
 
         rules_set = true;
     }


### PR DESCRIPTION
This PR reorders arguments in the newly-introduced codon model functions to place submodels as the first argument.

This is necessary to allow the use of the R 4.1 pipe operator `|>` for easy substitution model composition, if and when the the pipe operator is added to revbayes.  However, we need to do this before the 1.2 release so that we don't break users scripts by changing the argument order later.