### PR TITLE
Fix vectors in functions2

### DIFF
--- a/src/revlanguage/functions/UserFunction.cpp
+++ b/src/revlanguage/functions/UserFunction.cpp
@@ -66,7 +66,7 @@ RevPtr<RevVariable> UserFunction::execute( void )
 RevPtr<RevVariable> UserFunction::executeCode( void )
 {
     // Create new evaluation frame with function base class execution environment as parent
-    auto function_frame = std::make_shared<Environment>( getEnvironment(), "UserFunctionEnvironment" );
+    auto function_frame = std::make_unique<Environment>( getEnvironment(), "UserFunctionEnvironment" );
     
     // Add the arguments to our environment
     for ( std::vector<Argument>::iterator it = args.begin(); it != args.end(); ++it )

--- a/src/revlanguage/functions/UserFunction.cpp
+++ b/src/revlanguage/functions/UserFunction.cpp
@@ -66,7 +66,7 @@ RevPtr<RevVariable> UserFunction::execute( void )
 RevPtr<RevVariable> UserFunction::executeCode( void )
 {
     // Create new evaluation frame with function base class execution environment as parent
-    Environment* function_frame = new Environment( getEnvironment(), "UserFunctionEnvironment" );
+    auto function_frame = std::make_shared<Environment>( getEnvironment(), "UserFunctionEnvironment" );
     
     // Add the arguments to our environment
     for ( std::vector<Argument>::iterator it = args.begin(); it != args.end(); ++it )

--- a/src/revlanguage/parser/SyntaxIndexOperation.cpp
+++ b/src/revlanguage/parser/SyntaxIndexOperation.cpp
@@ -162,18 +162,19 @@ RevPtr<RevVariable> SyntaxIndexOperation::evaluateLHSContent( Environment& env, 
                 {
                     std::string elementIdentifier = theParentVar->getName() + "[" + std::to_string(i) + "]";
                 
+                    // first ensure that the environment has a slot named `elementIdentifier`
                     if ( !env.existsVariable( elementIdentifier ) )
                     {
-                        // create a new slot
+                        // create a new variable for environment slot `elementIdentifier`
                         RevPtr<RevVariable> theElementVar = RevPtr<RevVariable>( new RevVariable( c->getElement(i-1) ) );
-                        env.addVariable(elementIdentifier,theElementVar);
+                        env.addVariable( elementIdentifier, theElementVar );
                         theElementVar->setName( elementIdentifier );
                     }
-                
-                    // get the slot and variable
+
+                    // then look up the element variable in the environment by its identifier
                     RevPtr<RevVariable> theElementVar  = env.getVariable( elementIdentifier );
                 
-                    // set this variable as a hidden variable so that it doesn't show in ls()
+                    // set the element variable as a hidden variable so that it doesn't show in ls()
                     theElementVar->setElementVariableState( true );
                     
                     theParentVar->addIndex( int(i) , theElementVar );
@@ -190,15 +191,16 @@ RevPtr<RevVariable> SyntaxIndexOperation::evaluateLHSContent( Environment& env, 
     int idx = (int)static_cast<Integer&>( indexVar->getRevObject() ).getValue();
     std::string identifier = theParentVar->getName() + "[" + std::to_string(idx) + "]";
 
-    if ( env.existsVariable( identifier ) == false )
+    // first ensure that we've got an entry with name `identifier` in the environment
+    if ( not env.existsVariable( identifier ) )
     {
-        // create a new slot
+        // create a new variable called `identifier` if the environment doesn't have one.
         RevPtr<RevVariable> the_var = RevPtr<RevVariable>( new RevVariable( NULL ) );
-        env.addVariable(identifier,the_var);
+        env.addVariable( identifier, the_var );
         the_var->setName( identifier );
     }
 
-    // get the slot and variable
+    // then look up the variable in the environment by its identifier
     RevPtr<RevVariable> the_var  = env.getVariable( identifier );
     
     // set this variable as an element variable; which is by default a hidden variable so that it doesn't show in ls()

--- a/src/revlanguage/parser/SyntaxIndexOperation.cpp
+++ b/src/revlanguage/parser/SyntaxIndexOperation.cpp
@@ -145,7 +145,15 @@ RevPtr<RevVariable> SyntaxIndexOperation::evaluateLHSContent( Environment& env, 
         Container* c = dynamic_cast<Container*>( &theParentObj );
         if ( c != NULL )
         {
-            if ( theParentObj.getDagNode()->isConstant() && c->allowsModificationToCompositeContainer() )
+            if ( theParentObj.getDagNode()->isConstant() == false )
+            {
+                throw RbException("We cannot create a composite container from a non-constant container");
+            }
+            else if ( c->allowsModificationToCompositeContainer() == false )
+            {
+                throw RbException("An object of type '" + theParentObj.getType() + "' does not allow transformation into a composite container.");
+            }
+            else
             {
                 // We need to set this to a vector variable before we call addIndex on it.
                 theParentVar->setToVectorVariable();
@@ -169,17 +177,6 @@ RevPtr<RevVariable> SyntaxIndexOperation::evaluateLHSContent( Environment& env, 
                     theElementVar->setElementVariableState( true );
                     
                     theParentVar->addIndex( int(i) , theElementVar );
-                }
-            }
-            else
-            {
-                if ( !theParentObj.getDagNode()->isConstant() )
-                {
-                    throw RbException("We cannot create a composite container from a non-constant container");
-                }
-                else if ( !c->allowsModificationToCompositeContainer() )
-                {
-                    throw RbException("An object of type '" + theParentObj.getType() + "' does not allow transformation into a composite container.");
                 }
             }
         }

--- a/src/revlanguage/workspace/RevVariable.cpp
+++ b/src/revlanguage/workspace/RevVariable.cpp
@@ -206,14 +206,11 @@ RevObject& RevVariable::getRevObject(void) const
 
         // @TODO: We might need a to check if this should be dynamic or not. (Sebastian)
         bool dynamic = true;
-        Function* func = Workspace::userWorkspace().getFunction("v", args, not dynamic).clone();
+        std::unique_ptr<Function> func( Workspace::userWorkspace().getFunction("v", args, not dynamic).clone() );
         func->processArguments(args, not dynamic);
         
         // Evaluate the function (call the static evaluation function)
         RevPtr<RevVariable> func_return_value = func->execute();
-        
-        // free the memory of our copy
-        delete func;
         
         const_cast<RevVariable*>(this)->replaceRevObject( func_return_value->getRevObject().clone() );
     }

--- a/src/revlanguage/workspace/RevVariable.cpp
+++ b/src/revlanguage/workspace/RevVariable.cpp
@@ -121,10 +121,12 @@ RevVariable& RevVariable::operator=(const RevVariable &v)
 
 
 /** Resize the vector to include this index. */
-void RevVariable::addIndex(size_t idx, const RevPtr<RevVariable>& element)
+void RevVariable::addIndex(int idx, const RevPtr<RevVariable>& element)
 {
     assert( isVectorVariable() );
-    assert( idx > 0);
+
+    if (idx < 1)
+        throw RbException()<<"Index "<<idx<<" not allowed in '"<<name<<"["<<idx<<"]'.  The first element should be '"<<name<<"[1]'";
 
     if (idx > vector_var_elements->size())
         vector_var_elements->resize(idx);

--- a/src/revlanguage/workspace/RevVariable.cpp
+++ b/src/revlanguage/workspace/RevVariable.cpp
@@ -198,6 +198,11 @@ RevObject& RevVariable::getRevObject(void) const
                 std::string element_identifier = name + "[" + std::to_string(i) + "]";
                 throw RbException()<<"Cannot create vector variable with name '"<<name
                                    <<"' because element with name '"<<element_identifier<<"' is NULL.";
+
+                /* NOTE: This scenario can occur if we define x[4] but not x[3] and then try to print x.
+                 *       When x[4] is defined, vector_var_elements is padded with nullptrs to length 4.
+                 *       But only x[4] is then set to a non-NULL value.
+                 */
             }
 
             args.push_back( Argument( element_var ) );

--- a/src/revlanguage/workspace/RevVariable.h
+++ b/src/revlanguage/workspace/RevVariable.h
@@ -50,9 +50,9 @@ namespace RevLanguage {
         RevVariable&            operator=(const RevVariable &v);                        //!< Assignment operator
 
         // Regular functions
-        void                    addIndex(size_t idx, const RevPtr<RevVariable>& elem);  //!< Resize the vector to include this index.
+        void                    addIndex(int idx, const RevPtr<RevVariable>& elem);     //!< Resize the vector to include this index.
         RevVariable*            clone(void) const;                                      //!< Clone variable
-        size_t                  getMaxElementIndex(void) const;                        //!< Get the set of element indices for this vector variable.
+        size_t                  getMaxElementIndex(void) const;                         //!< Get the set of element indices for this vector variable.
         const std::string&      getName(void) const;                                    //!< Get the name of the variable
         RevObject&              getRevObject(void) const;                               //!< Get the value of the variable (non-const to return non-const value)
         const TypeSpec&         getRequiredTypeSpec(void) const;                        //!< Get the required Rev object type spec

--- a/src/revlanguage/workspace/RevVariable.h
+++ b/src/revlanguage/workspace/RevVariable.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <set>
+#include <boost/optional.hpp>
 
 namespace RevLanguage {
     
@@ -77,20 +78,20 @@ namespace RevLanguage {
         void                    incrementReferenceCount(void) const;                    //!< Increment the reference count for reference counting in smart pointers
         
     private:
-        
         // Member variables
-        size_t                  element_index_max;                                      //!< The maximum element index
-        mutable bool            needs_building;
-//        std::set<int>           element_indices;                                        //!< The indices of the elements if this is a vector variable.
-        bool                    is_element_var;                                         //!< Is this variable an element of a vector?
-        bool                    is_hidden_var;                                          //!< Is this a hidden variable?
-        bool                    is_reference_var;                                       //!< Is this a reference variable?
-        bool                    is_vector_var;                                          //!< Is this a vector variable?
-        bool                    is_workspace_var;                                       //!< Is this a workspace variable?
+
+        // variables related to building the components of a vector
+        bool                    is_vector_var = false;                                  //!< Is this a vector variable?
+        size_t                  element_index_max = 0;                                  //!< The maximum element index
+        mutable bool            needs_building = false;                                 //!< Do we need to construct the revobject?
+
+        bool                    is_element_var = false;                                 //!< Is this variable an element of a vector?
+        bool                    is_hidden_var = false;                                  //!< Is this a hidden variable?
+        bool                    is_workspace_var = false;                               //!< Is this a workspace variable?
         std::string             name;                                                   //!< Name of variable
-        mutable size_t          ref_count;                                              //!< Reference count used by RevPtr
-        RevPtr<RevVariable>     referenced_variable;                                    //!< Smart pointer to referenced variable
-        RevObject*              rev_object;                                             //!< Pointer to the Rev object inside the variable
+        mutable size_t          ref_count = 0;                                          //!< Reference count used by RevPtr
+        RevPtr<RevVariable>     referenced_variable = nullptr;                          //!< Smart pointer to referenced variable
+        RevObject*              rev_object = nullptr;                                   //!< Pointer to the Rev object inside the variable
         TypeSpec                required_type_spec;                                     //!< Required type of the object
     };
     

--- a/src/revlanguage/workspace/RevVariable.h
+++ b/src/revlanguage/workspace/RevVariable.h
@@ -50,7 +50,7 @@ namespace RevLanguage {
         RevVariable&            operator=(const RevVariable &v);                        //!< Assignment operator
 
         // Regular functions
-        void                    addIndex(size_t idx);                                      //!< Resize the vector to include this index.
+        void                    addIndex(size_t idx, const RevPtr<RevVariable>& elem);  //!< Resize the vector to include this index.
         RevVariable*            clone(void) const;                                      //!< Clone variable
         size_t                  getMaxElementIndex(void) const;                        //!< Get the set of element indices for this vector variable.
         const std::string&      getName(void) const;                                    //!< Get the name of the variable
@@ -66,7 +66,7 @@ namespace RevLanguage {
         void                    printValue(std::ostream& o, bool toScreen) const;       //!< Print value of variable
         void                    setElementVariableState(bool flag = true);              //!< Set (or unset) element variable status
         void                    setHiddenVariableState(bool flag = true);               //!< Set (or unset) hidden variable status
-        void                    setVectorVariableState(bool flag = true);               //!< Set (or unset) vector variable status
+        void                    setToVectorVariable();                                  //!< Set (or unset) vector variable status
         void                    setWorkspaceVariableState(bool flag = true);            //!< Set (or unset) control variable status
         void                    setName(const std::string &n);                          //!< Set the name of this variable
         void                    replaceRevObject(RevObject *newObj);                    //!< Replace the Rev object of this variable
@@ -81,9 +81,8 @@ namespace RevLanguage {
         // Member variables
 
         // variables related to building the components of a vector
-        bool                    is_vector_var = false;                                  //!< Is this a vector variable?
-        size_t                  element_index_max = 0;                                  //!< The maximum element index
-        mutable bool            needs_building = false;                                 //!< Do we need to construct the revobject?
+        boost::optional<std::vector<RevPtr<RevVariable>>> vector_var_elements;          //!< Elements if this is a vector variable.
+        bool                    needs_building = false;                                 //!< Do we need to construct the revobject?
 
         bool                    is_element_var = false;                                 //!< Is this variable an element of a vector?
         bool                    is_hidden_var = false;                                  //!< Is this a hidden variable?


### PR DESCRIPTION
Currently, you can define functions in Rev.  For example:

```
function sampleDirichlet(n, alpha)
{
  for(i in 1:n)
  {
     x[i] ~ dnGamma(alpha, 1.0)
  }
  return x/sum(x)
}
```

However, this function fails with the message:
```
> sampleDirichlet(10,2)
   Missing Variable:	Variable x[1] does not exist
```

The reason is that
*  each function has its own Environment that maps names to objects.  In this case, the function Environment includes the names `n`, `alpha`, `x`, `x[1]`, `x[2]`, ... etc.
* when we create vectors like `x`, RevBayes does not immediately lookup and record the RevVariable for each of the elements of `x`.
Instead, RevBayes sets the flag `needs_building` and defers construction of the vector until getRevObject( ) is called for `x`.
* when building the vector, RevBayes needs to look up the names `x[1]`, `x[2]`, etc. and then call the function `v( )` on the resulting list of variables.  However, we need to look these names up in the function environment, but RevBayes was using the global user workspace environment:
```
    // @TODO: We actually might need a different workspace here than the user workspace. (Sebastian)
    //        Environment &env = Workspace::userWorkspace();
```

This patch looks up element names like `x[1]` in the environment immediately and records their corresponding variable, instead of doing deferred lookup.  This ensures that we look up the element names in the right environment. 

In more detail, the patch:
* modifies RevVariable to remember the `RevPtr<RevVariable>` for each vector index, if the variable is a vector.
* modifies SyntaxIndexOperation to pass the `RevPtr<RevVariable>` for an index when we call `RevVariable::addIndex`.
* also refactors constructors for RevVariable, and removes the redundant field `is_reference_var`

With this patch, `sampleDirichlet(10,2)` works:
```
> function sampleDirichlet(n, alpha)
+ {
+   for(i in 1:n)
+   {
+      x[i] ~ dnGamma(alpha, 1.0)
+   }
+   return x/sum(x)
+ }
> sampleDirichlet(10,2)
   [ 0.148, 0.091, 0.090, 0.094, 0.055, 0.115, 0.188, 0.034, 0.042, 0.142 ]
```