### PR TITLE
Update test compilers1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        name: [ubuntu-gcc-6,
-               ubuntu-gcc-7,
+        name: [ubuntu-gcc-7,
                ubuntu-gcc-8,
                ubuntu-gcc-9,
                ubuntu-gcc-9-mpi,
@@ -24,13 +23,6 @@ jobs:
                ]
 
         include:
-          - name: ubuntu-gcc-6
-            os: ubuntu-18.04
-            compiler: gcc
-            version: "6"
-            install_boost: 1.74
-            mpi: false
-
           - name: ubuntu-gcc-7
             os: ubuntu-latest
             compiler: gcc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
                ubuntu-gcc-9-mpi,
                ubuntu-gcc-10,
                ubuntu-gcc-11,
-               ubuntu-clang-8,
+               ubuntu-clang-11,
                macos-xcode-11.7,
                windows
                ]
@@ -63,10 +63,10 @@ jobs:
             install_boost: 1.74
             mpi: false
 
-          - name: ubuntu-clang-8
+          - name: ubuntu-clang-11
             os: ubuntu-latest
             compiler: clang
-            version: "8"
+            version: "11"
             mpi: false
 
           - name: macos-xcode-11.7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
                ubuntu-gcc-10,
                ubuntu-gcc-11,
                ubuntu-clang-11,
-               macos-xcode-11.7,
+               macos-xcode-12.4,
                windows
                ]
 
@@ -69,10 +69,10 @@ jobs:
             version: "11"
             mpi: false
 
-          - name: macos-xcode-11.7
+          - name: macos-xcode-12.4
             os: macos-latest
             compiler: xcode
-            version: "11.7"
+            version: "12.4"
             mpi: false
   
           - name: windows

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,7 @@ jobs:
                ubuntu-gcc-9,
                ubuntu-gcc-9-mpi,
                ubuntu-gcc-10,
+               ubuntu-gcc-11,
                ubuntu-clang-8,
                macos-xcode-11.7,
                windows
@@ -52,6 +53,13 @@ jobs:
             os: ubuntu-latest
             compiler: gcc
             version: "10"
+            install_boost: 1.74
+            mpi: false
+
+          - name: ubuntu-gcc-11
+            os: ubuntu-latest
+            compiler: gcc
+            version: "11"
             install_boost: 1.74
             mpi: false
 


### PR DESCRIPTION
This PR removes GCC 6 from the list of test compilers, since github is going to start making it fail in October.

It also 
* adds a GCC-11 test to replace the GCC-6 one
* bumps the XCode test to XCode 12.4
* bumps the clang test to clang 11