### PR TITLE
Clean up MC3 code + add some MC3 mixing statistics

### DIFF
--- a/src/core/analysis/mcmc/Mcmcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmcmc.cpp
@@ -33,6 +33,35 @@
 #include <mpi.h>
 #endif
 
+/*
+ * Round trip statistics are inspired by the paper https://arxiv.org/pdf/cond-mat/0602085.pdf
+ *
+ * 1. The first idea is that simply having good acceptance probabilities for swapping adjacent temperatures is not good enough.
+ *    We need chains to make a round-trip from cold -> hot -> cold.
+ *    But it is possible to have a low rate of making round trips even if we have success swapping between adjacent temperatures.
+ *
+ * 2. The second idea is based on computing the fraction of the time that a chain at temperature j has most recently been at
+         the coldest chain versus the hottest chain.
+ *    The claim is that the fractions should be uniformly spaced.
+ *    For example, if we have 5 chains, then the fraction should be 100% for the cold chain, and then 75%, 50%, 25% and 0%.
+ *    In some cases, geometric heating produces very low round-trip rates, and this is because the fractions are NOT uniformly spaced.
+ *
+ * 3. The third idea is that one scenario where geometric heating works badly is when there is a "phase transition" at temperature T.
+ *    This means that the posterior distribution on one side of T looks very different than the posterior distribution on
+ *        the other side of T.
+ *    This can happen when there are a very large number of low-probability states.
+ *    As the temperature increases, the low-probability states increase in probability, and eventually overwhelm the high-probability
+ *        states because there are so many of the lower-probability states.
+ *    In such a case, we need closely-spaced temperatures near T, because the posterior changes rapidly as T changes.
+ *    However, we can tolerate wider spacing between temperatures further away from T.
+ *
+ * BDR: I worry that diffusion behavior limits the number of round-trips as the number of chains increases.
+ *      By diffusion behavior, I mean that a chain does not always move towards the coldest or hottest chain, but drifts randomly,
+          sometimes stepping away.
+ *      Does a chain take O(N^2) steps to move from cold -> hot, even if the temperatures are well placed?
+ * 
+ */
+
 using namespace RevBayesCore;
 
 Mcmcmc::Mcmcmc(const Model& m, const RbVector<Move> &mv, const RbVector<Monitor> &mn, std::string sT, size_t nc, size_t si, double dt, size_t ntries, bool th, double tht, std::string sm, std::string smo) : MonteCarloSampler( ),

--- a/src/core/analysis/mcmc/Mcmcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmcmc.cpp
@@ -66,17 +66,17 @@ using namespace RevBayesCore;
 
 using std::string;
 
-double Mcmcmc::heat_for_chain(int i) const
+double Mcmcmc::heatForChain(int i) const
 {
     return chain_heats[i];
 }
 
-bool Mcmcmc::is_cold_chain(int i) const
+bool Mcmcmc::isColdChain(int i) const
 {
-    return heat_for_chain(i) == 1.0;
+    return heatForChain(i) == 1.0;
 }
 
-double Mcmcmc::heat_for_index(int i) const
+double Mcmcmc::heatForIndex(int i) const
 {
     // Can we just maintain a sorted list of chain heats that is always valid?
     std::vector<double> tmp_chain_heats = chain_heats;
@@ -84,7 +84,7 @@ double Mcmcmc::heat_for_index(int i) const
     return tmp_chain_heats[i];
 }
 
-int Mcmcmc::heat_index_for_chain(int j) const
+int Mcmcmc::heatIndexForChain(int j) const
 {
     std::vector<double> tmp_chain_heats = chain_heats;
     std::sort(tmp_chain_heats.begin(), tmp_chain_heats.end(), std::greater<double>());
@@ -92,9 +92,9 @@ int Mcmcmc::heat_index_for_chain(int j) const
     return std::find(tmp_chain_heats.begin(), tmp_chain_heats.end(), chain_heats[j]) - tmp_chain_heats.begin();
 }
 
