### PR TITLE
Build singularity image & add initial release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,41 @@ jobs:
         draft: true
         prerelease: false
 
+  build_singularity_and_upload:
+    needs: create_release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - uses: eWaterCycle/setup-singularity@v7
+      with:
+        singularity-version: 3.8.3
+
+    - name: Get version
+      id: get_version
+      run: |
+        echo ::set-output name=version::$(echo $GITHUB_REF | cut -d / -f 3)
+
+    - name: Create singularity image
+      id: create_image
+      run: |
+        cd projects/singularity
+        PACKAGE=revbayes-${{ steps.get_version.outputs.version }}-linux64-singularity.simg
+        singularity build --fakeroot ~/${PACKAGE} Singularity
+        echo ::set-output name=archive_name::${PACKAGE}
+        echo ::set-output name=archive_path::${HOME}/${PACKAGE}
+
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ needs.create_release.outputs.upload_url }}
+        asset_path: ${{ steps.create_image.outputs.archive_path }}
+        asset_name: ${{ steps.create_image.outputs.archive_name }}
+        asset_content_type: application/octet-stream
 
   build_and_upload:
     needs: create_release
@@ -258,7 +293,7 @@ jobs:
 
   notify:
     name: Notify Slack
-    needs: build_and_upload
+    needs: [build_singularity_and_upload, build_and_upload]
     runs-on: ubuntu-latest
     if: always()
     steps:

--- a/doc/release-workflow.md
+++ b/doc/release-workflow.md
@@ -1,0 +1,27 @@
+# Release workflow
+
+0. Update NEWS.md file
+
+1. Build packages
+
+    1. Checkout the development branch
+        * `git checkout development`
+        * `git pull`
+    2. Create a tag for the release
+        * `git tag vD.D.D`
+        * tag names
+            * v2.0 for a major release
+    3. Push the tag to github
+        * `git push --tags`
+        * This will create a draft release.
+        * GitHub actions will upload packages for Linux, Linux/Singularity, Mac, Windows
+    4. Wait for packages to build.
+    5. Edit draft-release page on github
+        * See https://github.com/revbayes/revbayes/releases
+        * Add some basic release notes.
+        * Make the draft release public.
+
+2. Update website
+
+    1. Update version number on download page.
+    2. Update links on download page.

--- a/projects/singularity/Singularity
+++ b/projects/singularity/Singularity
@@ -3,6 +3,8 @@ From: ubuntu:20.04
 
 %post
 
+    export DEBIAN_FRONTEND=noninteractive
+
     mkdir /revbayes
     
     echo "Installing required packages..."


### PR DESCRIPTION
This PR is supposed to assist with the 1.2 release.
It autobuilds a linux singularity image, in addition to the standard compile.
It also adds an initial release workflow document-- although I can split that out if people prefer.
