### PR TITLE
Prevent NumStates methods from overriding character exclusion

### DIFF
--- a/src/revlanguage/datatypes/phylogenetics/characterdata/RlAbstractHomologousDiscreteCharacterData.cpp
+++ b/src/revlanguage/datatypes/phylogenetics/characterdata/RlAbstractHomologousDiscreteCharacterData.cpp
@@ -561,7 +561,7 @@ RevPtr<RevVariable> AbstractHomologousDiscreteCharacterData::executeMethod(std::
                 warn = true;
             }
 
-            if ( !v.isCharacterExcluded(i) && max + 1 == n)
+            if ( !v.isCharacterExcluded(i) && max + 1 == n) // only set partition for previously included characters
             {
                 v.includeCharacter(i);
             }
@@ -644,7 +644,7 @@ RevPtr<RevVariable> AbstractHomologousDiscreteCharacterData::executeMethod(std::
 
             for (size_t x = 0; x < v.getNumberOfStates(); x++)
             {
-                if ( max == x)
+                if ( !v.isCharacterExcluded(i) && max == x ) // only consider previously included characters
                 {
                     matVec[x]->includeCharacter(i);
                 }

--- a/src/revlanguage/datatypes/phylogenetics/characterdata/RlAbstractHomologousDiscreteCharacterData.cpp
+++ b/src/revlanguage/datatypes/phylogenetics/characterdata/RlAbstractHomologousDiscreteCharacterData.cpp
@@ -561,7 +561,7 @@ RevPtr<RevVariable> AbstractHomologousDiscreteCharacterData::executeMethod(std::
                 warn = true;
             }
 
-            if ( max + 1 == n)
+            if ( !v.isCharacterExcluded(i) && max + 1 == n)
             {
                 v.includeCharacter(i);
             }

--- a/src/revlanguage/datatypes/phylogenetics/characterdata/RlAbstractHomologousDiscreteCharacterData.cpp
+++ b/src/revlanguage/datatypes/phylogenetics/characterdata/RlAbstractHomologousDiscreteCharacterData.cpp
@@ -519,57 +519,60 @@ RevPtr<RevVariable> AbstractHomologousDiscreteCharacterData::executeMethod(std::
         size_t n = size_t( static_cast<const Natural&>( argument ).getValue() );
         for (size_t i = 0; i < nChars; i++)
         {
-            RevBayesCore::RbBitSet observed(v.getNumberOfStates());
-            size_t max = 0;
-            for (size_t j = 0; j < nTaxa; j++)
+            // only set state number partition for previously included characters
+            if ( !v.isCharacterExcluded(i) )
             {
-                const RevBayesCore::AbstractDiscreteTaxonData& td = v.getTaxonData(j);
-                if ( td.getCharacter(i).isMissingState() == false && td.getCharacter(i).isGapState() == false)
+                RevBayesCore::RbBitSet observed(v.getNumberOfStates());
+                size_t max = 0;
+                for (size_t j = 0; j < nTaxa; j++)
                 {
-                    if (td.getCharacter(i).getNumberObservedStates() > 1)
+                    const RevBayesCore::AbstractDiscreteTaxonData& td = v.getTaxonData(j);
+                    if ( td.getCharacter(i).isMissingState() == false && td.getCharacter(i).isGapState() == false)
                     {
-                        const RevBayesCore::RbBitSet& state = td.getCharacter(i).getState();
-                        for (size_t k = 0; k < state.size(); k++)
+                        if (td.getCharacter(i).getNumberObservedStates() > 1)
                         {
-                            if (state.isSet(k) )
+                            const RevBayesCore::RbBitSet& state = td.getCharacter(i).getState();
+                            for (size_t k = 0; k < state.size(); k++)
                             {
-                                observed.set(k);
-
-                                if ( k > max )
+                                if (state.isSet(k) )
                                 {
-                                    max = k;
+                                    observed.set(k);
+
+                                    if ( k > max )
+                                    {
+                                        max = k;
+                                    }
                                 }
                             }
                         }
-                    }
-                    else
-                    {
-                        size_t k = td.getCharacter(i).getStateIndex();
-
-                        observed.set(k);
-
-                        if (k > max)
+                        else
                         {
-                            max = k;
+                            size_t k = td.getCharacter(i).getStateIndex();
+
+                            observed.set(k);
+
+                            if (k > max)
+                            {
+                                max = k;
+                            }
                         }
                     }
                 }
-            }
 
-            if ( observed.getNumberSetBits() != max + 1 )
-            {
-                warn = true;
+                if ( observed.getNumberSetBits() != max + 1 )
+                {
+                    warn = true;
+                }
+                
+                if (max + 1 == n)
+                {
+                    v.includeCharacter(i);
+                }
+                else
+                {
+                    v.excludeCharacter(i);
+                }
             }
-
-            if ( !v.isCharacterExcluded(i) && max + 1 == n) // only set partition for previously included characters
-            {
-                v.includeCharacter(i);
-            }
-            else
-            {
-                v.excludeCharacter(i);
-            }
-
         }
 
         if ( warn == true )
@@ -600,57 +603,61 @@ RevPtr<RevVariable> AbstractHomologousDiscreteCharacterData::executeMethod(std::
 
         for (size_t i = 0; i < nChars; i++)
         {
-            RevBayesCore::RbBitSet observed(v.getNumberOfStates());
-            size_t max = 0;
-            for (size_t j = 0; j < nTaxa; j++)
+            // only set state number partition for previously included characters
+            if ( !v.isCharacterExcluded(i) )
             {
-                const RevBayesCore::AbstractDiscreteTaxonData& td = v.getTaxonData(j);
-                if ( td.getCharacter(i).isMissingState() == false && td.getCharacter(i).isGapState() == false)
+                RevBayesCore::RbBitSet observed(v.getNumberOfStates());
+                size_t max = 0;
+                for (size_t j = 0; j < nTaxa; j++)
                 {
-                    if (td.getCharacter(i).getNumberObservedStates() > 1)
+                    const RevBayesCore::AbstractDiscreteTaxonData& td = v.getTaxonData(j);
+                    if ( td.getCharacter(i).isMissingState() == false && td.getCharacter(i).isGapState() == false)
                     {
-                        const RevBayesCore::RbBitSet& state = td.getCharacter(i).getState();
-                        for (size_t k = 0; k < state.size(); k++)
+                        if (td.getCharacter(i).getNumberObservedStates() > 1)
                         {
-                            if (state.isSet(k) )
+                            const RevBayesCore::RbBitSet& state = td.getCharacter(i).getState();
+                            for (size_t k = 0; k < state.size(); k++)
                             {
-                                observed.set(k);
-
-                                if ( k > max )
+                                if (state.isSet(k) )
                                 {
-                                    max = k;
+                                    observed.set(k);
+
+                                    if ( k > max )
+                                    {
+                                        max = k;
+                                    }
                                 }
                             }
                         }
-                    }
-                    else
-                    {
-                        size_t k = td.getCharacter(i).getStateIndex();
-
-                        observed.set(k);
-
-                        if (k > max)
+                        else
                         {
-                            max = k;
+                            size_t k = td.getCharacter(i).getStateIndex();
+
+                            observed.set(k);
+
+                            if (k > max)
+                            {
+                                max = k;
+                            }
                         }
                     }
                 }
-            }
 
-            if ( observed.getNumberSetBits() != max + 1 )
-            {
-                warn = true;
-            }
-
-            for (size_t x = 0; x < v.getNumberOfStates(); x++)
-            {
-                if ( !v.isCharacterExcluded(i) && max == x ) // only consider previously included characters
+                if ( observed.getNumberSetBits() != max + 1 )
                 {
-                    matVec[x]->includeCharacter(i);
+                    warn = true;
                 }
-                else
+
+                for (size_t x = 0; x < v.getNumberOfStates(); x++)
                 {
-                    matVec[x]->excludeCharacter(i);
+                    if ( !v.isCharacterExcluded(i) && max == x ) // only consider previously included characters
+                    {
+                        matVec[x]->includeCharacter(i);
+                    }
+                    else
+                    {
+                        matVec[x]->excludeCharacter(i);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This branch includes minor changes to the `.setNumStatesPartition()` and `.getNumStatesVector()` methods of class `AbstractHomologousDiscreteCharacterData`, which are intended to solve issue #246. Note that a very similar solution was implemented in PR #249, which I closed because it crashed on one of the test scripts I was experimenting with. As it turns out, this was due to an unrelated problem in that script, which has now been addressed by PR #251.