-int Mcmcmc::chain_for_heat_index(int i) const
+int Mcmcmc::chainForHeatIndex(int i) const
 {
-    return std::find(chain_heats.begin(), chain_heats.end(), heat_for_index(i)) - chain_heats.begin();
+    return std::find(chain_heats.begin(), chain_heats.end(), heatForIndex(i)) - chain_heats.begin();
 /*
     // 1. Start with [0 .. num_chains-1]
     std::vector<int> tmp_heat_ranks;
@@ -347,7 +347,7 @@ double Mcmcmc::getModelLnProbability( bool likelihood_only )
     
     for (size_t i=0; i<num_chains; ++i)
     {
-        if ( is_cold_chain(i) )
+        if ( isColdChain(i) )
         {
             rv = chain_values[i];
             break;
@@ -437,7 +437,7 @@ void Mcmcmc::initializeChains(void)
             Mcmc* oneChain = new Mcmc( *base_chain );
             oneChain->setScheduleType( schedule_type );
             oneChain->setChainActive( i == 0 );
-            oneChain->setChainPosteriorHeat( heat_for_chain(i) );
+            oneChain->setChainPosteriorHeat( heatForChain(i) );
             oneChain->setChainIndex( i );
             oneChain->setActivePID( active_pid_for_chain, num_processer_for_chain );
             chains[i] = oneChain;
@@ -614,7 +614,7 @@ void Mcmcmc::nextCycle(bool advanceCycle)
     
     for(int i=0;i<num_chains;i++)
     {
-        int heat_rank = heat_index_for_chain(i);
+        int heat_rank = heatIndexForChain(i);
         if (chain_prev_boundary[i] == boundary::coldest)
             heat_visitors[heat_rank].first++;
         if (chain_prev_boundary[i] == boundary::hottest)
@@ -749,10 +749,10 @@ void Mcmcmc::printOperatorSummary(bool current_period)
         
         for (size_t i = 0; i < num_chains; ++i)
         {
-            size_t chainIdx = chain_for_heat_index(i);
+            size_t chainIdx = chainForHeatIndex(i);
             
             std::cout << std::endl;
-            std::cout << "chain_heats[" << i + 1 << "] = " << heat_for_index(i) << std::endl;
+            std::cout << "chain_heats[" << i + 1 << "] = " << heatForIndex(i) << std::endl;
             std::cout.flush();
             
             // printing the moves summary
@@ -841,7 +841,7 @@ void Mcmcmc::printHeatSummary(std::ostream &o) const
     {
         int c = heat_visitors[i].first;
         int h = heat_visitors[i].second;
-        double B = heat_for_index(i);
+        double B = heatForIndex(i);
         double T = 1.0/B;
         if (c + h > 0)
         {
@@ -1013,7 +1013,7 @@ void Mcmcmc::printSwapSummaryPair(std::ostream &o, const size_t &row, const size
     {
         o << " ";
     }
-    o << heat_for_index(row);
+    o << heatForIndex(row);
     o << " ";
     
     // print the heat of the chain that swaps are proposed to
@@ -1022,7 +1022,7 @@ void Mcmcmc::printSwapSummaryPair(std::ostream &o, const size_t &row, const size
     {
         o << " ";
     }
-    o << heat_for_index(col);
+    o << heatForIndex(col);
     o << " ";
     
     o << std::endl;
@@ -1633,8 +1633,8 @@ void Mcmcmc::swapNeighborChains(void)
     if ( GLOBAL_RNG->uniform01() >= 0.5)
         std::swap( heat_rankj, heat_rankk );
     
-    int j = chain_for_heat_index(heat_rankj);
-    int k = chain_for_heat_index(heat_rankk);
+    int j = chainForHeatIndex(heat_rankj);
+    int k = chainForHeatIndex(heat_rankk);
 
     swapGivenChains(j, k);
 }
@@ -1669,16 +1669,16 @@ void Mcmcmc::updateTrips(int j)
     // This is true, and would probably stay true.
 
     // The assumption is that we run this right after we have swapped j with another chain.
-    // Therefore heat_index_for_chain(j) is the NEW heat rank for chain j.
+    // Therefore heatIndexForChain(j) is the NEW heat rank for chain j.
 
-    if ( heat_index_for_chain(j) == 0)
+    if ( heatIndexForChain(j) == 0)
     {
         if (chain_prev_boundary[j] == boundary::hottest)
             chain_half_trips[j]++;
 
         chain_prev_boundary[j] = boundary::coldest;
     }
-    else if (heat_index_for_chain(j) == num_chains - 1)
+    else if (heatIndexForChain(j) == num_chains - 1)
     {
         if (chain_prev_boundary[j] == boundary::coldest)
             chain_half_trips[j]++;
@@ -1689,8 +1689,8 @@ void Mcmcmc::updateTrips(int j)
 
 void Mcmcmc::swapGivenChains(int j, int k, double lnProposalRatio)
 {
-    size_t heat_rankj = heat_index_for_chain(j);
-    size_t heat_rankk = heat_index_for_chain(k);
+    size_t heat_rankj = heatIndexForChain(j);
+    size_t heat_rankk = heatIndexForChain(k);
 
     ++num_attempted_swaps[heat_rankj][heat_rankk];
 
@@ -1766,9 +1766,9 @@ void Mcmcmc::swapGivenChains(int j, int k, double lnProposalRatio)
         {
             if ( chains[i] != NULL )
             {
-                chains[i]->setChainPosteriorHeat( heat_for_chain(i) );
+                chains[i]->setChainPosteriorHeat( heatForChain(i) );
                 chains[i]->setMovesTuningInfo(chain_moves_tuningInfo[i]);
-                chains[i]->setChainActive( is_cold_chain(i) );
+                chains[i]->setChainActive( isColdChain(i) );
             }
         }
 
@@ -1799,7 +1799,7 @@ void Mcmcmc::tune( void )
         
         for (size_t i = 1; i < num_chains; ++i)
         {
-            heats_diff[i - 1] = heat_for_index(i-1) - heat_for_index(i);
+            heats_diff[i - 1] = heatForIndex(i-1) - heatForIndex(i);
         }
         
         for (size_t i = 1; i < num_chains; ++i)
@@ -1828,12 +1828,12 @@ void Mcmcmc::tune( void )
         
         double heatMinBound = 0.01;
         size_t j = 1;
-        size_t colderChainIdx = chain_for_heat_index(j-1);
+        size_t colderChainIdx = chainForHeatIndex(j-1);
         size_t hotterChainIdx = colderChainIdx;
         
         for (; j < num_chains; ++j)
         {
-            hotterChainIdx = chain_for_heat_index(j);
+            hotterChainIdx = chainForHeatIndex(j);
             chain_heats[hotterChainIdx] = chain_heats[colderChainIdx] - heats_diff[j - 1];
             
             if (chain_heats[hotterChainIdx] < heatMinBound)
@@ -1870,8 +1870,8 @@ void Mcmcmc::tune( void )
     {
         if ( chains[i] != NULL )
         {
-            chains[i]->setChainPosteriorHeat( heat_for_chain(i) );
-            chains[i]->setChainActive( is_cold_chain( i ) );
+            chains[i]->setChainPosteriorHeat( heatForChain(i) );
+            chains[i]->setChainActive( isColdChain( i ) );
             
             chains[i]->tune();
         }
@@ -1908,7 +1908,7 @@ void Mcmcmc::updateChainState(size_t j)
     {
         if ( chains[i] != NULL )
         {
-            chains[i]->setChainActive( is_cold_chain(i) );
+            chains[i]->setChainActive( isColdChain(i) );
         }
     }
     

--- a/src/core/analysis/mcmc/Mcmcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmcmc.cpp
@@ -614,7 +614,7 @@ void Mcmcmc::nextCycle(bool advanceCycle)
     
     for(int i=0;i<num_chains;i++)
     {
-        int heat_rank = heat_ranks[i];
+        int heat_rank = heat_index_for_chain(i);
         if (chain_prev_boundary[i] == boundary::coldest)
             heat_visitors[heat_rank].first++;
         if (chain_prev_boundary[i] == boundary::hottest)
@@ -1664,17 +1664,21 @@ void Mcmcmc::swapRandomChains(void)
 
 void Mcmcmc::updateTrips(int j)
 {
-    // The assumption is that we run this right after we have swapped j with another chain.
-    // Therefore heat_ranks[j] is the NEW heat rank for chain j.
+    // I think this code assumes that there is only one coldest chain and one hottest chain.
+    // For example, there are not two chains with heat == 1.0.
+    // This is true, and would probably stay true.
 
-    if ( heat_ranks[j] == 0)
+    // The assumption is that we run this right after we have swapped j with another chain.
+    // Therefore heat_index_for_chain(j) is the NEW heat rank for chain j.
+
+    if ( heat_index_for_chain(j) == 0)
     {
         if (chain_prev_boundary[j] == boundary::hottest)
             chain_half_trips[j]++;
 
         chain_prev_boundary[j] = boundary::coldest;
     }
-    else if (heat_ranks[j] == num_chains - 1)
+    else if (heat_index_for_chain(j) == num_chains - 1)
     {
         if (chain_prev_boundary[j] == boundary::coldest)
             chain_half_trips[j]++;

--- a/src/core/analysis/mcmc/Mcmcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmcmc.cpp
@@ -1674,7 +1674,7 @@ void Mcmcmc::updateTrips(int j)
 
         chain_prev_boundary[j] = boundary::coldest;
     }
-    else if (heat_ranks[j] == int(heat_ranks.size()) - 1)
+    else if (heat_ranks[j] == num_chains - 1)
     {
         if (chain_prev_boundary[j] == boundary::coldest)
             chain_half_trips[j]++;

--- a/src/core/analysis/mcmc/Mcmcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmcmc.cpp
@@ -949,8 +949,28 @@ void Mcmcmc::resetCounters( void )
 }
 
 
-void Mcmcmc::setHeatsInitial(const std::vector<double> &ht)
+void Mcmcmc::setHeatsInitial(const std::vector<double>& ht)
 {
+    // 1. Check that there are num_chains heats.
+    if (ht.size() != num_chains)
+        throw RbException()<<"Heat vector contains "<<ht.size()<<" heats, but there are "<<num_chains<<" chains.";
+
+    // 2. Check that the heats are non-zero
+    for(int i=0; i<int(ht.size()); i++)
+    {
+        if (not (ht[i] > 0.0))
+            throw RbException()<<"Heat "<<i+1<<" is "<<ht[i]<<", but should be > 0";
+    }
+
+    // 3. Check that the heats are sorted with the largest heat first (== smallest temperature first).
+    for(int i=0;i<int(ht.size())-1;i++)
+        if (ht[i] < ht[i+1])
+            throw RbException()<<"Heat "<<i+1<<" ("<<ht[i]<<") should be greater than heat "<<i+2<<" ("<<ht[i+1]<<")";
+
+    // 4. Check that the first heat is 1
+    if (ht[0] != 1.0)
+        throw RbException()<<"Heat 1 should be 1.0 (the cold chain), but is actually "<<ht[0];
+
     heat_temps = ht;
 }
 

--- a/src/core/analysis/mcmc/Mcmcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmcmc.cpp
@@ -130,6 +130,9 @@ Mcmcmc::Mcmcmc(const Model& m, const RbVector<Move> &mv, const RbVector<Monitor>
     chains = std::vector<Mcmc*>(num_chains, NULL);
     chain_values.resize(num_chains, 0.0);
     chain_heats.resize(num_chains, 0.0);
+    chain_prev_boundary.resize(num_chains, boundary::intermediate);
+    chain_half_trips.resize(num_chains, 0);
+    heat_visitors.resize(num_chains, {0,0});
     pid_per_chain.resize(num_chains, 0);
     heat_ranks.resize(num_chains, 0);
     heat_temps.resize(num_chains, 0.0);
@@ -202,6 +205,9 @@ Mcmcmc::Mcmcmc(const Mcmcmc &m) : MonteCarloSampler(m)
     
     chain_values            = m.chain_values;
     chain_heats             = m.chain_heats;
+    chain_prev_boundary     = m.chain_prev_boundary;
+    chain_half_trips        = m.chain_half_trips;
+    heat_visitors           = m.heat_visitors;
     chain_moves_tuningInfo  = m.chain_moves_tuningInfo;
     
     burnin_generation       = m.burnin_generation;
@@ -1115,12 +1121,18 @@ void Mcmcmc::setActivePIDSpecialized(size_t i, size_t n)
     chains.clear();
     chain_values.clear();
     chain_heats.clear();
+    chain_prev_boundary.clear();
+    chain_half_trips.clear();
+    heat_visitors.clear();
     heat_ranks.clear();
     chain_moves_tuningInfo.clear();
     
     chains.resize(num_chains);
     chain_values.resize(num_chains, 0.0);
     chain_heats.resize(num_chains, 0.0);
+    chain_prev_boundary.resize(num_chains, boundary::intermediate);
+    chain_half_trips.resize(num_chains, 0);
+    heat_visitors.resize(num_chains, {0,0});
     pid_per_chain.resize(num_chains, 0);
     heat_ranks.resize(num_chains, 0);
     

--- a/src/core/analysis/mcmc/Mcmcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmcmc.cpp
@@ -1435,15 +1435,7 @@ void Mcmcmc::swapMovesTuningInfo(RbVector<Move> &mvsj, RbVector<Move> &mvsk)
 
 void Mcmcmc::swapNeighborChains(void)
 {
-    
-    double lnProposalRatio = 0.0;
-    
     // randomly pick the indices of two chains
-    int j = 0;
-    int k = 0;
-    
-    // swap?
-    bool accept = false;
     
     // find the chain index of the neighbor of chain j (no temperature exists between the temperature of chain j and chain k)
     std::vector<double> tmp_chain_heats = chain_heats;
@@ -1458,16 +1450,10 @@ void Mcmcmc::swapNeighborChains(void)
     }
     
     if ( GLOBAL_RNG->uniform01() >= 0.5)
-    {
-        size_t heat_ranktmp = heat_rankj;
-        heat_rankj = heat_rankk;
-        heat_rankk = heat_ranktmp;
-    }
+        std::swap( heat_rankj, heat_rankk );
     
-    ++num_attempted_swaps[heat_rankj][heat_rankk];
-    
-    j = int(std::find(chain_heats.begin(), chain_heats.end(), tmp_chain_heats[heat_rankj]) - chain_heats.begin());
-    k = int(std::find(chain_heats.begin(), chain_heats.end(), tmp_chain_heats[heat_rankk]) - chain_heats.begin());
+    int j = int(std::find(chain_heats.begin(), chain_heats.end(), tmp_chain_heats[heat_rankj]) - chain_heats.begin());
+    int k = int(std::find(chain_heats.begin(), chain_heats.end(), tmp_chain_heats[heat_rankk]) - chain_heats.begin());
 
     swapGivenChains(j, k);
 }
@@ -1476,9 +1462,6 @@ void Mcmcmc::swapNeighborChains(void)
 
 void Mcmcmc::swapRandomChains(void)
 {
-    
-    double lnProposalRatio = 0.0;
-    
     // randomly pick the indices of two chains
     int j = 0;
     int k = 0;
@@ -1572,25 +1555,9 @@ void Mcmcmc::swapGivenChains(int j, int k, double lnProposalRatio)
             active_chain_index = j;
         }
 
-        double bj = chain_heats[j];
-        double bk = chain_heats[k];
-        chain_heats[j] = bk;
-        chain_heats[k] = bj;
-        size_t tmp = heat_ranks[j];
-        heat_ranks[j] = heat_ranks[k];
-        heat_ranks[k] = tmp;
-
-        // also swap the tuning information of each move
-        //            RbVector<Move>& tmp_movesj = chains[j]->getMoves();
-        //            RbVector<Move>& tmp_movesk = chains[k]->getMoves();
-        //            swapMovesTuningInfo(tmp_movesj, tmp_movesk);
-        //            chains[j]->setMoves(tmp_movesj);
-        //            chains[k]->setMoves(tmp_movesk);
-
-        std::vector<Mcmc::tuningInfo> tmp_mvs_ti = chain_moves_tuningInfo[j];
-        chain_moves_tuningInfo[j] = chain_moves_tuningInfo[k];
-        chain_moves_tuningInfo[k] = tmp_mvs_ti;
-
+        std::swap( chain_heats[j], chain_heats[k] );
+        std::swap( heat_ranks[j], heat_ranks[k] );
+        std::swap( chain_moves_tuningInfo[j], chain_moves_tuningInfo[k] );
 
         for (size_t i=0; i<num_chains; ++i)
         {

--- a/src/core/analysis/mcmc/Mcmcmc.h
+++ b/src/core/analysis/mcmc/Mcmcmc.h
@@ -83,6 +83,7 @@ namespace RevBayesCore {
         void                                    swapNeighborChains(void);
         void                                    swapRandomChains(void);
         void                                    swapGivenChains(int j, int k, double lnProposalRatio = 0.0);
+        void                                    updateTrips(int j);
         void                                    synchronizeValues(bool likelihood_only);
         void                                    synchronizeHeats(void);
         void                                    synchronizeTuningInfo(void);

--- a/src/core/analysis/mcmc/Mcmcmc.h
+++ b/src/core/analysis/mcmc/Mcmcmc.h
@@ -56,6 +56,8 @@ namespace RevBayesCore {
         void                                    printMoveSummary(std::ostream &o, size_t chainId, size_t moveId, Move &mv) const;
         void                                    printOperatorSummary(bool current_period);
         void                                    printSwapSummary(std::ostream &o) const;
+        void                                    printTripSummary(std::ostream &o) const;
+        void                                    printHeatSummary(std::ostream &o) const;
         void                                    printSwapSummaryPair(std::ostream &o, const size_t &row, const size_t &col) const;
         void                                    redrawStartingValues(void);                                                     //!< Redraw the starting values.
         void                                    removeMonitors(void);

--- a/src/core/analysis/mcmc/Mcmcmc.h
+++ b/src/core/analysis/mcmc/Mcmcmc.h
@@ -81,7 +81,12 @@ namespace RevBayesCore {
         void                                    synchronizeTuningInfo(void);
         void                                    updateChainState(size_t j);
         double                                  computeBeta(double d, size_t i);                                                // incremental temperature schedule
-        
+        double                                  heat_for_chain(int i) const;
+        bool                                    is_cold_chain(int i) const;
+        int                                     heat_index_for_chain(int i) const;
+        int                                     chain_for_heat_index(int i) const;
+        double                                  heat_for_index(int i) const;
+
         size_t                                  num_chains;
         std::vector<size_t>                     heat_ranks;
         std::vector<size_t>                     pid_per_chain;

--- a/src/core/analysis/mcmc/Mcmcmc.h
+++ b/src/core/analysis/mcmc/Mcmcmc.h
@@ -91,11 +91,11 @@ namespace RevBayesCore {
         void                                    synchronizeTuningInfo(void);
         void                                    updateChainState(size_t j);
         double                                  computeBeta(double d, size_t i);                                                // incremental temperature schedule
-        double                                  heat_for_chain(int i) const;
-        bool                                    is_cold_chain(int i) const;
-        int                                     heat_index_for_chain(int i) const;
-        int                                     chain_for_heat_index(int i) const;
-        double                                  heat_for_index(int i) const;
+        double                                  heatForChain(int i) const;
+        bool                                    isColdChain(int i) const;
+        int                                     heatIndexForChain(int i) const;
+        int                                     chainForHeatIndex(int i) const;
+        double                                  heatForIndex(int i) const;
 
         size_t                                  num_chains;
         std::vector<size_t>                     heat_ranks;

--- a/src/core/analysis/mcmc/Mcmcmc.h
+++ b/src/core/analysis/mcmc/Mcmcmc.h
@@ -75,6 +75,7 @@ namespace RevBayesCore {
         void                                    swapMovesTuningInfo(RbVector<Move> &mvsj, RbVector<Move> &mvsk);
         void                                    swapNeighborChains(void);
         void                                    swapRandomChains(void);
+        void                                    swapGivenChains(int j, int k, double lnProposalRatio = 0.0);
         void                                    synchronizeValues(bool likelihood_only);
         void                                    synchronizeHeats(void);
         void                                    synchronizeTuningInfo(void);

--- a/src/core/analysis/mcmc/Mcmcmc.h
+++ b/src/core/analysis/mcmc/Mcmcmc.h
@@ -27,6 +27,13 @@ namespace RevBayesCore {
     class Mcmcmc : public MonteCarloSampler {
         
     public:
+        enum class boundary
+        {
+            hottest,
+            coldest,
+            intermediate
+        };
+
         Mcmcmc(const Model& m, const RbVector<Move> &mv, const RbVector<Monitor> &mn, std::string sT="random", size_t nc=4, size_t si=100, double dt=0.1, size_t ntries=1000, bool th=true, double tht=0.23, std::string sm="neighbor", std::string smo="multiple");
         Mcmcmc(const Mcmcmc &m);
         virtual                                ~Mcmcmc(void);                                                                   //!< Virtual destructor
@@ -93,6 +100,11 @@ namespace RevBayesCore {
         std::vector<Mcmc*>                      chains;
         std::vector<double>                     chain_values;
         std::vector<double>                     chain_heats;
+
+        std::vector<boundary>                   chain_prev_boundary;                                // has the chain most recently visited the hottest or coldest temperature
+        std::vector<int>                        chain_half_trips;                                   // how many trips has the chain made from hottest -> coldest or coldest to hottest
+        std::vector<std::pair<int,int>>         heat_visitors;                                      // how many times is the chain at this temperator most recently hottest (first) or coldest (second)
+
         std::string                             schedule_type;
         size_t                                  current_generation;
         size_t                                  burnin_generation;


### PR DESCRIPTION
This patch 
* cleans up the MC3 code
* adds mixing statistics that supplement the probability of swapping chains
* adds a comment and paper reference about the new mixing statistics.

There do not appear to be any MC3 tests in the testsuite, but I modified `test_JC_unrooted` (which is fast) to do the following:
```
mymcmc = mcmcmc(mymodel, monitors, moves, nchain=4, nruns=2, tuneHeat = TRUE)

mymcmc.burnin(generations=200,tuningInterval=20)
mymcmc.run(generations=2000)
```
According to my tests, there is no change to the output file `output{,4}/mcmcmc_JC_unrooted_uniform_run_1.out`.