### PR TITLE
Fix windows setwd

### DIFF
--- a/src/core/utils/RbFileManager.cpp
+++ b/src/core/utils/RbFileManager.cpp
@@ -11,7 +11,8 @@
 #include "RbFileManager.h"
 #include "RbSettings.h"
 #include "StringUtilities.h"
-#include "boost/filesystem/path.hpp"
+#include <boost/filesystem/path.hpp>
+#include <boost/filesystem/operations.hpp>
 
 #ifdef _WIN32
 #	include <dirent.h>
@@ -25,6 +26,7 @@
 
 
 using namespace RevBayesCore;
+namespace fs = boost::filesystem;
 
 /** Default constructor, creating a file manager object with the file
  path equal to the current (default) directory and an empty file name */
@@ -255,7 +257,7 @@ void RbFileManager::formatError(std::string& errorStr)
 
 std::string RbFileManager::getCurrentDirectory( void ) const
 {
-    return RbSettings::userSettings().getWorkingDirectory();
+    return fs::current_path().make_preferred().string();
 }
 
 

--- a/src/core/utils/RbFileManager.cpp
+++ b/src/core/utils/RbFileManager.cpp
@@ -253,7 +253,7 @@ void RbFileManager::formatError(std::string& errorStr)
 }
 
 
-const std::string& RbFileManager::getCurrentDirectory( void ) const
+std::string RbFileManager::getCurrentDirectory( void ) const
 {
     return RbSettings::userSettings().getWorkingDirectory();
 }

--- a/src/core/utils/RbFileManager.h
+++ b/src/core/utils/RbFileManager.h
@@ -31,7 +31,7 @@ namespace RevBayesCore {
         void                    closeFile(std::ofstream& strm);  //!< Close output file
         void                    createDirectoryForFile(void);  //!< Create the directories in the path of full_file_name
         void                    formatError(std::string& errorStr);  //!< Format the error string when (mis)reading files
-        const std::string&      getCurrentDirectory(void) const;  //!< Returns the current directory for the process
+        std::string             getCurrentDirectory(void) const;  //!< Returns the current directory for the process
         std::string             getFileExtension(void) const;  //!< Returns the file extension from file_name
         const std::string&      getFileName(void) const;
         std::string             getFileNameWithoutExtension(void) const;  //!< Returns file_name without extension

--- a/src/core/utils/RbSettings.cpp
+++ b/src/core/utils/RbSettings.cpp
@@ -10,10 +10,14 @@
 #include "RbException.h"
 #include "RbFileManager.h"
 #include "StringUtilities.h"
+#include <boost/filesystem/path.hpp>
+#include <boost/filesystem/operations.hpp>
 
 #	ifdef _WIN32
 #include <windows.h>
 #   endif
+
+namespace fs = boost::filesystem;
 
 
 
@@ -124,8 +128,7 @@ double RbSettings::getTolerance( void ) const
 
 std::string RbSettings::getWorkingDirectory( void ) const
 {
-    
-    return workingDirectory;
+    return fs::current_path().make_preferred().string();
 }
 
 
@@ -174,27 +177,14 @@ void RbSettings::initializeUserSettings(void)
     char buffer[MAX_DIR_PATH];
     GetModuleFileName( NULL, buffer, MAX_DIR_PATH );
     std::string::size_type pos = std::string( buffer ).find_last_of( "\\/" );
-    workingDirectory = std::string( buffer ).substr( 0, pos);
+    fs::current_path( std::string( buffer ).substr( 0, pos) );
 
 #	else
 
     char cwd[MAX_DIR_PATH+1];
-	if ( getcwd(cwd, MAX_DIR_PATH+1) )
+    if ( getcwd(cwd, MAX_DIR_PATH+1) )
     {
-        std::string pathSeparator = "/";
-        
-        std::string curdir = cwd;
-        
-        if ( curdir.at( curdir.length()-1 ) == pathSeparator[0] )
-        {
-            curdir.erase( curdir.length()-1 );
-        }
-        
-        workingDirectory = curdir;
-	}
-    else
-    {
-        workingDirectory = "";
+        fs::current_path( cwd );
     }
     
 #   endif
@@ -361,15 +351,16 @@ void RbSettings::setTolerance(double t)
 
 void RbSettings::setWorkingDirectory(const std::string &wd)
 {
-    
-    RevBayesCore::RbFileManager fm = RevBayesCore::RbFileManager( wd );
-    
-    if ( !fm.isDirectory() )
+    try
     {
-        throw RbException("Cannot set the current directory to '" + wd + "'.");
+        RevBayesCore::RbFileManager fm;
+        std::string wd2 = fm.expandUserDir(wd);
+        fs::current_path( wd2 );
     }
-    
-    workingDirectory = fm.getFullFilePath();
+    catch (...)
+    {
+        throw RbException()<<"Cannot set the current directory to \""<<wd<<"\"";
+    }
     
     // save the current settings for the future.
     writeUserSettings();

--- a/src/core/utils/RbSettings.cpp
+++ b/src/core/utils/RbSettings.cpp
@@ -122,7 +122,7 @@ double RbSettings::getTolerance( void ) const
 }
 
 
-const std::string& RbSettings::getWorkingDirectory( void ) const
+std::string RbSettings::getWorkingDirectory( void ) const
 {
     
     return workingDirectory;

--- a/src/core/utils/RbSettings.h
+++ b/src/core/utils/RbSettings.h
@@ -60,8 +60,6 @@ class RbSettings {
         size_t                      scalingDensity;
         double                      tolerance;                                          //!< Tolerance for comparison of doubles
         bool                        useScaling;
-        std::string                 workingDirectory;
-    
 };
 
 #endif

--- a/src/core/utils/RbSettings.h
+++ b/src/core/utils/RbSettings.h
@@ -27,7 +27,7 @@ class RbSettings {
         size_t                      getScalingDensity(void) const;                      //!< Retrieve the scaling density that determines how often to scale the likelihood in CTMC models
         double                      getTolerance(void) const;                           //!< Retrieve the tolerance for comparing doubles
         bool                        getUseScaling(void) const;                          //!< Retrieve the flag whether we should scale the likelihood in CTMC models
-        const std::string&          getWorkingDirectory(void) const;                    //!< Retrieve the current working directory
+        std::string                 getWorkingDirectory(void) const;                    //!< Retrieve the current working directory
         void                        listOptions(void) const;                            //!< Retrieve a list of all user options and their current values
 
         // setters


### PR DESCRIPTION
This fixes setwd(dir) on windows by using boost filesystem to set the current directory.  This means that we get to rely on boost filesystem to parse windows pathnames.  It also means that we no longer have to keep a string inside revbayes to track the current directory ourselves.

Incidentally, this means that `setwd("..")` now works.

We still handle `~`.