### PR TITLE
Don't crash when reading some trees

### DIFF
--- a/src/core/datatypes/trees/TopologyNode.h
+++ b/src/core/datatypes/trees/TopologyNode.h
@@ -38,6 +38,7 @@
 
 #include "Clade.h"
 #include "RbBitSet.h"
+#include "RbConstants.h"
 
 #include "TreeChangeEventMessage.h"
 #include "Taxon.h"
@@ -46,6 +47,7 @@
 #include <vector>
 #include <map>
 #include <string>
+#include <boost/optional.hpp>
 
 namespace RevBayesCore {
     
@@ -54,18 +56,19 @@ namespace RevBayesCore {
     class TopologyNode  {
         
     public:
-        TopologyNode(size_t indx=0);                                                                                                    //!< Default constructor with optional index
-        TopologyNode(const std::string& n, size_t indx=0);                                                                              //!< Constructor with name and optional index
-        TopologyNode(const Taxon& t, size_t indx=0);                                                                                    //!< Constructor with taxon and optional index
+        TopologyNode();                                                                                                                 //!< Default constructor with no index
+        TopologyNode(size_t indx);                                                                                                      //!< Default constructor with index
+        TopologyNode(const std::string& n, const boost::optional<size_t>& indx = {});                                                   //!< Constructor with name and optional index
+        TopologyNode(const Taxon& t, const boost::optional<size_t>& indx = {});                                                         //!< Constructor with taxon and optional index
         TopologyNode(const TopologyNode &n);                                                                                            //!< Copy constructor
         virtual                                    ~TopologyNode(void);                                                                 //!< Destructor
         TopologyNode&                               operator=(const TopologyNode& n);
-        
-        
+
+
         // Basic utility functions
         TopologyNode*                               clone(void) const;                                                                  //!< Clone object
         bool                                        equals(const TopologyNode& node) const;                                             //!< Test whether this is the same node
-        
+
         // public methods
         void                                        addBranchParameter(const std::string &n, double p);
         void                                        addBranchParameter(const std::string &n, const std::string &p);
@@ -75,10 +78,10 @@ namespace RevBayesCore {
         void                                        addNodeParameter(const std::string &n, double p);
         void                                        addNodeParameter(const std::string &n, const std::string &p);
         void                                        addNodeParameters(const std::string &n, const std::vector<double> &p, bool io);
-		void                                        addNodeParameters(const std::string &n, const std::vector<std::string> &p, bool io);
+	void                                        addNodeParameters(const std::string &n, const std::vector<std::string> &p, bool io);
         void                                        clearParameters(void);                                                              //!< Clear the node and branch parameters
         void                                        clearBranchParameters(void);
-		void                                        clearNodeParameters(void);
+	void                                        clearNodeParameters(void);
         virtual std::string                         computeNewick(bool round = true);                                                   //!< Compute the newick string for this clade
         std::string                                 computePlainNewick(void) const;                                                     //!< Compute the newick string for this clade as a plain string without branch length
         std::string                                 computeSimmapNewick(bool round = true);                                             //!< Compute the newick string compatible with SIMMAP and phytools
@@ -98,6 +101,7 @@ namespace RevBayesCore {
         const std::vector<TopologyNode*>&           getChildren(void) const;
         std::vector<int>                            getChildrenIndices(void) const;                                                     //!< Return children indices
         Clade                                       getClade(void) const;                                                               //!< Get the clade this node represents
+        bool                                        hasIndex(void) const;                                                               //!< Does the node have an index
         size_t                                      getIndex(void) const;                                                               //!< Get index of node
         void                                        getIndicesOfNodesInSubtree(bool countTips, std::vector<size_t>* indices) const;                                                               //!< Get index of node
         std::string                                 getIndividualName() const;                                                             //!< Get the species name for the node
@@ -149,7 +153,7 @@ namespace RevBayesCore {
 
         void                                        setName(const std::string& n);                                                      //!< Set the name of this node
         void                                        setNumberOfShiftEvents(size_t n);                                                   //!< Set the number of shift events for stochastic character maps
-  		void										setNodeType(bool tip, bool root, bool interior); //SK
+	void					    setNodeType(bool tip, bool root, bool interior); //SK
         void                                        setParent(TopologyNode* p);                                                         //!< Sets the node's parent
         void                                        setSampledAncestor(bool tf);                                                        //!< Set if the node is a sampled ancestor
         void                                        setSpeciesName(std::string const &n);                                               //!< Set the species name of this node
@@ -158,7 +162,7 @@ namespace RevBayesCore {
         void                                        setTimeInStates(std::vector<double> t);
         void                                        setTree(Tree *t);                                                                   //!< Sets the tree pointer
         void                                        setUseAges(bool tf, bool recursive);
-        
+
         // internal helper functions
         bool getBurstSpeciation(void) const { return burst_speciation; }
         bool getSamplingEvent(void) const { return sampling_event; }
@@ -168,42 +172,42 @@ namespace RevBayesCore {
         void setSamplingEvent(bool tf) { sampling_event = tf; }
         void setSerialSampling(bool tf) { serial_sampling = tf; }
         void setSerialSpeciation(bool tf) { serial_speciation = tf; }
-                
+
     protected:
 
-        bool burst_speciation;
-        bool sampling_event;
-        bool serial_sampling;
-        bool serial_speciation;
-        
+        bool burst_speciation = false;
+        bool sampling_event = false;
+        bool serial_sampling = false;
+        bool serial_speciation = false;
+
         // helper methods
         virtual std::string                         buildNewickString(bool simmap, bool round);                                                     //!< compute the newick string for a tree rooting at this node
-        
+
         // protected members
-        bool                                        use_ages;
-        double                                      age;
-        double                                      branch_length;
+        bool                                        use_ages = true;
+        double                                      age = RbConstants::Double::nan;
+        double                                      branch_length = RbConstants::Double::nan;
         std::vector<TopologyNode*>                  children;                                                                           //!< Vector holding the node's children. Note that the parent owns the children but not the other way around.
-        TopologyNode*                               parent;                                                                             //!< Pointer to the parent of the node. It is a regular pointer instead of a super smart pointer to avoid loops in the reference counting.
-        Tree*                                       tree;                                                                               //!< A pointer to the tree for convinience access
+        TopologyNode*                               parent = nullptr;                                                                   //!< Pointer to the parent of the node. It is a regular pointer instead of a super smart pointer to avoid loops in the reference counting.
+        Tree*                                       tree = nullptr;                                                                     //!< A pointer to the tree for convinience access
         Taxon                                       taxon;                                                                              //!< Taxon of the node, i.e. identifier/taxon name, plus species it comes from
 
-        size_t                                      index;                                                                              //!< Node index
-        bool                                        interior_node;
-        bool                                        root_node;
-        bool                                        tip_node;
-        bool                                        sampled_ancestor;
-        
+        boost::optional<size_t>                     index;                                                                              //!< Node index
+        bool                                        interior_node = false;
+        bool                                        root_node = true;
+        bool                                        tip_node = true;
+        bool                                        sampled_ancestor = false;
+
         // information for newick representation
         std::vector<std::string>                    node_comments;
         std::vector<std::string>                    branch_comments;
-       
+
         // for stochastic maps
         std::vector<double>                         time_in_states;
-        size_t                                      num_shift_events;
-        
+        size_t                                      num_shift_events = 0;
+
 //        RevLanguage::RevPtr<TaxonMap>               taxon_map;
-        
+
      // std::map<std::string,std::string>           nodeFields;
      // std::map<std::string,std::string>           branchFields;
     };

--- a/src/core/datatypes/trees/Tree.cpp
+++ b/src/core/datatypes/trees/Tree.cpp
@@ -1279,18 +1279,19 @@ bool Tree::isUltrametric( void ) const
 
 void Tree::makeInternalNodesBifurcating(bool reindex, bool as_fossils)
 {
-
     // delegate the call to the nodes which will make the tree bifurcating recursively.
     getRoot().makeBifurcating( as_fossils );
-    
 
+    // reindex here, in case makeBifurcating
+    // * added new fossil tips with no index
+    // * removed out-degree-1 nodes ("knuckles")
+    
     // we need to reset the root so that the vector of nodes get filled again with the new number of nodes
-    setRoot( &getRoot(), reindex );
+    setRoot( &getRoot(), true );
 
     // clear the taxon bitset map
     // the next time someone call getTaxonBitset() it will be rebuilt
     taxon_bitset_map.clear();
-
 }
 
 void Tree::makeRootBifurcating(const Clade& outgroup, bool as_fossils)

--- a/src/core/distributions/phylogenetics/tree/AbstractMultispeciesCoalescent.cpp
+++ b/src/core/distributions/phylogenetics/tree/AbstractMultispeciesCoalescent.cpp
@@ -112,13 +112,13 @@ void AbstractMultispeciesCoalescent::buildRandomBinaryTree(std::vector<TopologyN
         tips.erase(tips.begin()+index);
         
         // add a left child
-        TopologyNode* leftChild = new TopologyNode(0);
+        TopologyNode* leftChild = new TopologyNode();
         parent->addChild(leftChild);
         leftChild->setParent(parent);
         tips.push_back(leftChild);
         
         // add a right child
-        TopologyNode* rightChild = new TopologyNode(0);
+        TopologyNode* rightChild = new TopologyNode();
         parent->addChild(rightChild);
         rightChild->setParent(parent);
         tips.push_back(rightChild);

--- a/src/core/distributions/phylogenetics/tree/AbstractRootedTreeDistribution.cpp
+++ b/src/core/distributions/phylogenetics/tree/AbstractRootedTreeDistribution.cpp
@@ -151,13 +151,13 @@ void AbstractRootedTreeDistribution::buildRandomBinaryTree(std::vector<TopologyN
         tips.erase(tips.begin()+long(index));
         
         // add a left child
-        TopologyNode* leftChild = new TopologyNode(0);
+        TopologyNode* leftChild = new TopologyNode();
         parent->addChild(leftChild);
         leftChild->setParent(parent);
         tips.push_back(leftChild);
         
         // add a right child
-        TopologyNode* rightChild = new TopologyNode(0);
+        TopologyNode* rightChild = new TopologyNode();
         parent->addChild(rightChild);
         rightChild->setParent(parent);
         tips.push_back(rightChild);

--- a/src/core/distributions/phylogenetics/tree/DuplicationLossProcess.cpp
+++ b/src/core/distributions/phylogenetics/tree/DuplicationLossProcess.cpp
@@ -112,13 +112,13 @@ void DuplicationLossProcess::buildRandomBinaryTree(std::vector<TopologyNode*> &t
         tips.erase(tips.begin()+index);
         
         // add a left child
-        TopologyNode* leftChild = new TopologyNode(0);
+        TopologyNode* leftChild = new TopologyNode();
         parent->addChild(leftChild);
         leftChild->setParent(parent);
         tips.push_back(leftChild);
         
         // add a right child
-        TopologyNode* rightChild = new TopologyNode(0);
+        TopologyNode* rightChild = new TopologyNode();
         parent->addChild(rightChild);
         rightChild->setParent(parent);
         tips.push_back(rightChild);

--- a/src/core/distributions/phylogenetics/tree/MultispeciesCoalescentMigration.cpp
+++ b/src/core/distributions/phylogenetics/tree/MultispeciesCoalescentMigration.cpp
@@ -127,13 +127,13 @@ void MultispeciesCoalescentMigration::buildRandomBinaryTree(std::vector<Topology
         tips.erase(tips.begin()+index);
         
         // add a left child
-        TopologyNode* leftChild = new TopologyNode(0);
+        TopologyNode* leftChild = new TopologyNode();
         parent->addChild(leftChild);
         leftChild->setParent(parent);
         tips.push_back(leftChild);
         
         // add a right child
-        TopologyNode* rightChild = new TopologyNode(0);
+        TopologyNode* rightChild = new TopologyNode();
         parent->addChild(rightChild);
         rightChild->setParent(parent);
         tips.push_back(rightChild);

--- a/src/core/distributions/phylogenetics/tree/UniformTimeTreeDistribution.cpp
+++ b/src/core/distributions/phylogenetics/tree/UniformTimeTreeDistribution.cpp
@@ -104,13 +104,13 @@ void UniformTimeTreeDistribution::buildRandomBinaryHistory(std::vector<TopologyN
         tips.erase(tips.begin()+long(index));
         
         // Add a left child
-        TopologyNode* leftChild = new TopologyNode(0);
+        TopologyNode* leftChild = new TopologyNode();
         parent->addChild(leftChild);
         leftChild->setParent(parent);
         tips.push_back(leftChild);
         
         // Add a right child
-        TopologyNode* rightChild = new TopologyNode(0);
+        TopologyNode* rightChild = new TopologyNode();
         parent->addChild(rightChild);
         rightChild->setParent(parent);
         tips.push_back(rightChild);

--- a/src/core/distributions/phylogenetics/tree/birthdeath/ConditionedBirthDeathShiftProcessContinuous.cpp
+++ b/src/core/distributions/phylogenetics/tree/birthdeath/ConditionedBirthDeathShiftProcessContinuous.cpp
@@ -169,13 +169,13 @@ void ConditionedBirthDeathShiftProcessContinuous::buildRandomBinaryHistory(std::
         tips.erase(tips.begin()+long(index));
         
         // Add a left child
-        TopologyNode* leftChild = new TopologyNode(0);
+        TopologyNode* leftChild = new TopologyNode();
         parent->addChild(leftChild);
         leftChild->setParent(parent);
         tips.push_back(leftChild);
         
         // Add a right child
-        TopologyNode* rightChild = new TopologyNode(0);
+        TopologyNode* rightChild = new TopologyNode();
         parent->addChild(rightChild);
         rightChild->setParent(parent);
         tips.push_back(rightChild);

--- a/src/core/distributions/phylogenetics/tree/birthdeath/HeterogeneousRateBirthDeath.cpp
+++ b/src/core/distributions/phylogenetics/tree/birthdeath/HeterogeneousRateBirthDeath.cpp
@@ -156,13 +156,13 @@ void HeterogeneousRateBirthDeath::buildRandomBinaryHistory(std::vector<TopologyN
         tips.erase(tips.begin()+long(index));
         
         // Add a left child
-        TopologyNode* leftChild = new TopologyNode(0);
+        TopologyNode* leftChild = new TopologyNode();
         parent->addChild(leftChild);
         leftChild->setParent(parent);
         tips.push_back(leftChild);
         
         // Add a right child
-        TopologyNode* rightChild = new TopologyNode(0);
+        TopologyNode* rightChild = new TopologyNode();
         parent->addChild(rightChild);
         rightChild->setParent(parent);
         tips.push_back(rightChild);

--- a/src/core/distributions/phylogenetics/tree/birthdeath/StateDependentSpeciationExtinctionProcess.cpp
+++ b/src/core/distributions/phylogenetics/tree/birthdeath/StateDependentSpeciationExtinctionProcess.cpp
@@ -2590,7 +2590,7 @@ bool StateDependentSpeciationExtinctionProcess::simulateTree( size_t attempts )
     std::vector<TopologyNode*> nodes;
 
     // initialize the root node
-    TopologyNode* root = new TopologyNode(0);
+    TopologyNode* root = new TopologyNode();
     double t = process_age->getValue();
     if (condition_on_num_tips == true)
     {

--- a/src/core/distributions/phylogenetics/tree/birthdeath/TimeVaryingStateDependentSpeciationExtinctionProcess.cpp
+++ b/src/core/distributions/phylogenetics/tree/birthdeath/TimeVaryingStateDependentSpeciationExtinctionProcess.cpp
@@ -2035,7 +2035,7 @@ bool TimeVaryingStateDependentSpeciationExtinctionProcess::simulateTree( size_t 
     std::vector<TopologyNode*> nodes;
     
     // initialize the root node
-    TopologyNode* root = new TopologyNode(0);
+    TopologyNode* root = new TopologyNode();
     double t = process_age->getValue();
     root->setAge(t);
     root->setNodeType(false, true, true);

--- a/src/core/distributions/phylogenetics/tree/coalescent/AbstractCoalescent.cpp
+++ b/src/core/distributions/phylogenetics/tree/coalescent/AbstractCoalescent.cpp
@@ -116,13 +116,13 @@ void AbstractCoalescent::buildRandomBinaryTree(std::vector<TopologyNode*> &tips)
         tips.erase(tips.begin()+long(index));
         
         // add a left child
-        TopologyNode* leftChild = new TopologyNode(0);
+        TopologyNode* leftChild = new TopologyNode();
         parent->addChild(leftChild);
         leftChild->setParent(parent);
         tips.push_back(leftChild);
         
         // add a right child
-        TopologyNode* rightChild = new TopologyNode(0);
+        TopologyNode* rightChild = new TopologyNode();
         parent->addChild(rightChild);
         rightChild->setParent(parent);
         tips.push_back(rightChild);

--- a/src/revlanguage/functions/phylogenetics/tree/Func_simCompleteTree.cpp
+++ b/src/revlanguage/functions/phylogenetics/tree/Func_simCompleteTree.cpp
@@ -154,7 +154,7 @@ void Func_simCompleteTree::buildRandomBinaryTree(std::vector<RevBayesCore::Topol
         nodes.erase(nodes.begin()+long(index));
         
         
-        RevBayesCore::TopologyNode* parent = new RevBayesCore::TopologyNode(0);
+        RevBayesCore::TopologyNode* parent = new RevBayesCore::TopologyNode();
         parent->setAge( ages[0] );
         ages.erase( ages.begin() );
         

--- a/src/revlanguage/functions/phylogenetics/tree/Func_simTree.cpp
+++ b/src/revlanguage/functions/phylogenetics/tree/Func_simTree.cpp
@@ -197,13 +197,13 @@ void Func_simTree::simulateBalancedTree( size_t n, std::vector<RevBayesCore::Top
         RevBayesCore::TopologyNode *parent = nodes[i];
         
         // add a left child
-        RevBayesCore::TopologyNode* leftChild = new RevBayesCore::TopologyNode(0);
+        RevBayesCore::TopologyNode* leftChild = new RevBayesCore::TopologyNode();
         parent->addChild(leftChild);
         leftChild->setParent(parent);
         children.push_back(leftChild);
         
         // add a right child
-        RevBayesCore::TopologyNode* rightChild = new RevBayesCore::TopologyNode(0);
+        RevBayesCore::TopologyNode* rightChild = new RevBayesCore::TopologyNode();
         parent->addChild(rightChild);
         rightChild->setParent(parent);
         children.push_back(rightChild);
@@ -236,12 +236,12 @@ void Func_simTree::simulateCaterpillarTree( size_t n, RevBayesCore::TopologyNode
     
     
     // add a left child
-    RevBayesCore::TopologyNode* leftChild = new RevBayesCore::TopologyNode(0);
+    RevBayesCore::TopologyNode* leftChild = new RevBayesCore::TopologyNode();
     node->addChild(leftChild);
     leftChild->setParent(node);
     
     // add a right child
-    RevBayesCore::TopologyNode* rightChild = new RevBayesCore::TopologyNode(0);
+    RevBayesCore::TopologyNode* rightChild = new RevBayesCore::TopologyNode();
     node->addChild(rightChild);
     rightChild->setParent(node);
     


### PR DESCRIPTION
Investigating #240, it seems that reading some trees with sampled ancestors does not work.

The problem seems to be that when calling `getRoot().makeBifurcating( as_fossils )`, new tip nodes are created.  All of these new nodes have index 0 because the index is never set.  Later, `orderNodesByIndex( )` crashes because multiple nodes have the same index.

The patch here does three things:
1. it distinguishes between an index of 0 and an index that has never been set.
2. it makes TopologyNode::getIndex( ) complain when the node index has never been set.
3. it changes make the call to `set_root( , )` always recompute node indices after the call to `getRoot().makeBifurcating( as fossils )`

Distinguishing between nodes with an unset index, and nodes with index 0 should help to prevent problems like this in the future and make it more clear what the underlying problem is if unset indices are referenced.

Should the `reindex` parameter to `Tree::makeInternalNodesBifurcating( )` should be removed?  Or are there other approaches to the reindexing that would be better?