### PR TITLE
Fix vectors in functions

### DIFF
--- a/src/revlanguage/functions/UserFunction.cpp
+++ b/src/revlanguage/functions/UserFunction.cpp
@@ -66,7 +66,7 @@ RevPtr<RevVariable> UserFunction::execute( void )
 RevPtr<RevVariable> UserFunction::executeCode( void )
 {
     // Create new evaluation frame with function base class execution environment as parent
-    Environment* function_frame = new Environment( getEnvironment(), "UserFunctionEnvironment" );
+    auto function_frame = std::make_shared<Environment>( getEnvironment(), "UserFunctionEnvironment" );
     
     // Add the arguments to our environment
     for ( std::vector<Argument>::iterator it = args.begin(); it != args.end(); ++it )

--- a/src/revlanguage/functions/UserFunction.cpp
+++ b/src/revlanguage/functions/UserFunction.cpp
@@ -128,6 +128,14 @@ RevPtr<RevVariable> UserFunction::executeCode( void )
         }
     }
 
+    // Build any vectors that need to be built.
+    // This will clear the needs_building_env pointer, so there are no dangling references after the function frame is destroyed.
+    for(auto& p: function_frame->getVariableTable())
+    {
+        auto& name = p.first;
+        function_frame->getRevObject(name);
+    }
+
     // Return the return value
     return ret_var;
 }

--- a/src/revlanguage/parser/SyntaxIndexOperation.cpp
+++ b/src/revlanguage/parser/SyntaxIndexOperation.cpp
@@ -167,7 +167,7 @@ RevPtr<RevVariable> SyntaxIndexOperation::evaluateLHSContent( Environment& env, 
                     // set this variable as a hidden variable so that it doesn't show in ls()
                     theElementVar->setElementVariableState( true );
                     
-                    theParentVar->addIndex( int(i) );
+                    theParentVar->addIndex( int(i) , &env);
                 }
             }
             else
@@ -187,15 +187,14 @@ RevPtr<RevVariable> SyntaxIndexOperation::evaluateLHSContent( Environment& env, 
             throw RbException("We cannot make a composite container from variable of type '" + theParentObj.getType() + "'.");
         }
     }
-    
+
     // compute the index and internal name for this variable
     int idx = (int)static_cast<Integer&>( indexVar->getRevObject() ).getValue();
     std::string identifier = theParentVar->getName() + "[" + std::to_string(idx) + "]";
-    
-    // mark the parent variable as a vector variable
-    theParentVar->setVectorVariableState( true );
-    theParentVar->addIndex( idx );
 
