### PR TITLE
Dev cerny avgdistmat

### DIFF
--- a/src/revlanguage/datatypes/phylogenetics/characterdata/RlAbstractHomologousDiscreteCharacterData.cpp
+++ b/src/revlanguage/datatypes/phylogenetics/characterdata/RlAbstractHomologousDiscreteCharacterData.cpp
@@ -561,7 +561,7 @@ RevPtr<RevVariable> AbstractHomologousDiscreteCharacterData::executeMethod(std::
                 warn = true;
             }
 
-            if ( !v.isCharacterExcluded(i) && max + 1 == n)
+            if ( !v.isCharacterExcluded(i) && max + 1 == n) // only set partition for previously included characters
             {
                 v.includeCharacter(i);
             }
@@ -644,7 +644,7 @@ RevPtr<RevVariable> AbstractHomologousDiscreteCharacterData::executeMethod(std::
 
             for (size_t x = 0; x < v.getNumberOfStates(); x++)
             {
-                if ( max == x)
+                if ( !v.isCharacterExcluded(i) && max == x ) // only consider previously included characters
                 {
                     matVec[x]->includeCharacter(i);
                 }

--- a/src/revlanguage/datatypes/phylogenetics/characterdata/RlAbstractHomologousDiscreteCharacterData.cpp
+++ b/src/revlanguage/datatypes/phylogenetics/characterdata/RlAbstractHomologousDiscreteCharacterData.cpp
@@ -561,7 +561,7 @@ RevPtr<RevVariable> AbstractHomologousDiscreteCharacterData::executeMethod(std::
                 warn = true;
             }
 
-            if ( max + 1 == n)
+            if ( !v.isCharacterExcluded(i) && max + 1 == n)
             {
                 v.includeCharacter(i);
             }


### PR DESCRIPTION
Restricts the scope of two methods of the `AbstractHomologousDiscreteCharacterData` class to included characters only, in order to address issue #246 .