+    // mark the parent variable as a vector variable
+    theParentVar->setToVectorVariable( &env );
+    theParentVar->addIndex( idx, &env );
 
     if ( env.existsVariable( identifier ) == false )
     {
@@ -207,7 +206,6 @@ RevPtr<RevVariable> SyntaxIndexOperation::evaluateLHSContent( Environment& env, 
 
     // get the slot and variable
     RevPtr<RevVariable> the_var  = env.getVariable( identifier );
-    
     
     // set this variable as an element variable; which is by default a hidden variable so that it doesn't show in ls()
     the_var->setElementVariableState( true );

--- a/src/revlanguage/workspace/RevVariable.h
+++ b/src/revlanguage/workspace/RevVariable.h
@@ -10,6 +10,8 @@
 
 namespace RevLanguage {
     
+    class Environment;
+
     /**
      * @brief Variable: named (in frames) or unnamed (temporary) Rev variables
      *
@@ -49,7 +51,7 @@ namespace RevLanguage {
         RevVariable&            operator=(const RevVariable &v);                        //!< Assignment operator
 
         // Regular functions
-        void                    addIndex(size_t idx);                                      //!< Resize the vector to include this index.
+        void                    addIndex(size_t idx, Environment* env);                 //!< Resize the vector to include this index.
         RevVariable*            clone(void) const;                                      //!< Clone variable
         size_t                  getMaxElementIndex(void) const;                        //!< Get the set of element indices for this vector variable.
         const std::string&      getName(void) const;                                    //!< Get the name of the variable
@@ -65,7 +67,7 @@ namespace RevLanguage {
         void                    printValue(std::ostream& o, bool toScreen) const;       //!< Print value of variable
         void                    setElementVariableState(bool flag = true);              //!< Set (or unset) element variable status
         void                    setHiddenVariableState(bool flag = true);               //!< Set (or unset) hidden variable status
-        void                    setVectorVariableState(bool flag = true);               //!< Set (or unset) vector variable status
+        void                    setToVectorVariable(Environment* env= nullptr);         //!< Set (or unset) vector variable status
         void                    setWorkspaceVariableState(bool flag = true);            //!< Set (or unset) control variable status
         void                    setName(const std::string &n);                          //!< Set the name of this variable
         void                    replaceRevObject(RevObject *newObj);                    //!< Replace the Rev object of this variable
@@ -79,18 +81,21 @@ namespace RevLanguage {
     private:
         
         // Member variables
-        size_t                  element_index_max;                                      //!< The maximum element index
-        mutable bool            needs_building;
+
+        // variables related to building the components of a vector
+        bool                    is_vector_var = false;                                  //!< Is this a vector variable?
+        size_t                  element_index_max = 0;                                  //!< The maximum element index
+        mutable Environment*    needs_building_env = nullptr;                           //!< Environment to later look up element entries
 //        std::set<int>           element_indices;                                        //!< The indices of the elements if this is a vector variable.
-        bool                    is_element_var;                                         //!< Is this variable an element of a vector?
-        bool                    is_hidden_var;                                          //!< Is this a hidden variable?
-        bool                    is_reference_var;                                       //!< Is this a reference variable?
-        bool                    is_vector_var;                                          //!< Is this a vector variable?
-        bool                    is_workspace_var;                                       //!< Is this a workspace variable?
+
+        bool                    is_element_var = false;                                 //!< Is this variable an element of a vector?
+        bool                    is_hidden_var = false;                                  //!< Is this a hidden variable?
+        bool                    is_reference_var = false;                               //!< Is this a reference variable?
+        bool                    is_workspace_var = false;                               //!< Is this a workspace variable?
         std::string             name;                                                   //!< Name of variable
-        mutable size_t          ref_count;                                              //!< Reference count used by RevPtr
-        RevPtr<RevVariable>     referenced_variable;                                    //!< Smart pointer to referenced variable
-        RevObject*              rev_object;                                             //!< Pointer to the Rev object inside the variable
+        mutable size_t          ref_count = 0;                                          //!< Reference count used by RevPtr
+        RevPtr<RevVariable>     referenced_variable = nullptr;                          //!< Smart pointer to referenced variable
+        RevObject*              rev_object = nullptr;                                   //!< Pointer to the Rev object inside the variable
         TypeSpec                required_type_spec;                                     //!< Required type of the object
     };
     


### PR DESCRIPTION
Currently, you can define functions.  For example:

```
function sampleDirichlet(n, alpha)
{
  for(i in 1:n)
  {
     x[i] ~ dnGamma(alpha, 1.0)
  }
  return x/sum(x)
}
```

However, this function fails with the message:
```
> sampleDirichlet(10,2)
   Missing Variable:	Variable x[1] does not exist
```

The reason is each function has its own Environment that records names created in that function.  In this case, the function Environment include `n`, `alpha`, `x`, `x[1]`, `x[2]`, ... etc.

However, when we create vectors like `x`, RevBayes does not immediately record the Variable for each of the elements.
Instead, RevBayes sets the flag `needs_building` and defers construction of the vector until getRevObject( ) is called for `x`.

When building the vector, RevBayes needs to look up the names `x[1]`, `x[2]`, etc. and then call the function `v( )` on the resulting list of variables.  However, we need to look these names up in the function environment, not the global user workspace environment:

```
    // @TODO: We actually might need a different workspace here than the user workspace. (Sebastian)
    //        Environment &env = Workspace::userWorkspace();
```

This patch 
* modifies RevVariable to record the Environment to use when building a vector.
* modifies setToVectorVariable( ) and addIndex( ) to take an Environment* as an argument, so that we know what Environment to use.
* builds all vectors created during a function call after we finish executing the function, so that we don't have any dangling pointers to the function Environment.

With this patch, `sampleDirichlet(10,2)` works:

```
> function sampleDirichlet(n, alpha)
+ {
+   for(i in 1:n)
+   {
+      x[i] ~ dnGamma(alpha, 1.0)
+   }
+   return x/sum(x)
+ }
> sampleDirichlet(10,2)
   [ 0.148, 0.091, 0.090, 0.094, 0.055, 0.115, 0.188, 0.034, 0.042, 0.142 ]
```