### PR TITLE
Fix compatibility with C++17

### DIFF
--- a/src/core/distributions/phylogenetics/tree/birthdeath/SampledSpeciationBirthDeathProcess.cpp
+++ b/src/core/distributions/phylogenetics/tree/birthdeath/SampledSpeciationBirthDeathProcess.cpp
@@ -629,7 +629,8 @@ void SampledSpeciationBirthDeathProcess::simulateTree( void )
             std::vector<size_t> taxon_idx;
             for (size_t i = 0; i < taxa.size(); i++)
                 taxon_idx.push_back(i);
-            std::random_shuffle(taxon_idx.begin(), taxon_idx.end());
+
+            deprecated::random_shuffle(taxon_idx.begin(), taxon_idx.end());
             
             // Set names for terminal taxa
             for (size_t i = 0; i < taxa.size(); i++)

--- a/src/core/functions/phylogenetics/cladogenetic/DECCladogeneticStateFunction.cpp
+++ b/src/core/functions/phylogenetics/cladogenetic/DECCladogeneticStateFunction.cpp
@@ -817,7 +817,7 @@ std::string DECCladogeneticStateFunction::simulateDataAugmentedCladogeneticState
         if (event_type == "s")
         {
             // choose the area inherited by the right node
-            std::random_shuffle( node_child_on.begin(), node_child_on.end() );
+            deprecated::random_shuffle( node_child_on.begin(), node_child_on.end());
             size_t area_idx = node_child_on[0];
             
             if (GLOBAL_RNG->uniform01() < 0.5)
@@ -848,7 +848,7 @@ std::string DECCladogeneticStateFunction::simulateDataAugmentedCladogeneticState
         else if (event_type == "a")
         {
             // choose the area inherited by the right node
-            std::random_shuffle( node_child_on.begin(), node_child_on.end() );
+            deprecated::random_shuffle( node_child_on.begin(), node_child_on.end());
             size_t area_left_idx = node_child_on[0];
             size_t area_right_idx = node_child_on[1];
             
@@ -874,7 +874,7 @@ std::string DECCladogeneticStateFunction::simulateDataAugmentedCladogeneticState
         else if (event_type == "j")
         {
             // choose the area inherited by the right node
-            std::random_shuffle( node_child_off.begin(), node_child_off.end() );
+            deprecated::random_shuffle( node_child_off.begin(), node_child_off.end());
             size_t area_idx = node_child_off[0];
             
             if (GLOBAL_RNG->uniform01() < 0.5)

--- a/src/core/math/RandomNumberGenerator.h
+++ b/src/core/math/RandomNumberGenerator.h
@@ -25,8 +25,26 @@ namespace RevBayesCore {
         unsigned int seed;
 
     };
-    
 }
+
+namespace deprecated
+{
+    template< class RandomIt >
+    void random_shuffle( RandomIt first, RandomIt last )
+    {
+        typename std::iterator_traits<RandomIt>::difference_type i, n;
+        n = last - first;
+        for (i = n-1; i > 0; --i) {
+            using std::swap;
+            swap(first[i], first[std::rand() % (i+1)]);
+            // rand() % (i+1) isn't actually correct, because the generated number
+            // is not uniformly distributed for most values of i. A correct implementation
+            // will need to essentially reimplement C++11 std::uniform_int_distribution,
+            // which is beyond the scope of this example.
+        }
+    }
+}
+
 
 #endif
 

--- a/src/core/moves/characterhistory/BiogeographyCladogeneticRejectionShiftProposal.h
+++ b/src/core/moves/characterhistory/BiogeographyCladogeneticRejectionShiftProposal.h
@@ -1263,7 +1263,7 @@ double RevBayesCore::BiogeographicCladogeneticRejectionShiftProposal<charType>::
 
         // get random set of characters to contract (remove)
 //        std::vector<size_t> contractCharacters( sampledCharacters.begin(), sampledCharacters.end() );
-        std::random_shuffle( contractCharacters.begin(), contractCharacters.end() );
+        deprecated::random_shuffle( contractCharacters.begin(), contractCharacters.end());
         
         // remove areas in contractCharacters
         for (size_t i = 0; i < contractCharacters.size(); i++) {
@@ -1276,7 +1276,7 @@ double RevBayesCore::BiogeographicCladogeneticRejectionShiftProposal<charType>::
         // if we are losing the last character
         if ( onCharacters.size() == 2 ) {
             
-//            std::random_shuffle( onCharacters.begin(), onCharacters.end() );
+//            deprecated::random_shuffle( onCharacters.begin(), onCharacters.end());
             
             size_t site_index = contractCharacters[0];
             static_cast<CharacterEventDiscrete*>( nodeChildState[site_index] )->setState( 1 );
@@ -1293,7 +1293,7 @@ double RevBayesCore::BiogeographicCladogeneticRejectionShiftProposal<charType>::
 //         Sample cladogenetic states for trunk
         // get random set of characters to contract (remove)
 //        std::vector<size_t> expandCharacters( sampledCharacters.begin(), sampledCharacters.end() );
-        std::random_shuffle( expandCharacters.begin(), expandCharacters.end() );
+        deprecated::random_shuffle( expandCharacters.begin(), expandCharacters.end());
         
         std::set<size_t>::iterator it_s;
         for (size_t i = 0; i < expandCharacters.size(); i++)
@@ -1706,7 +1706,7 @@ void RevBayesCore::BiogeographicCladogeneticRejectionShiftProposal<charType>::se
     else if (onCharacters.size() == 2) {
         swapCharacters.push_back( onCharacters[0] );
         swapCharacters.push_back( onCharacters[1] );
-        std::random_shuffle( swapCharacters.begin(), swapCharacters.end() );
+        deprecated::random_shuffle( swapCharacters.begin(), swapCharacters.end());
         return;
     }
     
@@ -1744,8 +1744,8 @@ void RevBayesCore::BiogeographicCladogeneticRejectionShiftProposal<charType>::se
     size_t s_left = 0;
     size_t s_right = 0;
     do {
-        std::random_shuffle( leftCharacters.begin(), leftCharacters.end() );
-        std::random_shuffle( rightCharacters.begin(), rightCharacters.end() );
+        deprecated::random_shuffle( leftCharacters.begin(), leftCharacters.end());
+        deprecated::random_shuffle( rightCharacters.begin(), rightCharacters.end());
         
         s_left = leftCharacters[0];
         s_right = rightCharacters[0];
@@ -1754,7 +1754,7 @@ void RevBayesCore::BiogeographicCladogeneticRejectionShiftProposal<charType>::se
     
     swapCharacters.push_back( s_left );
     swapCharacters.push_back( s_right );
-    std::random_shuffle( swapCharacters.begin(), swapCharacters.end() );
+    deprecated::random_shuffle( swapCharacters.begin(), swapCharacters.end());
     
     return;
 }

--- a/src/core/moves/characterhistory/BiogeographyNodeRejectionSampleProposal.h
+++ b/src/core/moves/characterhistory/BiogeographyNodeRejectionSampleProposal.h
@@ -955,7 +955,7 @@ double RevBayesCore::BiogeographicNodeRejectionSampleProposal<charType>::sampleC
     else if (clado_type == "allopatry")
     {
         // sample how left/right characters will be divided
-        std::random_shuffle(idx_on.begin(), idx_on.end());
+        deprecated::random_shuffle(idx_on.begin(), idx_on.end());
         int n_child1_on = (int)(GLOBAL_RNG->uniform01() * (idx_on.size()-1) ) + 1;
         
         // set the left/right child states

--- a/src/core/moves/characterhistory/BiogeographyNodeRejectionShiftProposal.h
+++ b/src/core/moves/characterhistory/BiogeographyNodeRejectionShiftProposal.h
@@ -1046,7 +1046,7 @@ double RevBayesCore::BiogeographicNodeRejectionShiftProposal<charType>::sampleCl
             ; // do nothing
         } else {
             // sample how left/right characters will be divided
-            std::random_shuffle(idx_on.begin(), idx_on.end());
+            deprecated::random_shuffle(idx_on.begin(), idx_on.end());
             int n_child1_on = (int)(GLOBAL_RNG->uniform01() * (idx_on.size()-1) ) + 1;
             
             // set the left/right child states

--- a/src/revlanguage/parser/Parser.cpp
+++ b/src/revlanguage/parser/Parser.cpp
@@ -678,7 +678,7 @@ ParserInfo Parser::checkCommand(std::string& command, Environment* env)
 }
 
 /** Global call-back function for the flex-generated code in lex.yy.cpp */
-void rrinput(char* buf, size_t& result, size_t maxsize) {
+void rrinput(char* buf, int& result, size_t maxsize) {
 
     buf[0] = '\0';
     RevLanguage::Parser::getParser().getline(buf, maxsize);

--- a/src/revlanguage/parser/Parser.h
+++ b/src/revlanguage/parser/Parser.h
@@ -139,7 +139,7 @@ namespace RevLanguage {
 }
 
 // Global call-back function for flex-generated code
-void rrinput(char* buf, size_t& result, size_t maxsize);
+void rrinput(char* buf, int& result, size_t maxsize);
 
 // Global command buffer string stream for rrinput
 extern std::stringstream rrcommand;
@@ -151,6 +151,6 @@ extern bool foundEOF;
 
 // Global column and token length variables for flex
 extern size_t yycolumn;
-extern size_t yyleng;
+extern int    yyleng;
 
 #endif

--- a/src/revlanguage/parser/grammar.tab.cpp
+++ b/src/revlanguage/parser/grammar.tab.cpp
@@ -1,14 +1,14 @@
-/* A Bison parser, made by GNU Bison 2.3.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
-/* Skeleton implementation for Bison's Yacc-like parsers in C
+/* Bison implementation for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989, 1990, 2000, 2001, 2002, 2003, 2004, 2005, 2006
-   Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
+   Inc.
 
-   This program is free software; you can redistribute it and/or modify
+   This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2, or (at your option)
-   any later version.
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
 
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -16,9 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin Street, Fifth Floor,
-   Boston, MA 02110-1301, USA.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -36,6 +34,10 @@
 /* C LALR(1) parser skeleton written by Richard Stallman, by
    simplifying the original so-called "semantic" parser.  */
 
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
+
 /* All symbols defined below should begin with yy or YY, to avoid
    infringing on user name space.  This should be done even for local
    variables, as they might otherwise be expanded by user macros.
@@ -43,11 +45,11 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
-/* Identify Bison output.  */
-#define YYBISON 1
+/* Identify Bison output, and Bison version.  */
+#define YYBISON 30802
 
-/* Bison version.  */
-#define YYBISON_VERSION "2.3"
+/* Bison version string.  */
+#define YYBISON_VERSION "3.8.2"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -55,129 +57,16 @@
 /* Pure parsers.  */
 #define YYPURE 0
 
-/* Using locations.  */
-#define YYLSP_NEEDED 1
+/* Push parsers.  */
+#define YYPUSH 0
 
-
-
-/* Tokens.  */
-#ifndef YYTOKENTYPE
-# define YYTOKENTYPE
-   /* Put the tokens into the symbol table, so that GDB and other debuggers
-      know about them.  */
-   enum yytokentype {
-     REAL = 258,
-     INT = 259,
-     NAME = 260,
-     STRING = 261,
-     RBNULL = 262,
-     RBTAB = 263,
-     FALSE = 264,
-     TRUE = 265,
-     RBINF = 266,
-     FUNCTION = 267,
-     PROCEDURE = 268,
-     CLASS = 269,
-     FOR = 270,
-     IN = 271,
-     IF = 272,
-     ELSE = 273,
-     WHILE = 274,
-     NEXT = 275,
-     BREAK = 276,
-     RETURN = 277,
-     MOD_CONST = 278,
-     MOD_DYNAMIC = 279,
-     MOD_STOCHASTIC = 280,
-     MOD_DETERMINISTIC = 281,
-     PROTECTED = 282,
-     ARROW_ASSIGN = 283,
-     TILDE_ASSIGN = 284,
-     EQUATION_ASSIGN = 285,
-     WORKSPACE_ASSIGN = 286,
-     REFERENCE_ASSIGN = 287,
-     ADDITION_ASSIGN = 288,
-     SUBTRACTION_ASSIGN = 289,
-     MULTIPLICATION_ASSIGN = 290,
-     DIVISION_ASSIGN = 291,
-     DECREMENT = 292,
-     INCREMENT = 293,
-     EQUAL = 294,
-     AND = 295,
-     OR = 296,
-     AND2 = 297,
-     OR2 = 298,
-     GT = 299,
-     GE = 300,
-     LT = 301,
-     LE = 302,
-     EQ = 303,
-     NE = 304,
-     END_OF_INPUT = 305,
-     UNOT = 306,
-     UPLUS = 307,
-     UMINUS = 308,
-     UAND = 309
-   };
-#endif
-/* Tokens.  */
-#define REAL 258
-#define INT 259
-#define NAME 260
-#define STRING 261
-#define RBNULL 262
-#define RBTAB 263
-#define FALSE 264
-#define TRUE 265
-#define RBINF 266
-#define FUNCTION 267
-#define PROCEDURE 268
-#define CLASS 269
-#define FOR 270
-#define IN 271
-#define IF 272
-#define ELSE 273
-#define WHILE 274
-#define NEXT 275
-#define BREAK 276
-#define RETURN 277
-#define MOD_CONST 278
-#define MOD_DYNAMIC 279
-#define MOD_STOCHASTIC 280
-#define MOD_DETERMINISTIC 281
-#define PROTECTED 282
-#define ARROW_ASSIGN 283
-#define TILDE_ASSIGN 284
-#define EQUATION_ASSIGN 285
-#define WORKSPACE_ASSIGN 286
-#define REFERENCE_ASSIGN 287
-#define ADDITION_ASSIGN 288
-#define SUBTRACTION_ASSIGN 289
-#define MULTIPLICATION_ASSIGN 290
-#define DIVISION_ASSIGN 291
-#define DECREMENT 292
-#define INCREMENT 293
-#define EQUAL 294
-#define AND 295
-#define OR 296
-#define AND2 297
-#define OR2 298
-#define GT 299
-#define GE 300
-#define LT 301
-#define LE 302
-#define EQ 303
-#define NE 304
-#define END_OF_INPUT 305
-#define UNOT 306
-#define UPLUS 307
-#define UMINUS 308
-#define UAND 309
+/* Pull parsers.  */
+#define YYPULL 1
 
 
 
 
-/* Copy the first part of user declarations.  */
+/* First part of user prologue.  */
 #line 1 "./grammar.y"
 
 /**
@@ -200,11 +89,8 @@
 
 /* The following statements go into the resulting C code */
 
-#include <iostream>
-#include <list>
-
+#include "Environment.h"
 #include "Integer.h"
-#include "IntegerPos.h"
 #include "Natural.h"
 #include "Probability.h"
 #include "Parser.h"
@@ -237,10 +123,12 @@
 #include "SyntaxVariableDecl.h"
 #include "SyntaxVariable.h"
 #include "SyntaxWorkspaceVariableAssignment.h"
-#include "RbConstants.h"
-#include "RevPtr.h"
+#include "Workspace.h"
 
-namespace RevLanguage { class Environment; }
+#include <iostream>
+#include <list>
+#include <sstream>
+#include <string>
 
 using namespace RevLanguage;
 
@@ -257,100 +145,247 @@ Parser& parser = Parser::getParser();
 
 #define YY_NEVER_INTERACTIVE
 
+#line 149 "./grammar.tab.c"
 
-/* Enabling traces.  */
-#ifndef YYDEBUG
-# define YYDEBUG 0
-#endif
+# ifndef YY_CAST
+#  ifdef __cplusplus
+#   define YY_CAST(Type, Val) static_cast<Type> (Val)
+#   define YY_REINTERPRET_CAST(Type, Val) reinterpret_cast<Type> (Val)
+#  else
+#   define YY_CAST(Type, Val) ((Type) (Val))
+#   define YY_REINTERPRET_CAST(Type, Val) ((Type) (Val))
+#  endif
+# endif
+# ifndef YY_NULLPTR
+#  if defined __cplusplus
+#   if 201103L <= __cplusplus
+#    define YY_NULLPTR nullptr
+#   else
+#    define YY_NULLPTR 0
+#   endif
+#  else
+#   define YY_NULLPTR ((void*)0)
+#  endif
+# endif
 
-/* Enabling verbose error messages.  */
-#ifdef YYERROR_VERBOSE
-# undef YYERROR_VERBOSE
-# define YYERROR_VERBOSE 1
-#else
-# define YYERROR_VERBOSE 0
-#endif
-
-/* Enabling the token table.  */
-#ifndef YYTOKEN_TABLE
-# define YYTOKEN_TABLE 0
-#endif
-
-#if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
-typedef union YYSTYPE
-#line 80 "./grammar.y"
+#include "grammar.tab.h"
+/* Symbol kind.  */
+enum yysymbol_kind_t
 {
-    char*                                           c_string;
-    std::string*                                    string;
-    double                                          realValue;
-    long                                            longIntValue;
-    bool                                            boolValue;
-    RevLanguage::SyntaxElement*                     syntaxElement;
-    RevLanguage::SyntaxVariable*                    syntaxVariable;
-    RevLanguage::SyntaxFunctionCall*                syntaxFunctionCall;
-    RevLanguage::SyntaxLabeledExpr*                 syntaxLabeledExpr;
-    RevLanguage::SyntaxFormal*                      syntaxFormal;
-    std::list<RevLanguage::SyntaxElement*>*         syntaxElementList;
-    std::list<RevLanguage::SyntaxLabeledExpr*>*     argumentList;
-    std::list<RevLanguage::SyntaxFormal*>*          formalList;
-}
-/* Line 193 of yacc.c.  */
-#line 298 "./grammar.tab.c"
-	YYSTYPE;
-# define yystype YYSTYPE /* obsolescent; will be withdrawn */
-# define YYSTYPE_IS_DECLARED 1
-# define YYSTYPE_IS_TRIVIAL 1
-#endif
+  YYSYMBOL_YYEMPTY = -2,
+  YYSYMBOL_YYEOF = 0,                      /* "end of file"  */
+  YYSYMBOL_YYerror = 1,                    /* error  */
+  YYSYMBOL_YYUNDEF = 2,                    /* "invalid token"  */
+  YYSYMBOL_REAL = 3,                       /* REAL  */
+  YYSYMBOL_INT = 4,                        /* INT  */
+  YYSYMBOL_NAME = 5,                       /* NAME  */
+  YYSYMBOL_STRING = 6,                     /* STRING  */
+  YYSYMBOL_RBNULL = 7,                     /* RBNULL  */
+  YYSYMBOL_RBTAB = 8,                      /* RBTAB  */
+  YYSYMBOL_FALSE = 9,                      /* FALSE  */
+  YYSYMBOL_TRUE = 10,                      /* TRUE  */
+  YYSYMBOL_RBINF = 11,                     /* RBINF  */
+  YYSYMBOL_FUNCTION = 12,                  /* FUNCTION  */
+  YYSYMBOL_PROCEDURE = 13,                 /* PROCEDURE  */
+  YYSYMBOL_CLASS = 14,                     /* CLASS  */
+  YYSYMBOL_FOR = 15,                       /* FOR  */
+  YYSYMBOL_IN = 16,                        /* IN  */
+  YYSYMBOL_IF = 17,                        /* IF  */
+  YYSYMBOL_ELSE = 18,                      /* ELSE  */
+  YYSYMBOL_WHILE = 19,                     /* WHILE  */
+  YYSYMBOL_NEXT = 20,                      /* NEXT  */
+  YYSYMBOL_BREAK = 21,                     /* BREAK  */
+  YYSYMBOL_RETURN = 22,                    /* RETURN  */
+  YYSYMBOL_MOD_CONST = 23,                 /* MOD_CONST  */
+  YYSYMBOL_MOD_DYNAMIC = 24,               /* MOD_DYNAMIC  */
+  YYSYMBOL_MOD_STOCHASTIC = 25,            /* MOD_STOCHASTIC  */
+  YYSYMBOL_MOD_DETERMINISTIC = 26,         /* MOD_DETERMINISTIC  */
+  YYSYMBOL_PROTECTED = 27,                 /* PROTECTED  */
+  YYSYMBOL_ARROW_ASSIGN = 28,              /* ARROW_ASSIGN  */
+  YYSYMBOL_TILDE_ASSIGN = 29,              /* TILDE_ASSIGN  */
+  YYSYMBOL_EQUATION_ASSIGN = 30,           /* EQUATION_ASSIGN  */
+  YYSYMBOL_WORKSPACE_ASSIGN = 31,          /* WORKSPACE_ASSIGN  */
+  YYSYMBOL_REFERENCE_ASSIGN = 32,          /* REFERENCE_ASSIGN  */
+  YYSYMBOL_ADDITION_ASSIGN = 33,           /* ADDITION_ASSIGN  */
+  YYSYMBOL_SUBTRACTION_ASSIGN = 34,        /* SUBTRACTION_ASSIGN  */
+  YYSYMBOL_MULTIPLICATION_ASSIGN = 35,     /* MULTIPLICATION_ASSIGN  */
+  YYSYMBOL_DIVISION_ASSIGN = 36,           /* DIVISION_ASSIGN  */
+  YYSYMBOL_DECREMENT = 37,                 /* DECREMENT  */
+  YYSYMBOL_INCREMENT = 38,                 /* INCREMENT  */
+  YYSYMBOL_EQUAL = 39,                     /* EQUAL  */
+  YYSYMBOL_AND = 40,                       /* AND  */
+  YYSYMBOL_OR = 41,                        /* OR  */
+  YYSYMBOL_AND2 = 42,                      /* AND2  */
+  YYSYMBOL_OR2 = 43,                       /* OR2  */
+  YYSYMBOL_GT = 44,                        /* GT  */
+  YYSYMBOL_GE = 45,                        /* GE  */
+  YYSYMBOL_LT = 46,                        /* LT  */
+  YYSYMBOL_LE = 47,                        /* LE  */
+  YYSYMBOL_EQ = 48,                        /* EQ  */
+  YYSYMBOL_NE = 49,                        /* NE  */
+  YYSYMBOL_END_OF_INPUT = 50,              /* END_OF_INPUT  */
+  YYSYMBOL_51_ = 51,                       /* '?'  */
+  YYSYMBOL_UNOT = 52,                      /* UNOT  */
+  YYSYMBOL_53_ = 53,                       /* '+'  */
+  YYSYMBOL_54_ = 54,                       /* '-'  */
+  YYSYMBOL_55_ = 55,                       /* '*'  */
+  YYSYMBOL_56_ = 56,                       /* '/'  */
+  YYSYMBOL_57_ = 57,                       /* ':'  */
+  YYSYMBOL_58_ = 58,                       /* '%'  */
+  YYSYMBOL_UMINUS = 59,                    /* UMINUS  */
+  YYSYMBOL_UPLUS = 60,                     /* UPLUS  */
+  YYSYMBOL_61_ = 61,                       /* '^'  */
+  YYSYMBOL_62_ = 62,                       /* '.'  */
+  YYSYMBOL_UAND = 63,                      /* UAND  */
+  YYSYMBOL_64_ = 64,                       /* '('  */
+  YYSYMBOL_65_ = 65,                       /* '['  */
+  YYSYMBOL_66_n_ = 66,                     /* '\n'  */
+  YYSYMBOL_67_ = 67,                       /* ';'  */
+  YYSYMBOL_68_ = 68,                       /* ')'  */
+  YYSYMBOL_69_ = 69,                       /* '!'  */
+  YYSYMBOL_70_ = 70,                       /* ']'  */
+  YYSYMBOL_71_ = 71,                       /* ','  */
+  YYSYMBOL_72_ = 72,                       /* '{'  */
+  YYSYMBOL_73_ = 73,                       /* '}'  */
+  YYSYMBOL_YYACCEPT = 74,                  /* $accept  */
+  YYSYMBOL_prog = 75,                      /* prog  */
+  YYSYMBOL_expression = 76,                /* expression  */
+  YYSYMBOL_arrowAssign = 77,               /* arrowAssign  */
+  YYSYMBOL_tildeAssign = 78,               /* tildeAssign  */
+  YYSYMBOL_equationAssign = 79,            /* equationAssign  */
+  YYSYMBOL_workspaceAssign = 80,           /* workspaceAssign  */
+  YYSYMBOL_referenceAssign = 81,           /* referenceAssign  */
+  YYSYMBOL_additionAssign = 82,            /* additionAssign  */
+  YYSYMBOL_subtractionAssign = 83,         /* subtractionAssign  */
+  YYSYMBOL_multiplicationAssign = 84,      /* multiplicationAssign  */
+  YYSYMBOL_divisionAssign = 85,            /* divisionAssign  */
+  YYSYMBOL_variable = 86,                  /* variable  */
+  YYSYMBOL_optElements = 87,               /* optElements  */
+  YYSYMBOL_elementList = 88,               /* elementList  */
+  YYSYMBOL_fxnCall = 89,                   /* fxnCall  */
+  YYSYMBOL_functionCall = 90,              /* functionCall  */
+  YYSYMBOL_optArguments = 91,              /* optArguments  */
+  YYSYMBOL_argumentList = 92,              /* argumentList  */
+  YYSYMBOL_argument = 93,                  /* argument  */
+  YYSYMBOL_functionDef = 94,               /* functionDef  */
+  YYSYMBOL_procedureDef = 95,              /* procedureDef  */
+  YYSYMBOL_optFormals = 96,                /* optFormals  */
+  YYSYMBOL_formalList = 97,                /* formalList  */
+  YYSYMBOL_formal = 98,                    /* formal  */
+  YYSYMBOL_typeSpec = 99,                  /* typeSpec  */
+  YYSYMBOL_optDims = 100,                  /* optDims  */
+  YYSYMBOL_dimList = 101,                  /* dimList  */
+  YYSYMBOL_stmts = 102,                    /* stmts  */
+  YYSYMBOL_stmtList = 103,                 /* stmtList  */
+  YYSYMBOL_statement = 104,                /* statement  */
+  YYSYMBOL_stmt_or_expr = 105,             /* stmt_or_expr  */
+  YYSYMBOL_declaration = 106,              /* declaration  */
+  YYSYMBOL_memberDefs = 107,               /* memberDefs  */
+  YYSYMBOL_memberDef = 108,                /* memberDef  */
+  YYSYMBOL_classDef = 109,                 /* classDef  */
+  YYSYMBOL_ifStatement = 110,              /* ifStatement  */
+  YYSYMBOL_cond = 111,                     /* cond  */
+  YYSYMBOL_forStatement = 112,             /* forStatement  */
+  YYSYMBOL_forCond = 113,                  /* forCond  */
+  YYSYMBOL_whileStatement = 114,           /* whileStatement  */
+  YYSYMBOL_nextStatement = 115,            /* nextStatement  */
+  YYSYMBOL_breakStatement = 116,           /* breakStatement  */
+  YYSYMBOL_returnStatement = 117,          /* returnStatement  */
+  YYSYMBOL_identifier = 118,               /* identifier  */
+  YYSYMBOL_vector = 119,                   /* vector  */
+  YYSYMBOL_vectorList = 120,               /* vectorList  */
+  YYSYMBOL_constant = 121                  /* constant  */
+};
+typedef enum yysymbol_kind_t yysymbol_kind_t;
 
-#if ! defined YYLTYPE && ! defined YYLTYPE_IS_DECLARED
-typedef struct YYLTYPE
-{
-  int first_line;
-  int first_column;
-  int last_line;
-  int last_column;
-} YYLTYPE;
-# define yyltype YYLTYPE /* obsolescent; will be withdrawn */
-# define YYLTYPE_IS_DECLARED 1
-# define YYLTYPE_IS_TRIVIAL 1
-#endif
 
 
-/* Copy the second part of user declarations.  */
-
-
-/* Line 216 of yacc.c.  */
-#line 323 "./grammar.tab.c"
 
 #ifdef short
 # undef short
 #endif
 
-#ifdef YYTYPE_UINT8
-typedef YYTYPE_UINT8 yytype_uint8;
-#else
-typedef unsigned char yytype_uint8;
+/* On compilers that do not define __PTRDIFF_MAX__ etc., make sure
+   <limits.h> and (if available) <stdint.h> are included
+   so that the code can choose integer types of a good width.  */
+
+#ifndef __PTRDIFF_MAX__
+# include <limits.h> /* INFRINGES ON USER NAME SPACE */
+# if defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
+#  include <stdint.h> /* INFRINGES ON USER NAME SPACE */
+#  define YY_STDINT_H
+# endif
 #endif
 
-#ifdef YYTYPE_INT8
-typedef YYTYPE_INT8 yytype_int8;
-#elif (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+/* Narrow types that promote to a signed type and that can represent a
+   signed or unsigned integer of at least N bits.  In tables they can
+   save space and decrease cache pressure.  Promoting to a signed type
+   helps avoid bugs in integer arithmetic.  */
+
+#ifdef __INT_LEAST8_MAX__
+typedef __INT_LEAST8_TYPE__ yytype_int8;
+#elif defined YY_STDINT_H
+typedef int_least8_t yytype_int8;
+#else
 typedef signed char yytype_int8;
-#else
-typedef short int yytype_int8;
 #endif
 
-#ifdef YYTYPE_UINT16
-typedef YYTYPE_UINT16 yytype_uint16;
+#ifdef __INT_LEAST16_MAX__
+typedef __INT_LEAST16_TYPE__ yytype_int16;
+#elif defined YY_STDINT_H
+typedef int_least16_t yytype_int16;
 #else
-typedef unsigned short int yytype_uint16;
+typedef short yytype_int16;
 #endif
 
-#ifdef YYTYPE_INT16
-typedef YYTYPE_INT16 yytype_int16;
+/* Work around bug in HP-UX 11.23, which defines these macros
+   incorrectly for preprocessor constants.  This workaround can likely
+   be removed in 2023, as HPE has promised support for HP-UX 11.23
+   (aka HP-UX 11i v2) only through the end of 2022; see Table 2 of
+   <https://h20195.www2.hpe.com/V2/getpdf.aspx/4AA4-7673ENW.pdf>.  */
+#ifdef __hpux
+# undef UINT_LEAST8_MAX
+# undef UINT_LEAST16_MAX
+# define UINT_LEAST8_MAX 255
+# define UINT_LEAST16_MAX 65535
+#endif
+
+#if defined __UINT_LEAST8_MAX__ && __UINT_LEAST8_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST8_TYPE__ yytype_uint8;
+#elif (!defined __UINT_LEAST8_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST8_MAX <= INT_MAX)
+typedef uint_least8_t yytype_uint8;
+#elif !defined __UINT_LEAST8_MAX__ && UCHAR_MAX <= INT_MAX
+typedef unsigned char yytype_uint8;
 #else
-typedef short int yytype_int16;
+typedef short yytype_uint8;
+#endif
+
+#if defined __UINT_LEAST16_MAX__ && __UINT_LEAST16_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST16_TYPE__ yytype_uint16;
+#elif (!defined __UINT_LEAST16_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST16_MAX <= INT_MAX)
+typedef uint_least16_t yytype_uint16;
+#elif !defined __UINT_LEAST16_MAX__ && USHRT_MAX <= INT_MAX
+typedef unsigned short yytype_uint16;
+#else
+typedef int yytype_uint16;
+#endif
+
+#ifndef YYPTRDIFF_T
+# if defined __PTRDIFF_TYPE__ && defined __PTRDIFF_MAX__
+#  define YYPTRDIFF_T __PTRDIFF_TYPE__
+#  define YYPTRDIFF_MAXIMUM __PTRDIFF_MAX__
+# elif defined PTRDIFF_MAX
+#  ifndef ptrdiff_t
+#   include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#  endif
+#  define YYPTRDIFF_T ptrdiff_t
+#  define YYPTRDIFF_MAXIMUM PTRDIFF_MAX
+# else
+#  define YYPTRDIFF_T long
+#  define YYPTRDIFF_MAXIMUM LONG_MAX
+# endif
 #endif
 
 #ifndef YYSIZE_T
@@ -358,57 +393,106 @@ typedef short int yytype_int16;
 #  define YYSIZE_T __SIZE_TYPE__
 # elif defined size_t
 #  define YYSIZE_T size_t
-# elif ! defined YYSIZE_T && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+# elif defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
 #  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
-
 #  define YYSIZE_T size_t
 # else
-#  define YYSIZE_T unsigned int
+#  define YYSIZE_T unsigned
 # endif
 #endif
 
-#define YYSIZE_MAXIMUM ((YYSIZE_T) -1)
+#define YYSIZE_MAXIMUM                                  \
+  YY_CAST (YYPTRDIFF_T,                                 \
+           (YYPTRDIFF_MAXIMUM < YY_CAST (YYSIZE_T, -1)  \
+            ? YYPTRDIFF_MAXIMUM                         \
+            : YY_CAST (YYSIZE_T, -1)))
+
+#define YYSIZEOF(X) YY_CAST (YYPTRDIFF_T, sizeof (X))
+
+
+/* Stored state numbers (used for stacks). */
+typedef yytype_int16 yy_state_t;
+
+/* State numbers in computations.  */
+typedef int yy_state_fast_t;
 
 #ifndef YY_
 # if defined YYENABLE_NLS && YYENABLE_NLS
 #  if ENABLE_NLS
 #   include <libintl.h> /* INFRINGES ON USER NAME SPACE */
-
-#   define YY_(msgid) dgettext ("bison-runtime", msgid)
+#   define YY_(Msgid) dgettext ("bison-runtime", Msgid)
 #  endif
 # endif
 # ifndef YY_
-#  define YY_(msgid) msgid
+#  define YY_(Msgid) Msgid
+# endif
+#endif
+
+
+#ifndef YY_ATTRIBUTE_PURE
+# if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_PURE __attribute__ ((__pure__))
+# else
+#  define YY_ATTRIBUTE_PURE
+# endif
+#endif
+
+#ifndef YY_ATTRIBUTE_UNUSED
+# if defined __GNUC__ && 2 < __GNUC__ + (7 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_UNUSED __attribute__ ((__unused__))
+# else
+#  define YY_ATTRIBUTE_UNUSED
 # endif
 #endif
 
 /* Suppress unused-variable warnings by "using" E.  */
 #if ! defined lint || defined __GNUC__
-# define YYUSE(e) ((void) (e))
+# define YY_USE(E) ((void) (E))
 #else
-# define YYUSE(e) /* empty */
+# define YY_USE(E) /* empty */
 #endif
 
-/* Identity function, used to suppress warnings about constant conditions.  */
-#ifndef lint
-# define YYID(n) (n)
+/* Suppress an incorrect diagnostic about yylval being uninitialized.  */
+#if defined __GNUC__ && ! defined __ICC && 406 <= __GNUC__ * 100 + __GNUC_MINOR__
+# if __GNUC__ * 100 + __GNUC_MINOR__ < 407
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")
+# else
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")              \
+    _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+# endif
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END      \
+    _Pragma ("GCC diagnostic pop")
 #else
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-static int
-YYID (int i)
-#else
-static int
-YYID (i)
-    int i;
+# define YY_INITIAL_VALUE(Value) Value
 #endif
-{
-  return i;
-}
+#ifndef YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END
+#endif
+#ifndef YY_INITIAL_VALUE
+# define YY_INITIAL_VALUE(Value) /* Nothing. */
 #endif
 
-#if ! defined yyoverflow || YYERROR_VERBOSE
+#if defined __cplusplus && defined __GNUC__ && ! defined __ICC && 6 <= __GNUC__
+# define YY_IGNORE_USELESS_CAST_BEGIN                          \
+    _Pragma ("GCC diagnostic push")                            \
+    _Pragma ("GCC diagnostic ignored \"-Wuseless-cast\"")
+# define YY_IGNORE_USELESS_CAST_END            \
+    _Pragma ("GCC diagnostic pop")
+#endif
+#ifndef YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_END
+#endif
+
+
+#define YY_ASSERT(E) ((void) (0 && (E)))
+
+#if !defined yyoverflow
 
 /* The parser invokes alloca or malloc; define the necessary symbols.  */
 
@@ -422,15 +506,14 @@ YYID (i)
 #    define YYSTACK_ALLOC __alloca
 #   elif defined _MSC_VER
 #    include <malloc.h> /* INFRINGES ON USER NAME SPACE */
-
 #    define alloca _alloca
 #   else
 #    define YYSTACK_ALLOC alloca
-#    if ! defined _ALLOCA_H && ! defined _STDLIB_H && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#    if ! defined _ALLOCA_H && ! defined EXIT_SUCCESS
 #     include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
-#     ifndef _STDLIB_H
-#      define _STDLIB_H 1
+      /* Use EXIT_SUCCESS as a witness for stdlib.h.  */
+#     ifndef EXIT_SUCCESS
+#      define EXIT_SUCCESS 0
 #     endif
 #    endif
 #   endif
@@ -438,8 +521,8 @@ YYID (i)
 # endif
 
 # ifdef YYSTACK_ALLOC
-   /* Pacify GCC's `empty if-body' warning.  */
-#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (YYID (0))
+   /* Pacify GCC's 'empty if-body' warning.  */
+#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (0)
 #  ifndef YYSTACK_ALLOC_MAXIMUM
     /* The OS might guarantee only one guard page at the bottom of the stack,
        and a page size can be as small as 4096 bytes.  So we cannot safely
@@ -453,89 +536,91 @@ YYID (i)
 #  ifndef YYSTACK_ALLOC_MAXIMUM
 #   define YYSTACK_ALLOC_MAXIMUM YYSIZE_MAXIMUM
 #  endif
-#  if (defined __cplusplus && ! defined _STDLIB_H \
+#  if (defined __cplusplus && ! defined EXIT_SUCCESS \
        && ! ((defined YYMALLOC || defined malloc) \
-	     && (defined YYFREE || defined free)))
+             && (defined YYFREE || defined free)))
 #   include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
-#   ifndef _STDLIB_H
-#    define _STDLIB_H 1
+#   ifndef EXIT_SUCCESS
+#    define EXIT_SUCCESS 0
 #   endif
 #  endif
 #  ifndef YYMALLOC
 #   define YYMALLOC malloc
-#   if ! defined malloc && ! defined _STDLIB_H && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#   if ! defined malloc && ! defined EXIT_SUCCESS
 void *malloc (YYSIZE_T); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 #  ifndef YYFREE
 #   define YYFREE free
-#   if ! defined free && ! defined _STDLIB_H && (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
+#   if ! defined free && ! defined EXIT_SUCCESS
 void free (void *); /* INFRINGES ON USER NAME SPACE */
 #   endif
 #  endif
 # endif
-#endif /* ! defined yyoverflow || YYERROR_VERBOSE */
-
+#endif /* !defined yyoverflow */
 
 #if (! defined yyoverflow \
      && (! defined __cplusplus \
-	 || (defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL \
-	     && defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
+         || (defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL \
+             && defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
 
 /* A type that is properly aligned for any stack member.  */
 union yyalloc
 {
-  yytype_int16 yyss;
-  YYSTYPE yyvs;
-    YYLTYPE yyls;
+  yy_state_t yyss_alloc;
+  YYSTYPE yyvs_alloc;
+  YYLTYPE yyls_alloc;
 };
 
 /* The size of the maximum gap between one aligned stack and the next.  */
-# define YYSTACK_GAP_MAXIMUM (sizeof (union yyalloc) - 1)
+# define YYSTACK_GAP_MAXIMUM (YYSIZEOF (union yyalloc) - 1)
 
 /* The size of an array large to enough to hold all stacks, each with
    N elements.  */
 # define YYSTACK_BYTES(N) \
-     ((N) * (sizeof (yytype_int16) + sizeof (YYSTYPE) + sizeof (YYLTYPE)) \
+     ((N) * (YYSIZEOF (yy_state_t) + YYSIZEOF (YYSTYPE) \
+             + YYSIZEOF (YYLTYPE)) \
       + 2 * YYSTACK_GAP_MAXIMUM)
 
-/* Copy COUNT objects from FROM to TO.  The source and destination do
-   not overlap.  */
-# ifndef YYCOPY
-#  if defined __GNUC__ && 1 < __GNUC__
-#   define YYCOPY(To, From, Count) \
-      __builtin_memcpy (To, From, (Count) * sizeof (*(From)))
-#  else
-#   define YYCOPY(To, From, Count)		\
-      do					\
-	{					\
-	  YYSIZE_T yyi;				\
-	  for (yyi = 0; yyi < (Count); yyi++)	\
-	    (To)[yyi] = (From)[yyi];		\
-	}					\
-      while (YYID (0))
-#  endif
-# endif
+# define YYCOPY_NEEDED 1
 
 /* Relocate STACK from its old location to the new one.  The
    local variables YYSIZE and YYSTACKSIZE give the old and new number of
    elements in the stack, and YYPTR gives the new location of the
    stack.  Advance YYPTR to a properly aligned location for the next
    stack.  */
-# define YYSTACK_RELOCATE(Stack)					\
-    do									\
-      {									\
-	YYSIZE_T yynewbytes;						\
-	YYCOPY (&yyptr->Stack, Stack, yysize);				\
-	Stack = &yyptr->Stack;						\
-	yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
-	yyptr += yynewbytes / sizeof (*yyptr);				\
-      }									\
-    while (YYID (0))
+# define YYSTACK_RELOCATE(Stack_alloc, Stack)                           \
+    do                                                                  \
+      {                                                                 \
+        YYPTRDIFF_T yynewbytes;                                         \
+        YYCOPY (&yyptr->Stack_alloc, Stack, yysize);                    \
+        Stack = &yyptr->Stack_alloc;                                    \
+        yynewbytes = yystacksize * YYSIZEOF (*Stack) + YYSTACK_GAP_MAXIMUM; \
+        yyptr += yynewbytes / YYSIZEOF (*yyptr);                        \
+      }                                                                 \
+    while (0)
 
 #endif
+
+#if defined YYCOPY_NEEDED && YYCOPY_NEEDED
+/* Copy COUNT objects from SRC to DST.  The source and destination do
+   not overlap.  */
+# ifndef YYCOPY
+#  if defined __GNUC__ && 1 < __GNUC__
+#   define YYCOPY(Dst, Src, Count) \
+      __builtin_memcpy (Dst, Src, YY_CAST (YYSIZE_T, (Count)) * sizeof (*(Src)))
+#  else
+#   define YYCOPY(Dst, Src, Count)              \
+      do                                        \
+        {                                       \
+          YYPTRDIFF_T yyi;                      \
+          for (yyi = 0; yyi < (Count); yyi++)   \
+            (Dst)[yyi] = (Src)[yyi];            \
+        }                                       \
+      while (0)
+#  endif
+# endif
+#endif /* !YYCOPY_NEEDED */
 
 /* YYFINAL -- State number of the termination state.  */
 #define YYFINAL  86
@@ -548,18 +633,23 @@ union yyalloc
 #define YYNNTS  48
 /* YYNRULES -- Number of rules.  */
 #define YYNRULES  157
-/* YYNRULES -- Number of states.  */
+/* YYNSTATES -- Number of states.  */
 #define YYNSTATES  285
 
-/* YYTRANSLATE(YYLEX) -- Bison symbol number corresponding to YYLEX.  */
-#define YYUNDEFTOK  2
+/* YYMAXUTOK -- Last valid token kind.  */
 #define YYMAXUTOK   309
 
-#define YYTRANSLATE(YYX)						\
-  ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
 
-/* YYTRANSLATE[YYLEX] -- Bison symbol number corresponding to YYLEX.  */
-static const yytype_uint8 yytranslate[] =
+/* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex, with out-of-bounds checking.  */
+#define YYTRANSLATE(YYX)                                \
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK                     \
+   ? YY_CAST (yysymbol_kind_t, yytranslate[YYX])        \
+   : YYSYMBOL_YYUNDEF)
+
+/* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex.  */
+static const yytype_int8 yytranslate[] =
 {
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
       66,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -595,87 +685,8 @@ static const yytype_uint8 yytranslate[] =
 };
 
 #if YYDEBUG
-/* YYPRHS[YYN] -- Index of the first RHS symbol of rule number YYN in
-   YYRHS.  */
-static const yytype_uint16 yyprhs[] =
-{
-       0,     0,     3,     5,     7,    10,    13,    16,    19,    23,
-      27,    33,    39,    43,    47,    50,    53,    55,    57,    61,
-      64,    67,    70,    73,    76,    79,    82,    85,    89,    93,
-      97,   101,   105,   109,   113,   117,   121,   125,   129,   133,
-     137,   141,   145,   149,   153,   155,   157,   159,   161,   163,
-     165,   167,   169,   171,   173,   175,   179,   183,   187,   191,
-     195,   199,   203,   207,   211,   214,   220,   228,   236,   237,
-     239,   243,   246,   251,   255,   260,   262,   266,   270,   271,
-     273,   275,   279,   281,   285,   292,   301,   308,   317,   318,
-     320,   322,   326,   328,   332,   335,   340,   343,   347,   351,
-     355,   359,   360,   362,   365,   369,   373,   375,   376,   378,
-     382,   385,   389,   392,   394,   396,   398,   400,   402,   404,
-     406,   408,   410,   412,   414,   418,   419,   421,   425,   428,
-     432,   435,   437,   440,   442,   444,   452,   456,   462,   466,
-     470,   476,   480,   482,   484,   486,   489,   491,   495,   499,
-     501,   503,   505,   507,   509,   511,   513,   515
-};
-
-/* YYRHS -- A `-1'-separated list of the rules' RHS.  */
-static const yytype_int8 yyrhs[] =
-{
-      75,     0,    -1,    50,    -1,    66,    -1,   105,    66,    -1,
-     105,    67,    -1,   106,    66,    -1,   106,    67,    -1,    51,
-     118,    66,    -1,    51,   118,    67,    -1,    51,   118,    62,
-     118,    66,    -1,    51,   118,    62,   118,    67,    -1,    51,
-      90,    66,    -1,    51,    90,    67,    -1,     1,    66,    -1,
-       1,    67,    -1,   121,    -1,   119,    -1,    64,    76,    68,
-      -1,    54,    76,    -1,    53,    76,    -1,    69,    76,    -1,
-      40,    76,    -1,    37,    86,    -1,    86,    37,    -1,    38,
-      86,    -1,    86,    38,    -1,    76,    57,    76,    -1,    76,
-      53,    76,    -1,    76,    54,    76,    -1,    76,    55,    76,
-      -1,    76,    56,    76,    -1,    76,    61,    76,    -1,    76,
-      58,    76,    -1,    76,    46,    76,    -1,    76,    47,    76,
-      -1,    76,    48,    76,    -1,    76,    49,    76,    -1,    76,
-      45,    76,    -1,    76,    44,    76,    -1,    76,    40,    76,
-      -1,    76,    41,    76,    -1,    76,    42,    76,    -1,    76,
-      43,    76,    -1,    77,    -1,    79,    -1,    78,    -1,    80,
-      -1,    81,    -1,    82,    -1,    83,    -1,    84,    -1,    85,
-      -1,    90,    -1,    86,    -1,    76,    28,    76,    -1,    76,
-      29,    76,    -1,    76,    30,    76,    -1,    76,    39,    76,
-      -1,    76,    32,    76,    -1,    76,    33,    76,    -1,    76,
-      34,    76,    -1,    76,    35,    76,    -1,    76,    36,    76,
-      -1,   118,    87,    -1,    89,    65,    76,    70,    87,    -1,
-      64,    76,    68,    65,    76,    70,    87,    -1,    86,    62,
-      89,    65,    76,    70,    87,    -1,    -1,    88,    -1,    65,
-      76,    70,    -1,    65,    70,    -1,    88,    65,    76,    70,
-      -1,    88,    65,    70,    -1,   118,    64,    91,    68,    -1,
-      89,    -1,    86,    62,    89,    -1,    90,    62,    89,    -1,
-      -1,    92,    -1,    93,    -1,    92,    71,    93,    -1,    76,
-      -1,   118,    39,    76,    -1,    12,   118,    64,    96,    68,
-     102,    -1,    12,   118,   100,   118,    64,    96,    68,   102,
-      -1,    13,   118,    64,    96,    68,   102,    -1,    13,   118,
-     100,   118,    64,    96,    68,   102,    -1,    -1,    97,    -1,
-      98,    -1,    97,    71,    98,    -1,   118,    -1,   118,    39,
-      76,    -1,    99,   118,    -1,    99,   118,    39,    76,    -1,
-     118,   100,    -1,    23,   118,   100,    -1,    24,   118,   100,
-      -1,    25,   118,   100,    -1,    26,   118,   100,    -1,    -1,
-     101,    -1,    65,    70,    -1,   101,    65,    70,    -1,    72,
-     103,    73,    -1,   105,    -1,    -1,   105,    -1,   103,    67,
-     105,    -1,   103,    67,    -1,   103,    66,   105,    -1,   103,
-      66,    -1,   110,    -1,   112,    -1,   114,    -1,   115,    -1,
-     116,    -1,   117,    -1,   104,    -1,    76,    -1,   109,    -1,
-      94,    -1,    95,    -1,   118,    87,   118,    -1,    -1,   108,
-      -1,   107,    67,   108,    -1,   107,    67,    -1,   107,    66,
-     108,    -1,   107,    66,    -1,    98,    -1,    27,    98,    -1,
-      94,    -1,    95,    -1,    14,   118,    57,   118,    72,   107,
-      73,    -1,    17,   111,   102,    -1,    17,   111,   102,    18,
-     102,    -1,    64,    76,    68,    -1,    15,   113,   102,    -1,
-      64,   118,    16,    76,    68,    -1,    19,   111,   102,    -1,
-      20,    -1,    21,    -1,    22,    -1,    22,    76,    -1,     5,
-      -1,    65,   120,    70,    -1,   120,    71,    76,    -1,    76,
-      -1,     9,    -1,    10,    -1,     7,    -1,     8,    -1,    11,
-      -1,     4,    -1,     6,    -1,     3,    -1
-};
-
-/* YYRLINE[YYN] -- source line where rule number YYN was defined.  */
-static const yytype_uint16 yyrline[] =
+/* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
+static const yytype_int16 yyrline[] =
 {
        0,   234,   234,   241,   248,   257,   266,   275,   284,   293,
      302,   312,   322,   331,   340,   347,   356,   358,   360,   362,
@@ -696,96 +707,96 @@ static const yytype_uint16 yyrline[] =
 };
 #endif
 
-#if YYDEBUG || YYERROR_VERBOSE || YYTOKEN_TABLE
+/** Accessing symbol of state STATE.  */
+#define YY_ACCESSING_SYMBOL(State) YY_CAST (yysymbol_kind_t, yystos[State])
+
+#if YYDEBUG || 0
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
+
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
 static const char *const yytname[] =
 {
-  "$end", "error", "$undefined", "REAL", "INT", "NAME", "STRING",
-  "RBNULL", "RBTAB", "FALSE", "TRUE", "RBINF", "FUNCTION", "PROCEDURE",
-  "CLASS", "FOR", "IN", "IF", "ELSE", "WHILE", "NEXT", "BREAK", "RETURN",
-  "MOD_CONST", "MOD_DYNAMIC", "MOD_STOCHASTIC", "MOD_DETERMINISTIC",
-  "PROTECTED", "ARROW_ASSIGN", "TILDE_ASSIGN", "EQUATION_ASSIGN",
-  "WORKSPACE_ASSIGN", "REFERENCE_ASSIGN", "ADDITION_ASSIGN",
-  "SUBTRACTION_ASSIGN", "MULTIPLICATION_ASSIGN", "DIVISION_ASSIGN",
-  "DECREMENT", "INCREMENT", "EQUAL", "AND", "OR", "AND2", "OR2", "GT",
-  "GE", "LT", "LE", "EQ", "NE", "END_OF_INPUT", "'?'", "UNOT", "'+'",
-  "'-'", "'*'", "'/'", "':'", "'%'", "UPLUS", "UMINUS", "'^'", "'.'",
-  "UAND", "'('", "'['", "'\\n'", "';'", "')'", "'!'", "']'", "','", "'{'",
-  "'}'", "$accept", "prog", "expression", "arrowAssign", "tildeAssign",
-  "equationAssign", "workspaceAssign", "referenceAssign", "additionAssign",
-  "subtractionAssign", "multiplicationAssign", "divisionAssign",
-  "variable", "optElements", "elementList", "fxnCall", "functionCall",
-  "optArguments", "argumentList", "argument", "functionDef",
-  "procedureDef", "optFormals", "formalList", "formal", "typeSpec",
-  "optDims", "dimList", "stmts", "stmtList", "statement", "stmt_or_expr",
-  "declaration", "memberDefs", "memberDef", "classDef", "ifStatement",
-  "cond", "forStatement", "forCond", "whileStatement", "nextStatement",
-  "breakStatement", "returnStatement", "identifier", "vector",
-  "vectorList", "constant", 0
+  "\"end of file\"", "error", "\"invalid token\"", "REAL", "INT", "NAME",
+  "STRING", "RBNULL", "RBTAB", "FALSE", "TRUE", "RBINF", "FUNCTION",
+  "PROCEDURE", "CLASS", "FOR", "IN", "IF", "ELSE", "WHILE", "NEXT",
+  "BREAK", "RETURN", "MOD_CONST", "MOD_DYNAMIC", "MOD_STOCHASTIC",
+  "MOD_DETERMINISTIC", "PROTECTED", "ARROW_ASSIGN", "TILDE_ASSIGN",
+  "EQUATION_ASSIGN", "WORKSPACE_ASSIGN", "REFERENCE_ASSIGN",
+  "ADDITION_ASSIGN", "SUBTRACTION_ASSIGN", "MULTIPLICATION_ASSIGN",
+  "DIVISION_ASSIGN", "DECREMENT", "INCREMENT", "EQUAL", "AND", "OR",
+  "AND2", "OR2", "GT", "GE", "LT", "LE", "EQ", "NE", "END_OF_INPUT", "'?'",
+  "UNOT", "'+'", "'-'", "'*'", "'/'", "':'", "'%'", "UMINUS", "UPLUS",
+  "'^'", "'.'", "UAND", "'('", "'['", "'\\n'", "';'", "')'", "'!'", "']'",
+  "','", "'{'", "'}'", "$accept", "prog", "expression", "arrowAssign",
+  "tildeAssign", "equationAssign", "workspaceAssign", "referenceAssign",
+  "additionAssign", "subtractionAssign", "multiplicationAssign",
+  "divisionAssign", "variable", "optElements", "elementList", "fxnCall",
+  "functionCall", "optArguments", "argumentList", "argument",
+  "functionDef", "procedureDef", "optFormals", "formalList", "formal",
+  "typeSpec", "optDims", "dimList", "stmts", "stmtList", "statement",
+  "stmt_or_expr", "declaration", "memberDefs", "memberDef", "classDef",
+  "ifStatement", "cond", "forStatement", "forCond", "whileStatement",
+  "nextStatement", "breakStatement", "returnStatement", "identifier",
+  "vector", "vectorList", "constant", YY_NULLPTR
 };
+
+static const char *
+yysymbol_name (yysymbol_kind_t yysymbol)
+{
+  return yytname[yysymbol];
+}
 #endif
 
-# ifdef YYPRINT
-/* YYTOKNUM[YYLEX-NUM] -- Internal token number corresponding to
-   token YYLEX-NUM.  */
-static const yytype_uint16 yytoknum[] =
-{
-       0,   256,   257,   258,   259,   260,   261,   262,   263,   264,
-     265,   266,   267,   268,   269,   270,   271,   272,   273,   274,
-     275,   276,   277,   278,   279,   280,   281,   282,   283,   284,
-     285,   286,   287,   288,   289,   290,   291,   292,   293,   294,
-     295,   296,   297,   298,   299,   300,   301,   302,   303,   304,
-     305,    63,   306,    43,    45,    42,    47,    58,    37,   307,
-     308,    94,    46,   309,    40,    91,    10,    59,    41,    33,
-      93,    44,   123,   125
-};
-# endif
+#define YYPACT_NINF (-221)
 
-/* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
-static const yytype_uint8 yyr1[] =
-{
-       0,    74,    75,    75,    75,    75,    75,    75,    75,    75,
-      75,    75,    75,    75,    75,    75,    76,    76,    76,    76,
-      76,    76,    76,    76,    76,    76,    76,    76,    76,    76,
-      76,    76,    76,    76,    76,    76,    76,    76,    76,    76,
-      76,    76,    76,    76,    76,    76,    76,    76,    76,    76,
-      76,    76,    76,    76,    76,    77,    78,    79,    80,    81,
-      82,    83,    84,    85,    86,    86,    86,    86,    87,    87,
-      88,    88,    88,    88,    89,    90,    90,    90,    91,    91,
-      92,    92,    93,    93,    94,    94,    95,    95,    96,    96,
-      97,    97,    98,    98,    98,    98,    99,    99,    99,    99,
-      99,   100,   100,   101,   101,   102,   102,   103,   103,   103,
-     103,   103,   103,   104,   104,   104,   104,   104,   104,   105,
-     105,   106,   106,   106,   106,   107,   107,   107,   107,   107,
-     107,   108,   108,   108,   108,   109,   110,   110,   111,   112,
-     113,   114,   115,   116,   117,   117,   118,   119,   120,   120,
-     121,   121,   121,   121,   121,   121,   121,   121
-};
+#define yypact_value_is_default(Yyn) \
+  ((Yyn) == YYPACT_NINF)
 
-/* YYR2[YYN] -- Number of symbols composing right hand side of rule YYN.  */
-static const yytype_uint8 yyr2[] =
+#define YYTABLE_NINF (-102)
+
+#define yytable_value_is_error(Yyn) \
+  ((Yyn) == YYTABLE_NINF)
+
+/* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
+   STATE-NUM.  */
+static const yytype_int16 yypact[] =
 {
-       0,     2,     1,     1,     2,     2,     2,     2,     3,     3,
-       5,     5,     3,     3,     2,     2,     1,     1,     3,     2,
-       2,     2,     2,     2,     2,     2,     2,     3,     3,     3,
-       3,     3,     3,     3,     3,     3,     3,     3,     3,     3,
-       3,     3,     3,     3,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     1,     3,     3,     3,     3,     3,
-       3,     3,     3,     3,     2,     5,     7,     7,     0,     1,
-       3,     2,     4,     3,     4,     1,     3,     3,     0,     1,
-       1,     3,     1,     3,     6,     8,     6,     8,     0,     1,
-       1,     3,     1,     3,     2,     4,     2,     3,     3,     3,
-       3,     0,     1,     2,     3,     3,     1,     0,     1,     3,
-       2,     3,     2,     1,     1,     1,     1,     1,     1,     1,
-       1,     1,     1,     1,     3,     0,     1,     3,     2,     3,
-       2,     1,     2,     1,     1,     7,     3,     5,     3,     3,
-       5,     3,     1,     1,     1,     2,     1,     3,     3,     1,
-       1,     1,     1,     1,     1,     1,     1,     1
+     353,   -24,  -221,  -221,  -221,  -221,  -221,  -221,  -221,  -221,
+    -221,    18,    18,    18,   -47,   -36,   -36,  -221,  -221,   461,
+       2,     2,   461,  -221,     2,   461,   461,   461,   461,  -221,
+     461,    33,   842,  -221,  -221,  -221,  -221,  -221,  -221,  -221,
+    -221,  -221,   -28,   -27,    -3,  -221,  -221,  -221,   -22,     5,
+    -221,  -221,  -221,  -221,  -221,  -221,  -221,    10,  -221,  -221,
+    -221,  -221,    22,    25,   -21,    18,   283,   461,   283,   283,
+     842,    10,   461,    21,   -27,    21,  -221,    37,   -40,    54,
+      19,    19,   694,   842,    35,   166,  -221,   461,   461,   461,
+     461,   461,   461,   461,   461,   461,   461,   461,   461,   461,
+     461,   461,   461,   461,   461,   461,   461,   461,   461,   461,
+     461,   461,   461,  -221,  -221,    18,   461,    18,  -221,  -221,
+    -221,  -221,   461,    44,    18,    30,    53,    -8,    18,    36,
+      53,    18,    18,    87,   441,  -221,  -221,   731,    92,  -221,
+    -221,   768,    18,  -221,  -221,    18,  -221,  -221,    58,  -221,
+     461,   842,   872,   902,   932,   961,   989,  1013,  1036,   285,
+     166,  1056,   166,  1056,  1074,  1074,  1074,  1074,  1074,  1074,
+      12,    12,   -26,   -26,    19,    19,    19,    60,    70,   499,
+    -221,   842,    73,    72,  -221,   -35,  -221,   538,  -221,   373,
+      18,    18,    18,    18,    76,    75,  -221,    18,    -2,  -221,
+      88,   113,   116,   121,   114,   461,   -52,  -221,  -221,   283,
+      58,    60,    45,   461,   842,   461,   122,  -221,   461,   461,
+    -221,  -221,   577,   129,   129,   129,   129,   283,    53,   156,
+     461,  -221,    53,  -221,   283,    53,   124,   805,   441,   441,
+    -221,  -221,  -221,  -221,   616,   655,  -221,  -221,   842,  -221,
+    -221,  -221,  -221,  -221,  -221,  -221,   461,   842,   128,  -221,
+     131,    53,  -221,  -221,  -221,   -48,  -221,  -221,  -221,  -221,
+     122,   122,   842,   283,   283,  -221,   124,   124,  -221,  -221,
+    -221,  -221,  -221,  -221,  -221
 };
 
-/* YYDEFACT[STATE-NAME] -- Default rule to reduce with in state
-   STATE-NUM when YYTABLE doesn't specify something else to do.  Zero
+/* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
+   Performed when YYTABLE does not specify something else to do.  Zero
    means the default is an error.  */
 static const yytype_uint8 yydefact[] =
 {
@@ -820,52 +831,6 @@ static const yytype_uint8 yydefact[] =
       67,    85,    87,   129,   127
 };
 
-/* YYDEFGOTO[NTERM-NUM].  */
-static const yytype_int16 yydefgoto[] =
-{
-      -1,    31,    32,    33,    34,    35,    36,    37,    38,    39,
-      40,    41,    42,   140,   125,    43,    44,   182,   183,   184,
-     262,   263,   194,   195,   196,   197,   128,   129,   135,   206,
-      47,   136,    49,   265,   266,    50,    51,    68,    52,    66,
-      53,    54,    55,    56,    71,    58,    84,    59
-};
-
-/* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
-   STATE-NUM.  */
-#define YYPACT_NINF -221
-static const yytype_int16 yypact[] =
-{
-     353,   -24,  -221,  -221,  -221,  -221,  -221,  -221,  -221,  -221,
-    -221,    18,    18,    18,   -47,   -36,   -36,  -221,  -221,   461,
-       2,     2,   461,  -221,     2,   461,   461,   461,   461,  -221,
-     461,    33,   842,  -221,  -221,  -221,  -221,  -221,  -221,  -221,
-    -221,  -221,   -28,   -27,    -3,  -221,  -221,  -221,   -22,     5,
-    -221,  -221,  -221,  -221,  -221,  -221,  -221,    10,  -221,  -221,
-    -221,  -221,    22,    25,   -21,    18,   283,   461,   283,   283,
-     842,    10,   461,    21,   -27,    21,  -221,    37,   -40,    54,
-      19,    19,   694,   842,    35,   166,  -221,   461,   461,   461,
-     461,   461,   461,   461,   461,   461,   461,   461,   461,   461,
-     461,   461,   461,   461,   461,   461,   461,   461,   461,   461,
-     461,   461,   461,  -221,  -221,    18,   461,    18,  -221,  -221,
-    -221,  -221,   461,    44,    18,    30,    53,    -8,    18,    36,
-      53,    18,    18,    87,   441,  -221,  -221,   731,    92,  -221,
-    -221,   768,    18,  -221,  -221,    18,  -221,  -221,    58,  -221,
-     461,   842,   872,   902,   932,   961,   989,  1013,  1036,   285,
-     166,  1056,   166,  1056,  1074,  1074,  1074,  1074,  1074,  1074,
-      12,    12,   -26,   -26,    19,    19,    19,    60,    70,   499,
-    -221,   842,    73,    72,  -221,   -35,  -221,   538,  -221,   373,
-      18,    18,    18,    18,    76,    75,  -221,    18,    -2,  -221,
-      88,   113,   116,   121,   114,   461,   -52,  -221,  -221,   283,
-      58,    60,    45,   461,   842,   461,   122,  -221,   461,   461,
-    -221,  -221,   577,   129,   129,   129,   129,   283,    53,   156,
-     461,  -221,    53,  -221,   283,    53,   124,   805,   441,   441,
-    -221,  -221,  -221,  -221,   616,   655,  -221,  -221,   842,  -221,
-    -221,  -221,  -221,  -221,  -221,  -221,   461,   842,   128,  -221,
-     131,    53,  -221,  -221,  -221,   -48,  -221,  -221,  -221,  -221,
-     122,   122,   842,   283,   283,  -221,   124,   124,  -221,  -221,
-    -221,  -221,  -221,  -221,  -221
-};
-
 /* YYPGOTO[NTERM-NUM].  */
 static const yytype_int16 yypgoto[] =
 {
@@ -876,11 +841,19 @@ static const yytype_int16 yypgoto[] =
     -221,  -221,  -221,  -221,     0,  -221,  -221,  -221
 };
 
-/* YYTABLE[YYPACT[STATE-NUM]].  What to do in state STATE-NUM.  If
-   positive, shift that token.  If negative, reduce the rule which
-   number is the opposite.  If zero, do what YYDEFACT says.
-   If YYTABLE_NINF, syntax error.  */
-#define YYTABLE_NINF -102
+/* YYDEFGOTO[NTERM-NUM].  */
+static const yytype_int16 yydefgoto[] =
+{
+       0,    31,    32,    33,    34,    35,    36,    37,    38,    39,
+      40,    41,    42,   140,   125,    43,    44,   182,   183,   184,
+     262,   263,   194,   195,   196,   197,   128,   129,   135,   206,
+      47,   136,    49,   265,   266,    50,    51,    68,    52,    66,
+      53,    54,    55,    56,    71,    58,    84,    59
+};
+
+/* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
+   positive, shift that token.  If negative, reduce the rule whose
+   number is the opposite.  If YYTABLE_NINF, syntax error.  */
 static const yytype_int16 yytable[] =
 {
       57,    48,   202,  -101,   219,    74,    74,     4,   255,   113,
@@ -1117,9 +1090,9 @@ static const yytype_int16 yycheck[] =
       56,    57,    58,    -1,    -1,    61
 };
 
-/* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
-   symbol of state STATE-NUM.  */
-static const yytype_uint8 yystos[] =
+/* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
+   state STATE-NUM.  */
+static const yytype_int8 yystos[] =
 {
        0,     1,     3,     4,     5,     6,     7,     8,     9,    10,
       11,    12,    13,    14,    15,    17,    19,    20,    21,    22,
@@ -1152,184 +1125,230 @@ static const yytype_uint8 yystos[] =
       87,   102,   102,   108,   108
 };
 
-#define yyerrok		(yyerrstatus = 0)
-#define yyclearin	(yychar = YYEMPTY)
-#define YYEMPTY		(-2)
-#define YYEOF		0
+/* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
+static const yytype_int8 yyr1[] =
+{
+       0,    74,    75,    75,    75,    75,    75,    75,    75,    75,
+      75,    75,    75,    75,    75,    75,    76,    76,    76,    76,
+      76,    76,    76,    76,    76,    76,    76,    76,    76,    76,
+      76,    76,    76,    76,    76,    76,    76,    76,    76,    76,
+      76,    76,    76,    76,    76,    76,    76,    76,    76,    76,
+      76,    76,    76,    76,    76,    77,    78,    79,    80,    81,
+      82,    83,    84,    85,    86,    86,    86,    86,    87,    87,
+      88,    88,    88,    88,    89,    90,    90,    90,    91,    91,
+      92,    92,    93,    93,    94,    94,    95,    95,    96,    96,
+      97,    97,    98,    98,    98,    98,    99,    99,    99,    99,
+      99,   100,   100,   101,   101,   102,   102,   103,   103,   103,
+     103,   103,   103,   104,   104,   104,   104,   104,   104,   105,
+     105,   106,   106,   106,   106,   107,   107,   107,   107,   107,
+     107,   108,   108,   108,   108,   109,   110,   110,   111,   112,
+     113,   114,   115,   116,   117,   117,   118,   119,   120,   120,
+     121,   121,   121,   121,   121,   121,   121,   121
+};
 
-#define YYACCEPT	goto yyacceptlab
-#define YYABORT		goto yyabortlab
-#define YYERROR		goto yyerrorlab
+/* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
+static const yytype_int8 yyr2[] =
+{
+       0,     2,     1,     1,     2,     2,     2,     2,     3,     3,
+       5,     5,     3,     3,     2,     2,     1,     1,     3,     2,
+       2,     2,     2,     2,     2,     2,     2,     3,     3,     3,
+       3,     3,     3,     3,     3,     3,     3,     3,     3,     3,
+       3,     3,     3,     3,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     1,     3,     3,     3,     3,     3,
+       3,     3,     3,     3,     2,     5,     7,     7,     0,     1,
+       3,     2,     4,     3,     4,     1,     3,     3,     0,     1,
+       1,     3,     1,     3,     6,     8,     6,     8,     0,     1,
+       1,     3,     1,     3,     2,     4,     2,     3,     3,     3,
+       3,     0,     1,     2,     3,     3,     1,     0,     1,     3,
+       2,     3,     2,     1,     1,     1,     1,     1,     1,     1,
+       1,     1,     1,     1,     3,     0,     1,     3,     2,     3,
+       2,     1,     2,     1,     1,     7,     3,     5,     3,     3,
+       5,     3,     1,     1,     1,     2,     1,     3,     3,     1,
+       1,     1,     1,     1,     1,     1,     1,     1
+};
 
 
-/* Like YYERROR except do call yyerror.  This remains here temporarily
-   to ease the transition to the new meaning of YYERROR, for GCC.
-   Once GCC version 2 has supplanted version 1, this can go.  */
+enum { YYENOMEM = -2 };
 
-#define YYFAIL		goto yyerrlab
+#define yyerrok         (yyerrstatus = 0)
+#define yyclearin       (yychar = YYEMPTY)
+
+#define YYACCEPT        goto yyacceptlab
+#define YYABORT         goto yyabortlab
+#define YYERROR         goto yyerrorlab
+#define YYNOMEM         goto yyexhaustedlab
+
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
-#define YYBACKUP(Token, Value)					\
-do								\
-  if (yychar == YYEMPTY && yylen == 1)				\
-    {								\
-      yychar = (Token);						\
-      yylval = (Value);						\
-      yytoken = YYTRANSLATE (yychar);				\
-      YYPOPSTACK (1);						\
-      goto yybackup;						\
-    }								\
-  else								\
-    {								\
-      yyerror (YY_("syntax error: cannot back up")); \
-      YYERROR;							\
-    }								\
-while (YYID (0))
+#define YYBACKUP(Token, Value)                                    \
+  do                                                              \
+    if (yychar == YYEMPTY)                                        \
+      {                                                           \
+        yychar = (Token);                                         \
+        yylval = (Value);                                         \
+        YYPOPSTACK (yylen);                                       \
+        yystate = *yyssp;                                         \
+        goto yybackup;                                            \
+      }                                                           \
+    else                                                          \
+      {                                                           \
+        yyerror (YY_("syntax error: cannot back up")); \
+        YYERROR;                                                  \
+      }                                                           \
+  while (0)
 
-
-#define YYTERROR	1
-#define YYERRCODE	256
-
+/* Backward compatibility with an undocumented macro.
+   Use YYerror or YYUNDEF. */
+#define YYERRCODE YYUNDEF
 
 /* YYLLOC_DEFAULT -- Set CURRENT to span from RHS[1] to RHS[N].
    If N is 0, then set CURRENT to the empty location which ends
    the previous symbol: RHS[0] (always defined).  */
 
-#define YYRHSLOC(Rhs, K) ((Rhs)[K])
 #ifndef YYLLOC_DEFAULT
-# define YYLLOC_DEFAULT(Current, Rhs, N)				\
-    do									\
-      if (YYID (N))                                                    \
-	{								\
-	  (Current).first_line   = YYRHSLOC (Rhs, 1).first_line;	\
-	  (Current).first_column = YYRHSLOC (Rhs, 1).first_column;	\
-	  (Current).last_line    = YYRHSLOC (Rhs, N).last_line;		\
-	  (Current).last_column  = YYRHSLOC (Rhs, N).last_column;	\
-	}								\
-      else								\
-	{								\
-	  (Current).first_line   = (Current).last_line   =		\
-	    YYRHSLOC (Rhs, 0).last_line;				\
-	  (Current).first_column = (Current).last_column =		\
-	    YYRHSLOC (Rhs, 0).last_column;				\
-	}								\
-    while (YYID (0))
+# define YYLLOC_DEFAULT(Current, Rhs, N)                                \
+    do                                                                  \
+      if (N)                                                            \
+        {                                                               \
+          (Current).first_line   = YYRHSLOC (Rhs, 1).first_line;        \
+          (Current).first_column = YYRHSLOC (Rhs, 1).first_column;      \
+          (Current).last_line    = YYRHSLOC (Rhs, N).last_line;         \
+          (Current).last_column  = YYRHSLOC (Rhs, N).last_column;       \
+        }                                                               \
+      else                                                              \
+        {                                                               \
+          (Current).first_line   = (Current).last_line   =              \
+            YYRHSLOC (Rhs, 0).last_line;                                \
+          (Current).first_column = (Current).last_column =              \
+            YYRHSLOC (Rhs, 0).last_column;                              \
+        }                                                               \
+    while (0)
 #endif
 
+#define YYRHSLOC(Rhs, K) ((Rhs)[K])
 
-/* YY_LOCATION_PRINT -- Print the location on the stream.
-   This macro was not mandated originally: define only if we know
-   we won't break user code: when these are the locations we know.  */
-
-#ifndef YY_LOCATION_PRINT
-# if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
-#  define YY_LOCATION_PRINT(File, Loc)			\
-     fprintf (File, "%d.%d-%d.%d",			\
-	      (Loc).first_line, (Loc).first_column,	\
-	      (Loc).last_line,  (Loc).last_column)
-# else
-#  define YY_LOCATION_PRINT(File, Loc) ((void) 0)
-# endif
-#endif
-
-
-/* YYLEX -- calling `yylex' with the right arguments.  */
-
-#ifdef YYLEX_PARAM
-# define YYLEX yylex (YYLEX_PARAM)
-#else
-# define YYLEX yylex ()
-#endif
 
 /* Enable debugging if requested.  */
 #if YYDEBUG
 
 # ifndef YYFPRINTF
 #  include <stdio.h> /* INFRINGES ON USER NAME SPACE */
-
 #  define YYFPRINTF fprintf
 # endif
 
-# define YYDPRINTF(Args)			\
-do {						\
-  if (yydebug)					\
-    YYFPRINTF Args;				\
-} while (YYID (0))
-
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)			  \
-do {									  \
-  if (yydebug)								  \
-    {									  \
-      YYFPRINTF (stderr, "%s ", Title);					  \
-      yy_symbol_print (stderr,						  \
-		  Type, Value, Location); \
-      YYFPRINTF (stderr, "\n");						  \
-    }									  \
-} while (YYID (0))
+# define YYDPRINTF(Args)                        \
+do {                                            \
+  if (yydebug)                                  \
+    YYFPRINTF Args;                             \
+} while (0)
 
 
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
+/* YYLOCATION_PRINT -- Print the location on the stream.
+   This macro was not mandated originally: define only if we know
+   we won't break user code: when these are the locations we know.  */
 
-/*ARGSUSED*/
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-static void
-yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp)
-#else
-static void
-yy_symbol_value_print (yyoutput, yytype, yyvaluep, yylocationp)
-    FILE *yyoutput;
-    int yytype;
-    YYSTYPE const * const yyvaluep;
-    YYLTYPE const * const yylocationp;
-#endif
+# ifndef YYLOCATION_PRINT
+
+#  if defined YY_LOCATION_PRINT
+
+   /* Temporary convenience wrapper in case some people defined the
+      undocumented and private YY_LOCATION_PRINT macros.  */
+#   define YYLOCATION_PRINT(File, Loc)  YY_LOCATION_PRINT(File, *(Loc))
+
+#  elif defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
+
+/* Print *YYLOCP on YYO.  Private, do not rely on its existence. */
+
+YY_ATTRIBUTE_UNUSED
+static int
+yy_location_print_ (FILE *yyo, YYLTYPE const * const yylocp)
 {
+  int res = 0;
+  int end_col = 0 != yylocp->last_column ? yylocp->last_column - 1 : 0;
+  if (0 <= yylocp->first_line)
+    {
+      res += YYFPRINTF (yyo, "%d", yylocp->first_line);
+      if (0 <= yylocp->first_column)
+        res += YYFPRINTF (yyo, ".%d", yylocp->first_column);
+    }
+  if (0 <= yylocp->last_line)
+    {
+      if (yylocp->first_line < yylocp->last_line)
+        {
+          res += YYFPRINTF (yyo, "-%d", yylocp->last_line);
+          if (0 <= end_col)
+            res += YYFPRINTF (yyo, ".%d", end_col);
+        }
+      else if (0 <= end_col && yylocp->first_column < end_col)
+        res += YYFPRINTF (yyo, "-%d", end_col);
+    }
+  return res;
+}
+
+#   define YYLOCATION_PRINT  yy_location_print_
+
+    /* Temporary convenience wrapper in case some people defined the
+       undocumented and private YY_LOCATION_PRINT macros.  */
+#   define YY_LOCATION_PRINT(File, Loc)  YYLOCATION_PRINT(File, &(Loc))
+
+#  else
+
+#   define YYLOCATION_PRINT(File, Loc) ((void) 0)
+    /* Temporary convenience wrapper in case some people defined the
+       undocumented and private YY_LOCATION_PRINT macros.  */
+#   define YY_LOCATION_PRINT  YYLOCATION_PRINT
+
+#  endif
+# endif /* !defined YYLOCATION_PRINT */
+
+
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)                    \
+do {                                                                      \
+  if (yydebug)                                                            \
+    {                                                                     \
+      YYFPRINTF (stderr, "%s ", Title);                                   \
+      yy_symbol_print (stderr,                                            \
+                  Kind, Value, Location); \
+      YYFPRINTF (stderr, "\n");                                           \
+    }                                                                     \
+} while (0)
+
+
+/*-----------------------------------.
+| Print this symbol's value on YYO.  |
+`-----------------------------------*/
+
+static void
+yy_symbol_value_print (FILE *yyo,
+                       yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp)
+{
+  FILE *yyoutput = yyo;
+  YY_USE (yyoutput);
+  YY_USE (yylocationp);
   if (!yyvaluep)
     return;
-  YYUSE (yylocationp);
-# ifdef YYPRINT
-  if (yytype < YYNTOKENS)
-    YYPRINT (yyoutput, yytoknum[yytype], *yyvaluep);
-# else
-  YYUSE (yyoutput);
-# endif
-  switch (yytype)
-    {
-      default:
-	break;
-    }
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  YY_USE (yykind);
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
 
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
+/*---------------------------.
+| Print this symbol on YYO.  |
+`---------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
-yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp)
-#else
-static void
-yy_symbol_print (yyoutput, yytype, yyvaluep, yylocationp)
-    FILE *yyoutput;
-    int yytype;
-    YYSTYPE const * const yyvaluep;
-    YYLTYPE const * const yylocationp;
-#endif
+yy_symbol_print (FILE *yyo,
+                 yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, YYLTYPE const * const yylocationp)
 {
-  if (yytype < YYNTOKENS)
-    YYFPRINTF (yyoutput, "token %s (", yytname[yytype]);
-  else
-    YYFPRINTF (yyoutput, "nterm %s (", yytname[yytype]);
+  YYFPRINTF (yyo, "%s %s (",
+             yykind < YYNTOKENS ? "token" : "nterm", yysymbol_name (yykind));
 
-  YY_LOCATION_PRINT (yyoutput, *yylocationp);
-  YYFPRINTF (yyoutput, ": ");
-  yy_symbol_value_print (yyoutput, yytype, yyvaluep, yylocationp);
-  YYFPRINTF (yyoutput, ")");
+  YYLOCATION_PRINT (yyo, yylocationp);
+  YYFPRINTF (yyo, ": ");
+  yy_symbol_value_print (yyo, yykind, yyvaluep, yylocationp);
+  YYFPRINTF (yyo, ")");
 }
 
 /*------------------------------------------------------------------.
@@ -1337,81 +1356,69 @@ yy_symbol_print (yyoutput, yytype, yyvaluep, yylocationp)
 | TOP (included).                                                   |
 `------------------------------------------------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
-yy_stack_print (yytype_int16 *bottom, yytype_int16 *top)
-#else
-static void
-yy_stack_print (bottom, top)
-    yytype_int16 *bottom;
-    yytype_int16 *top;
-#endif
+yy_stack_print (yy_state_t *yybottom, yy_state_t *yytop)
 {
   YYFPRINTF (stderr, "Stack now");
-  for (; bottom <= top; ++bottom)
-    YYFPRINTF (stderr, " %d", *bottom);
+  for (; yybottom <= yytop; yybottom++)
+    {
+      int yybot = *yybottom;
+      YYFPRINTF (stderr, " %d", yybot);
+    }
   YYFPRINTF (stderr, "\n");
 }
 
-# define YY_STACK_PRINT(Bottom, Top)				\
-do {								\
-  if (yydebug)							\
-    yy_stack_print ((Bottom), (Top));				\
-} while (YYID (0))
+# define YY_STACK_PRINT(Bottom, Top)                            \
+do {                                                            \
+  if (yydebug)                                                  \
+    yy_stack_print ((Bottom), (Top));                           \
+} while (0)
 
 
 /*------------------------------------------------.
 | Report that the YYRULE is going to be reduced.  |
 `------------------------------------------------*/
 
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
-yy_reduce_print (YYSTYPE *yyvsp, YYLTYPE *yylsp, int yyrule)
-#else
-static void
-yy_reduce_print (yyvsp, yylsp, yyrule)
-    YYSTYPE *yyvsp;
-    YYLTYPE *yylsp;
-    int yyrule;
-#endif
+yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, YYLTYPE *yylsp,
+                 int yyrule)
 {
+  int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
   int yyi;
-  unsigned long int yylno = yyrline[yyrule];
-  YYFPRINTF (stderr, "Reducing stack by rule %d (line %lu):\n",
-	     yyrule - 1, yylno);
+  YYFPRINTF (stderr, "Reducing stack by rule %d (line %d):\n",
+             yyrule - 1, yylno);
   /* The symbols being reduced.  */
   for (yyi = 0; yyi < yynrhs; yyi++)
     {
-      fprintf (stderr, "   $%d = ", yyi + 1);
-      yy_symbol_print (stderr, yyrhs[yyprhs[yyrule] + yyi],
-		       &(yyvsp[(yyi + 1) - (yynrhs)])
-		       , &(yylsp[(yyi + 1) - (yynrhs)])		       );
-      fprintf (stderr, "\n");
+      YYFPRINTF (stderr, "   $%d = ", yyi + 1);
+      yy_symbol_print (stderr,
+                       YY_ACCESSING_SYMBOL (+yyssp[yyi + 1 - yynrhs]),
+                       &yyvsp[(yyi + 1) - (yynrhs)],
+                       &(yylsp[(yyi + 1) - (yynrhs)]));
+      YYFPRINTF (stderr, "\n");
     }
 }
 
-# define YY_REDUCE_PRINT(Rule)		\
-do {					\
-  if (yydebug)				\
-    yy_reduce_print (yyvsp, yylsp, Rule); \
-} while (YYID (0))
+# define YY_REDUCE_PRINT(Rule)          \
+do {                                    \
+  if (yydebug)                          \
+    yy_reduce_print (yyssp, yyvsp, yylsp, Rule); \
+} while (0)
 
 /* Nonzero means print parse trace.  It is left uninitialized so that
    multiple parsers can coexist.  */
 int yydebug;
 #else /* !YYDEBUG */
-# define YYDPRINTF(Args)
-# define YY_SYMBOL_PRINT(Title, Type, Value, Location)
+# define YYDPRINTF(Args) ((void) 0)
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)
 # define YY_STACK_PRINT(Bottom, Top)
 # define YY_REDUCE_PRINT(Rule)
 #endif /* !YYDEBUG */
 
 
 /* YYINITDEPTH -- initial size of the parser's stacks.  */
-#ifndef	YYINITDEPTH
+#ifndef YYINITDEPTH
 # define YYINITDEPTH 200
 #endif
 
@@ -1426,511 +1433,325 @@ int yydebug;
 # define YYMAXDEPTH 10000
 #endif
 
-
 
-#if YYERROR_VERBOSE
 
-# ifndef yystrlen
-#  if defined __GLIBC__ && defined _STRING_H
-#   define yystrlen strlen
-#  else
-/* Return the length of YYSTR.  */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-static YYSIZE_T
-yystrlen (const char *yystr)
-#else
-static YYSIZE_T
-yystrlen (yystr)
-    const char *yystr;
-#endif
-{
-  YYSIZE_T yylen;
-  for (yylen = 0; yystr[yylen]; yylen++)
-    continue;
-  return yylen;
-}
-#  endif
-# endif
 
-# ifndef yystpcpy
-#  if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
-#   define yystpcpy stpcpy
-#  else
-/* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
-   YYDEST.  */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-static char *
-yystpcpy (char *yydest, const char *yysrc)
-#else
-static char *
-yystpcpy (yydest, yysrc)
-    char *yydest;
-    const char *yysrc;
-#endif
-{
-  char *yyd = yydest;
-  const char *yys = yysrc;
 
-  while ((*yyd++ = *yys++) != '\0')
-    continue;
-
-  return yyd - 1;
-}
-#  endif
-# endif
-
-# ifndef yytnamerr
-/* Copy to YYRES the contents of YYSTR after stripping away unnecessary
-   quotes and backslashes, so that it's suitable for yyerror.  The
-   heuristic is that double-quoting is unnecessary unless the string
-   contains an apostrophe, a comma, or backslash (other than
-   backslash-backslash).  YYSTR is taken from yytname.  If YYRES is
-   null, do not copy; instead, return the length of what the result
-   would have been.  */
-static YYSIZE_T
-yytnamerr (char *yyres, const char *yystr)
-{
-  if (*yystr == '"')
-    {
-      YYSIZE_T yyn = 0;
-      char const *yyp = yystr;
-
-      for (;;)
-	switch (*++yyp)
-	  {
-	  case '\'':
-	  case ',':
-	    goto do_not_strip_quotes;
-
-	  case '\\':
-	    if (*++yyp != '\\')
-	      goto do_not_strip_quotes;
-	    /* Fall through.  */
-	  default:
-	    if (yyres)
-	      yyres[yyn] = *yyp;
-	    yyn++;
-	    break;
-
-	  case '"':
-	    if (yyres)
-	      yyres[yyn] = '\0';
-	    return yyn;
-	  }
-    do_not_strip_quotes: ;
-    }
-
-  if (! yyres)
-    return yystrlen (yystr);
-
-  return yystpcpy (yyres, yystr) - yyres;
-}
-# endif
-
-/* Copy into YYRESULT an error message about the unexpected token
-   YYCHAR while in state YYSTATE.  Return the number of bytes copied,
-   including the terminating null byte.  If YYRESULT is null, do not
-   copy anything; just return the number of bytes that would be
-   copied.  As a special case, return 0 if an ordinary "syntax error"
-   message will do.  Return YYSIZE_MAXIMUM if overflow occurs during
-   size calculation.  */
-static YYSIZE_T
-yysyntax_error (char *yyresult, int yystate, int yychar)
-{
-  int yyn = yypact[yystate];
-
-  if (! (YYPACT_NINF < yyn && yyn <= YYLAST))
-    return 0;
-  else
-    {
-      int yytype = YYTRANSLATE (yychar);
-      YYSIZE_T yysize0 = yytnamerr (0, yytname[yytype]);
-      YYSIZE_T yysize = yysize0;
-      YYSIZE_T yysize1;
-      int yysize_overflow = 0;
-      enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
-      char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
-      int yyx;
-
-# if 0
-      /* This is so xgettext sees the translatable formats that are
-	 constructed on the fly.  */
-      YY_("syntax error, unexpected %s");
-      YY_("syntax error, unexpected %s, expecting %s");
-      YY_("syntax error, unexpected %s, expecting %s or %s");
-      YY_("syntax error, unexpected %s, expecting %s or %s or %s");
-      YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s");
-# endif
-      char *yyfmt;
-      char const *yyf;
-      static char const yyunexpected[] = "syntax error, unexpected %s";
-      static char const yyexpecting[] = ", expecting %s";
-      static char const yyor[] = " or %s";
-      char yyformat[sizeof yyunexpected
-		    + sizeof yyexpecting - 1
-		    + ((YYERROR_VERBOSE_ARGS_MAXIMUM - 2)
-		       * (sizeof yyor - 1))];
-      char const *yyprefix = yyexpecting;
-
-      /* Start YYX at -YYN if negative to avoid negative indexes in
-	 YYCHECK.  */
-      int yyxbegin = yyn < 0 ? -yyn : 0;
-
-      /* Stay within bounds of both yycheck and yytname.  */
-      int yychecklim = YYLAST - yyn + 1;
-      int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-      int yycount = 1;
-
-      yyarg[0] = yytname[yytype];
-      yyfmt = yystpcpy (yyformat, yyunexpected);
-
-      for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-	if (yycheck[yyx + yyn] == yyx && yyx != YYTERROR)
-	  {
-	    if (yycount == YYERROR_VERBOSE_ARGS_MAXIMUM)
-	      {
-		yycount = 1;
-		yysize = yysize0;
-		yyformat[sizeof yyunexpected - 1] = '\0';
-		break;
-	      }
-	    yyarg[yycount++] = yytname[yyx];
-	    yysize1 = yysize + yytnamerr (0, yytname[yyx]);
-	    yysize_overflow |= (yysize1 < yysize);
-	    yysize = yysize1;
-	    yyfmt = yystpcpy (yyfmt, yyprefix);
-	    yyprefix = yyor;
-	  }
-
-      yyf = YY_(yyformat);
-      yysize1 = yysize + yystrlen (yyf);
-      yysize_overflow |= (yysize1 < yysize);
-      yysize = yysize1;
-
-      if (yysize_overflow)
-	return YYSIZE_MAXIMUM;
-
-      if (yyresult)
-	{
-	  /* Avoid sprintf, as that infringes on the user's name space.
-	     Don't have undefined behavior even if the translation
-	     produced a string with the wrong number of "%s"s.  */
-	  char *yyp = yyresult;
-	  int yyi = 0;
-	  while ((*yyp = *yyf) != '\0')
-	    {
-	      if (*yyp == '%' && yyf[1] == 's' && yyi < yycount)
-		{
-		  yyp += yytnamerr (yyp, yyarg[yyi++]);
-		  yyf += 2;
-		}
-	      else
-		{
-		  yyp++;
-		  yyf++;
-		}
-	    }
-	}
-      return yysize;
-    }
-}
-#endif /* YYERROR_VERBOSE */
-
 
 /*-----------------------------------------------.
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
-/*ARGSUSED*/
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 static void
-yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocationp)
-#else
-static void
-yydestruct (yymsg, yytype, yyvaluep, yylocationp)
-    const char *yymsg;
-    int yytype;
-    YYSTYPE *yyvaluep;
-    YYLTYPE *yylocationp;
-#endif
+yydestruct (const char *yymsg,
+            yysymbol_kind_t yykind, YYSTYPE *yyvaluep, YYLTYPE *yylocationp)
 {
-  YYUSE (yyvaluep);
-  YYUSE (yylocationp);
-
+  YY_USE (yyvaluep);
+  YY_USE (yylocationp);
   if (!yymsg)
     yymsg = "Deleting";
-  YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
+  YY_SYMBOL_PRINT (yymsg, yykind, yyvaluep, yylocationp);
 
-  switch (yytype)
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  switch (yykind)
     {
-      case 76: /* "expression" */
+    case YYSYMBOL_expression: /* expression  */
 #line 141 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1668 "./grammar.tab.c"
-	break;
-      case 77: /* "arrowAssign" */
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1462 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_arrowAssign: /* arrowAssign  */
 #line 142 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1673 "./grammar.tab.c"
-	break;
-      case 78: /* "tildeAssign" */
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1468 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_tildeAssign: /* tildeAssign  */
 #line 142 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1678 "./grammar.tab.c"
-	break;
-      case 79: /* "equationAssign" */
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1474 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_equationAssign: /* equationAssign  */
 #line 142 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1683 "./grammar.tab.c"
-	break;
-      case 80: /* "workspaceAssign" */
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1480 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_workspaceAssign: /* workspaceAssign  */
 #line 142 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1688 "./grammar.tab.c"
-	break;
-      case 81: /* "referenceAssign" */
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1486 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_referenceAssign: /* referenceAssign  */
 #line 143 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1693 "./grammar.tab.c"
-	break;
-      case 82: /* "additionAssign" */
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1492 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_additionAssign: /* additionAssign  */
 #line 144 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1698 "./grammar.tab.c"
-	break;
-      case 83: /* "subtractionAssign" */
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1498 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_subtractionAssign: /* subtractionAssign  */
 #line 144 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1703 "./grammar.tab.c"
-	break;
-      case 84: /* "multiplicationAssign" */
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1504 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_multiplicationAssign: /* multiplicationAssign  */
 #line 144 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1510 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_divisionAssign: /* divisionAssign  */
+#line 144 "./grammar.y"
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1516 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_variable: /* variable  */
+#line 140 "./grammar.y"
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1522 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_optElements: /* optElements  */
+#line 136 "./grammar.y"
+            { for (std::list<SyntaxElement*>::iterator it=((*yyvaluep).syntaxElementList)->begin(); it != ((*yyvaluep).syntaxElementList)->end(); it++) { SyntaxElement* theElement = *it; delete theElement; }; delete (((*yyvaluep).syntaxElementList)); }
+#line 1528 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_elementList: /* elementList  */
+#line 136 "./grammar.y"
+            { for (std::list<SyntaxElement*>::iterator it=((*yyvaluep).syntaxElementList)->begin(); it != ((*yyvaluep).syntaxElementList)->end(); it++) { SyntaxElement* theElement = *it; delete theElement; }; delete (((*yyvaluep).syntaxElementList)); }
+#line 1534 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_fxnCall: /* fxnCall  */
+#line 140 "./grammar.y"
+            { delete (((*yyvaluep).syntaxFunctionCall)); }
+#line 1540 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_functionCall: /* functionCall  */
+#line 140 "./grammar.y"
+            { delete (((*yyvaluep).syntaxFunctionCall)); }
+#line 1546 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_optArguments: /* optArguments  */
+#line 137 "./grammar.y"
+            { for (std::list<SyntaxLabeledExpr*>::iterator it=((*yyvaluep).argumentList)->begin(); it != ((*yyvaluep).argumentList)->end(); it++) { SyntaxLabeledExpr* theElement = *it; delete theElement; }; delete (((*yyvaluep).argumentList)); }
+#line 1552 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_argumentList: /* argumentList  */
+#line 137 "./grammar.y"
+            { for (std::list<SyntaxLabeledExpr*>::iterator it=((*yyvaluep).argumentList)->begin(); it != ((*yyvaluep).argumentList)->end(); it++) { SyntaxLabeledExpr* theElement = *it; delete theElement; }; delete (((*yyvaluep).argumentList)); }
+#line 1558 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_argument: /* argument  */
+#line 140 "./grammar.y"
+            { delete (((*yyvaluep).syntaxLabeledExpr)); }
+#line 1564 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_functionDef: /* functionDef  */
+#line 146 "./grammar.y"
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1570 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_procedureDef: /* procedureDef  */
+#line 146 "./grammar.y"
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1576 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_optFormals: /* optFormals  */
+#line 138 "./grammar.y"
+            { for (std::list<SyntaxFormal*>::iterator it=((*yyvaluep).formalList)->begin(); it != ((*yyvaluep).formalList)->end(); it++) { SyntaxFormal* theElement = *it; delete theElement; }; delete (((*yyvaluep).formalList)); }
+#line 1582 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_formalList: /* formalList  */
+#line 138 "./grammar.y"
+            { for (std::list<SyntaxFormal*>::iterator it=((*yyvaluep).formalList)->begin(); it != ((*yyvaluep).formalList)->end(); it++) { SyntaxFormal* theElement = *it; delete theElement; }; delete (((*yyvaluep).formalList)); }
+#line 1588 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_formal: /* formal  */
+#line 140 "./grammar.y"
+            { delete (((*yyvaluep).syntaxFormal)); }
+#line 1594 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_typeSpec: /* typeSpec  */
+#line 139 "./grammar.y"
+            { delete (((*yyvaluep).string)); }
+#line 1600 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_optDims: /* optDims  */
+#line 139 "./grammar.y"
+            { delete (((*yyvaluep).string)); }
+#line 1606 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_dimList: /* dimList  */
+#line 139 "./grammar.y"
+            { delete (((*yyvaluep).string)); }
+#line 1612 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_stmts: /* stmts  */
+#line 136 "./grammar.y"
+            { for (std::list<SyntaxElement*>::iterator it=((*yyvaluep).syntaxElementList)->begin(); it != ((*yyvaluep).syntaxElementList)->end(); it++) { SyntaxElement* theElement = *it; delete theElement; }; delete (((*yyvaluep).syntaxElementList)); }
+#line 1618 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_stmtList: /* stmtList  */
+#line 136 "./grammar.y"
+            { for (std::list<SyntaxElement*>::iterator it=((*yyvaluep).syntaxElementList)->begin(); it != ((*yyvaluep).syntaxElementList)->end(); it++) { SyntaxElement* theElement = *it; delete theElement; }; delete (((*yyvaluep).syntaxElementList)); }
+#line 1624 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_statement: /* statement  */
+#line 141 "./grammar.y"
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1630 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_stmt_or_expr: /* stmt_or_expr  */
+#line 141 "./grammar.y"
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1636 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_declaration: /* declaration  */
+#line 145 "./grammar.y"
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1642 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_memberDefs: /* memberDefs  */
+#line 136 "./grammar.y"
+            { for (std::list<SyntaxElement*>::iterator it=((*yyvaluep).syntaxElementList)->begin(); it != ((*yyvaluep).syntaxElementList)->end(); it++) { SyntaxElement* theElement = *it; delete theElement; }; delete (((*yyvaluep).syntaxElementList)); }
+#line 1648 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_memberDef: /* memberDef  */
+#line 145 "./grammar.y"
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1654 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_classDef: /* classDef  */
+#line 145 "./grammar.y"
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1660 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_ifStatement: /* ifStatement  */
+#line 147 "./grammar.y"
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1666 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_cond: /* cond  */
+#line 148 "./grammar.y"
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1672 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_forStatement: /* forStatement  */
+#line 147 "./grammar.y"
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1678 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_forCond: /* forCond  */
+#line 148 "./grammar.y"
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1684 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_whileStatement: /* whileStatement  */
+#line 147 "./grammar.y"
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1690 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_nextStatement: /* nextStatement  */
+#line 149 "./grammar.y"
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1696 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_breakStatement: /* breakStatement  */
+#line 149 "./grammar.y"
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1702 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_returnStatement: /* returnStatement  */
+#line 148 "./grammar.y"
+            { delete (((*yyvaluep).syntaxElement)); }
 #line 1708 "./grammar.tab.c"
-	break;
-      case 85: /* "divisionAssign" */
-#line 144 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1713 "./grammar.tab.c"
-	break;
-      case 86: /* "variable" */
-#line 140 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1718 "./grammar.tab.c"
-	break;
-      case 87: /* "optElements" */
-#line 136 "./grammar.y"
-	{ for (std::list<SyntaxElement*>::iterator it=(yyvaluep->syntaxElementList)->begin(); it != (yyvaluep->syntaxElementList)->end(); it++) { SyntaxElement* theElement = *it; delete theElement; }; delete ((yyvaluep->syntaxElementList)); };
-#line 1723 "./grammar.tab.c"
-	break;
-      case 88: /* "elementList" */
-#line 136 "./grammar.y"
-	{ for (std::list<SyntaxElement*>::iterator it=(yyvaluep->syntaxElementList)->begin(); it != (yyvaluep->syntaxElementList)->end(); it++) { SyntaxElement* theElement = *it; delete theElement; }; delete ((yyvaluep->syntaxElementList)); };
-#line 1728 "./grammar.tab.c"
-	break;
-      case 89: /* "fxnCall" */
-#line 140 "./grammar.y"
-	{ delete ((yyvaluep->syntaxFunctionCall)); };
-#line 1733 "./grammar.tab.c"
-	break;
-      case 90: /* "functionCall" */
-#line 140 "./grammar.y"
-	{ delete ((yyvaluep->syntaxFunctionCall)); };
-#line 1738 "./grammar.tab.c"
-	break;
-      case 91: /* "optArguments" */
-#line 137 "./grammar.y"
-	{ for (std::list<SyntaxLabeledExpr*>::iterator it=(yyvaluep->argumentList)->begin(); it != (yyvaluep->argumentList)->end(); it++) { SyntaxLabeledExpr* theElement = *it; delete theElement; }; delete ((yyvaluep->argumentList)); };
-#line 1743 "./grammar.tab.c"
-	break;
-      case 92: /* "argumentList" */
-#line 137 "./grammar.y"
-	{ for (std::list<SyntaxLabeledExpr*>::iterator it=(yyvaluep->argumentList)->begin(); it != (yyvaluep->argumentList)->end(); it++) { SyntaxLabeledExpr* theElement = *it; delete theElement; }; delete ((yyvaluep->argumentList)); };
-#line 1748 "./grammar.tab.c"
-	break;
-      case 93: /* "argument" */
-#line 140 "./grammar.y"
-	{ delete ((yyvaluep->syntaxLabeledExpr)); };
-#line 1753 "./grammar.tab.c"
-	break;
-      case 94: /* "functionDef" */
-#line 146 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1758 "./grammar.tab.c"
-	break;
-      case 95: /* "procedureDef" */
-#line 146 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1763 "./grammar.tab.c"
-	break;
-      case 96: /* "optFormals" */
-#line 138 "./grammar.y"
-	{ for (std::list<SyntaxFormal*>::iterator it=(yyvaluep->formalList)->begin(); it != (yyvaluep->formalList)->end(); it++) { SyntaxFormal* theElement = *it; delete theElement; }; delete ((yyvaluep->formalList)); };
-#line 1768 "./grammar.tab.c"
-	break;
-      case 97: /* "formalList" */
-#line 138 "./grammar.y"
-	{ for (std::list<SyntaxFormal*>::iterator it=(yyvaluep->formalList)->begin(); it != (yyvaluep->formalList)->end(); it++) { SyntaxFormal* theElement = *it; delete theElement; }; delete ((yyvaluep->formalList)); };
-#line 1773 "./grammar.tab.c"
-	break;
-      case 98: /* "formal" */
-#line 140 "./grammar.y"
-	{ delete ((yyvaluep->syntaxFormal)); };
-#line 1778 "./grammar.tab.c"
-	break;
-      case 99: /* "typeSpec" */
+        break;
+
+    case YYSYMBOL_identifier: /* identifier  */
 #line 139 "./grammar.y"
-	{ delete ((yyvaluep->string)); };
-#line 1783 "./grammar.tab.c"
-	break;
-      case 100: /* "optDims" */
-#line 139 "./grammar.y"
-	{ delete ((yyvaluep->string)); };
-#line 1788 "./grammar.tab.c"
-	break;
-      case 101: /* "dimList" */
-#line 139 "./grammar.y"
-	{ delete ((yyvaluep->string)); };
-#line 1793 "./grammar.tab.c"
-	break;
-      case 102: /* "stmts" */
-#line 136 "./grammar.y"
-	{ for (std::list<SyntaxElement*>::iterator it=(yyvaluep->syntaxElementList)->begin(); it != (yyvaluep->syntaxElementList)->end(); it++) { SyntaxElement* theElement = *it; delete theElement; }; delete ((yyvaluep->syntaxElementList)); };
-#line 1798 "./grammar.tab.c"
-	break;
-      case 103: /* "stmtList" */
-#line 136 "./grammar.y"
-	{ for (std::list<SyntaxElement*>::iterator it=(yyvaluep->syntaxElementList)->begin(); it != (yyvaluep->syntaxElementList)->end(); it++) { SyntaxElement* theElement = *it; delete theElement; }; delete ((yyvaluep->syntaxElementList)); };
-#line 1803 "./grammar.tab.c"
-	break;
-      case 104: /* "statement" */
-#line 141 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1808 "./grammar.tab.c"
-	break;
-      case 105: /* "stmt_or_expr" */
-#line 141 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1813 "./grammar.tab.c"
-	break;
-      case 106: /* "declaration" */
-#line 145 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1818 "./grammar.tab.c"
-	break;
-      case 107: /* "memberDefs" */
-#line 136 "./grammar.y"
-	{ for (std::list<SyntaxElement*>::iterator it=(yyvaluep->syntaxElementList)->begin(); it != (yyvaluep->syntaxElementList)->end(); it++) { SyntaxElement* theElement = *it; delete theElement; }; delete ((yyvaluep->syntaxElementList)); };
-#line 1823 "./grammar.tab.c"
-	break;
-      case 108: /* "memberDef" */
-#line 145 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1828 "./grammar.tab.c"
-	break;
-      case 109: /* "classDef" */
-#line 145 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1833 "./grammar.tab.c"
-	break;
-      case 110: /* "ifStatement" */
-#line 147 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1838 "./grammar.tab.c"
-	break;
-      case 111: /* "cond" */
-#line 148 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1843 "./grammar.tab.c"
-	break;
-      case 112: /* "forStatement" */
-#line 147 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1848 "./grammar.tab.c"
-	break;
-      case 113: /* "forCond" */
-#line 148 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1853 "./grammar.tab.c"
-	break;
-      case 114: /* "whileStatement" */
-#line 147 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1858 "./grammar.tab.c"
-	break;
-      case 115: /* "nextStatement" */
-#line 149 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1863 "./grammar.tab.c"
-	break;
-      case 116: /* "breakStatement" */
-#line 149 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1868 "./grammar.tab.c"
-	break;
-      case 117: /* "returnStatement" */
-#line 148 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1873 "./grammar.tab.c"
-	break;
-      case 118: /* "identifier" */
-#line 139 "./grammar.y"
-	{ delete ((yyvaluep->string)); };
-#line 1878 "./grammar.tab.c"
-	break;
-      case 119: /* "vector" */
+            { delete (((*yyvaluep).string)); }
+#line 1714 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_vector: /* vector  */
 #line 137 "./grammar.y"
-	{ for (std::list<SyntaxLabeledExpr*>::iterator it=(yyvaluep->argumentList)->begin(); it != (yyvaluep->argumentList)->end(); it++) { SyntaxLabeledExpr* theElement = *it; delete theElement; }; delete ((yyvaluep->argumentList)); };
-#line 1883 "./grammar.tab.c"
-	break;
-      case 120: /* "vectorList" */
+            { for (std::list<SyntaxLabeledExpr*>::iterator it=((*yyvaluep).argumentList)->begin(); it != ((*yyvaluep).argumentList)->end(); it++) { SyntaxLabeledExpr* theElement = *it; delete theElement; }; delete (((*yyvaluep).argumentList)); }
+#line 1720 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_vectorList: /* vectorList  */
 #line 137 "./grammar.y"
-	{ for (std::list<SyntaxLabeledExpr*>::iterator it=(yyvaluep->argumentList)->begin(); it != (yyvaluep->argumentList)->end(); it++) { SyntaxLabeledExpr* theElement = *it; delete theElement; }; delete ((yyvaluep->argumentList)); };
-#line 1888 "./grammar.tab.c"
-	break;
-      case 121: /* "constant" */
+            { for (std::list<SyntaxLabeledExpr*>::iterator it=((*yyvaluep).argumentList)->begin(); it != ((*yyvaluep).argumentList)->end(); it++) { SyntaxLabeledExpr* theElement = *it; delete theElement; }; delete (((*yyvaluep).argumentList)); }
+#line 1726 "./grammar.tab.c"
+        break;
+
+    case YYSYMBOL_constant: /* constant  */
 #line 140 "./grammar.y"
-	{ delete ((yyvaluep->syntaxElement)); };
-#line 1893 "./grammar.tab.c"
-	break;
+            { delete (((*yyvaluep).syntaxElement)); }
+#line 1732 "./grammar.tab.c"
+        break;
 
       default:
-	break;
+        break;
     }
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
-
-
-/* Prevent warnings from -Wmissing-prototypes.  */
-
-#ifdef YYPARSE_PARAM
-#if defined __STDC__ || defined __cplusplus
-int yyparse (void *YYPARSE_PARAM);
-#else
-int yyparse ();
-#endif
-#else /* ! YYPARSE_PARAM */
-#if defined __STDC__ || defined __cplusplus
-int yyparse (void);
-#else
-int yyparse ();
-#endif
-#endif /* ! YYPARSE_PARAM */
 
 
-
-/* The look-ahead symbol.  */
+/* Lookahead token kind.  */
 int yychar;
 
-/* The semantic value of the look-ahead symbol.  */
+/* The semantic value of the lookahead symbol.  */
 YYSTYPE yylval;
-
+/* Location data for the lookahead symbol.  */
+YYLTYPE yylloc
+# if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
+  = { 1, 1, 1, 1 }
+# endif
+;
 /* Number of syntax errors so far.  */
 int yynerrs;
-/* Location data for the look-ahead symbol.  */
-YYLTYPE yylloc;
+
 
 
 
@@ -1938,76 +1759,50 @@ YYLTYPE yylloc;
 | yyparse.  |
 `----------*/
 
-#ifdef YYPARSE_PARAM
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
-int
-yyparse (void *YYPARSE_PARAM)
-#else
-int
-yyparse (YYPARSE_PARAM)
-    void *YYPARSE_PARAM;
-#endif
-#else /* ! YYPARSE_PARAM */
-#if (defined __STDC__ || defined __C99__FUNC__ \
-     || defined __cplusplus || defined _MSC_VER)
 int
 yyparse (void)
-#else
-int
-yyparse ()
-
-#endif
-#endif
 {
-  
-  int yystate;
+    yy_state_fast_t yystate = 0;
+    /* Number of tokens to shift before error messages enabled.  */
+    int yyerrstatus = 0;
+
+    /* Refer to the stacks through separate pointers, to allow yyoverflow
+       to reallocate them elsewhere.  */
+
+    /* Their size.  */
+    YYPTRDIFF_T yystacksize = YYINITDEPTH;
+
+    /* The state stack: array, bottom, top.  */
+    yy_state_t yyssa[YYINITDEPTH];
+    yy_state_t *yyss = yyssa;
+    yy_state_t *yyssp = yyss;
+
+    /* The semantic value stack: array, bottom, top.  */
+    YYSTYPE yyvsa[YYINITDEPTH];
+    YYSTYPE *yyvs = yyvsa;
+    YYSTYPE *yyvsp = yyvs;
+
+    /* The location stack: array, bottom, top.  */
+    YYLTYPE yylsa[YYINITDEPTH];
+    YYLTYPE *yyls = yylsa;
+    YYLTYPE *yylsp = yyls;
+
   int yyn;
+  /* The return value of yyparse.  */
   int yyresult;
-  /* Number of tokens to shift before error messages enabled.  */
-  int yyerrstatus;
-  /* Look-ahead token as an internal (translated) token number.  */
-  int yytoken = 0;
-#if YYERROR_VERBOSE
-  /* Buffer for error messages, and its allocated size.  */
-  char yymsgbuf[128];
-  char *yymsg = yymsgbuf;
-  YYSIZE_T yymsg_alloc = sizeof yymsgbuf;
-#endif
-
-  /* Three stacks and their tools:
-     `yyss': related to states,
-     `yyvs': related to semantic values,
-     `yyls': related to locations.
-
-     Refer to the stacks thru separate pointers, to allow yyoverflow
-     to reallocate them elsewhere.  */
-
-  /* The state stack.  */
-  yytype_int16 yyssa[YYINITDEPTH];
-  yytype_int16 *yyss = yyssa;
-  yytype_int16 *yyssp;
-
-  /* The semantic value stack.  */
-  YYSTYPE yyvsa[YYINITDEPTH];
-  YYSTYPE *yyvs = yyvsa;
-  YYSTYPE *yyvsp;
-
-  /* The location stack.  */
-  YYLTYPE yylsa[YYINITDEPTH];
-  YYLTYPE *yyls = yylsa;
-  YYLTYPE *yylsp;
-  /* The locations where the error started and ended.  */
-  YYLTYPE yyerror_range[2];
-
-#define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N), yylsp -= (N))
-
-  YYSIZE_T yystacksize = YYINITDEPTH;
-
+  /* Lookahead symbol kind.  */
+  yysymbol_kind_t yytoken = YYSYMBOL_YYEMPTY;
   /* The variables used to return semantic value and location from the
      action routines.  */
   YYSTYPE yyval;
   YYLTYPE yyloc;
+
+  /* The locations where the error started and ended.  */
+  YYLTYPE yyerror_range[3];
+
+
+
+#define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N), yylsp -= (N))
 
   /* The number of symbols on the RHS of the reduced rule.
      Keep to zero when no symbol should be popped.  */
@@ -2015,133 +1810,144 @@ yyparse ()
 
   YYDPRINTF ((stderr, "Starting parse\n"));
 
-  yystate = 0;
-  yyerrstatus = 0;
-  yynerrs = 0;
-  yychar = YYEMPTY;		/* Cause a token to be read.  */
+  yychar = YYEMPTY; /* Cause a token to be read.  */
 
-  /* Initialize stack pointers.
-     Waste one element of value and location stack
-     so that they stay on the same level as the state stack.
-     The wasted elements are never initialized.  */
-
-  yyssp = yyss;
-  yyvsp = yyvs;
-  yylsp = yyls;
-#if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
-  /* Initialize the default location before parsing starts.  */
-  yylloc.first_line   = yylloc.last_line   = 1;
-  yylloc.first_column = yylloc.last_column = 0;
-#endif
-
+  yylsp[0] = yylloc;
   goto yysetstate;
 
+
 /*------------------------------------------------------------.
-| yynewstate -- Push a new state, which is found in yystate.  |
+| yynewstate -- push a new state, which is found in yystate.  |
 `------------------------------------------------------------*/
- yynewstate:
+yynewstate:
   /* In all cases, when you get here, the value and location stacks
      have just been pushed.  So pushing a state here evens the stacks.  */
   yyssp++;
 
- yysetstate:
-  *yyssp = yystate;
+
+/*--------------------------------------------------------------------.
+| yysetstate -- set current state (the top of the stack) to yystate.  |
+`--------------------------------------------------------------------*/
+yysetstate:
+  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+  YY_ASSERT (0 <= yystate && yystate < YYNSTATES);
+  YY_IGNORE_USELESS_CAST_BEGIN
+  *yyssp = YY_CAST (yy_state_t, yystate);
+  YY_IGNORE_USELESS_CAST_END
+  YY_STACK_PRINT (yyss, yyssp);
 
   if (yyss + yystacksize - 1 <= yyssp)
+#if !defined yyoverflow && !defined YYSTACK_RELOCATE
+    YYNOMEM;
+#else
     {
       /* Get the current used size of the three stacks, in elements.  */
-      YYSIZE_T yysize = yyssp - yyss + 1;
+      YYPTRDIFF_T yysize = yyssp - yyss + 1;
 
-#ifdef yyoverflow
+# if defined yyoverflow
       {
-	/* Give user a chance to reallocate the stack.  Use copies of
-	   these so that the &'s don't force the real ones into
-	   memory.  */
-	YYSTYPE *yyvs1 = yyvs;
-	yytype_int16 *yyss1 = yyss;
-	YYLTYPE *yyls1 = yyls;
+        /* Give user a chance to reallocate the stack.  Use copies of
+           these so that the &'s don't force the real ones into
+           memory.  */
+        yy_state_t *yyss1 = yyss;
+        YYSTYPE *yyvs1 = yyvs;
+        YYLTYPE *yyls1 = yyls;
 
-	/* Each stack pointer address is followed by the size of the
-	   data in use in that stack, in bytes.  This used to be a
-	   conditional around just the two extra args, but that might
-	   be undefined if yyoverflow is a macro.  */
-	yyoverflow (YY_("memory exhausted"),
-		    &yyss1, yysize * sizeof (*yyssp),
-		    &yyvs1, yysize * sizeof (*yyvsp),
-		    &yyls1, yysize * sizeof (*yylsp),
-		    &yystacksize);
-	yyls = yyls1;
-	yyss = yyss1;
-	yyvs = yyvs1;
+        /* Each stack pointer address is followed by the size of the
+           data in use in that stack, in bytes.  This used to be a
+           conditional around just the two extra args, but that might
+           be undefined if yyoverflow is a macro.  */
+        yyoverflow (YY_("memory exhausted"),
+                    &yyss1, yysize * YYSIZEOF (*yyssp),
+                    &yyvs1, yysize * YYSIZEOF (*yyvsp),
+                    &yyls1, yysize * YYSIZEOF (*yylsp),
+                    &yystacksize);
+        yyss = yyss1;
+        yyvs = yyvs1;
+        yyls = yyls1;
       }
-#else /* no yyoverflow */
-# ifndef YYSTACK_RELOCATE
-      goto yyexhaustedlab;
-# else
+# else /* defined YYSTACK_RELOCATE */
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
-	goto yyexhaustedlab;
+        YYNOMEM;
       yystacksize *= 2;
       if (YYMAXDEPTH < yystacksize)
-	yystacksize = YYMAXDEPTH;
+        yystacksize = YYMAXDEPTH;
 
       {
-	yytype_int16 *yyss1 = yyss;
-	union yyalloc *yyptr =
-	  (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
-	if (! yyptr)
-	  goto yyexhaustedlab;
-	YYSTACK_RELOCATE (yyss);
-	YYSTACK_RELOCATE (yyvs);
-	YYSTACK_RELOCATE (yyls);
+        yy_state_t *yyss1 = yyss;
+        union yyalloc *yyptr =
+          YY_CAST (union yyalloc *,
+                   YYSTACK_ALLOC (YY_CAST (YYSIZE_T, YYSTACK_BYTES (yystacksize))));
+        if (! yyptr)
+          YYNOMEM;
+        YYSTACK_RELOCATE (yyss_alloc, yyss);
+        YYSTACK_RELOCATE (yyvs_alloc, yyvs);
+        YYSTACK_RELOCATE (yyls_alloc, yyls);
 #  undef YYSTACK_RELOCATE
-	if (yyss1 != yyssa)
-	  YYSTACK_FREE (yyss1);
+        if (yyss1 != yyssa)
+          YYSTACK_FREE (yyss1);
       }
 # endif
-#endif /* no yyoverflow */
 
       yyssp = yyss + yysize - 1;
       yyvsp = yyvs + yysize - 1;
       yylsp = yyls + yysize - 1;
 
-      YYDPRINTF ((stderr, "Stack size increased to %lu\n",
-		  (unsigned long int) yystacksize));
+      YY_IGNORE_USELESS_CAST_BEGIN
+      YYDPRINTF ((stderr, "Stack size increased to %ld\n",
+                  YY_CAST (long, yystacksize)));
+      YY_IGNORE_USELESS_CAST_END
 
       if (yyss + yystacksize - 1 <= yyssp)
-	YYABORT;
+        YYABORT;
     }
+#endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
 
-  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+
+  if (yystate == YYFINAL)
+    YYACCEPT;
 
   goto yybackup;
+
 
 /*-----------.
 | yybackup.  |
 `-----------*/
 yybackup:
-
   /* Do appropriate processing given the current state.  Read a
-     look-ahead token if we need one and don't already have one.  */
+     lookahead token if we need one and don't already have one.  */
 
-  /* First try to decide what to do without reference to look-ahead token.  */
+  /* First try to decide what to do without reference to lookahead token.  */
   yyn = yypact[yystate];
-  if (yyn == YYPACT_NINF)
+  if (yypact_value_is_default (yyn))
     goto yydefault;
 
-  /* Not known => get a look-ahead token if don't already have one.  */
+  /* Not known => get a lookahead token if don't already have one.  */
 
-  /* YYCHAR is either YYEMPTY or YYEOF or a valid look-ahead symbol.  */
+  /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
   if (yychar == YYEMPTY)
     {
-      YYDPRINTF ((stderr, "Reading a token: "));
-      yychar = YYLEX;
+      YYDPRINTF ((stderr, "Reading a token\n"));
+      yychar = yylex ();
     }
 
   if (yychar <= YYEOF)
     {
-      yychar = yytoken = YYEOF;
+      yychar = YYEOF;
+      yytoken = YYSYMBOL_YYEOF;
       YYDPRINTF ((stderr, "Now at end of input.\n"));
+    }
+  else if (yychar == YYerror)
+    {
+      /* The scanner already issued an error message, process directly
+         to error recovery.  But do not keep the error token as
+         lookahead, it is too special and may lead us to an endless
+         loop in error recovery. */
+      yychar = YYUNDEF;
+      yytoken = YYSYMBOL_YYerror;
+      yyerror_range[1] = yylloc;
+      goto yyerrlab1;
     }
   else
     {
@@ -2157,30 +1963,27 @@ yybackup:
   yyn = yytable[yyn];
   if (yyn <= 0)
     {
-      if (yyn == 0 || yyn == YYTABLE_NINF)
-	goto yyerrlab;
+      if (yytable_value_is_error (yyn))
+        goto yyerrlab;
       yyn = -yyn;
       goto yyreduce;
     }
-
-  if (yyn == YYFINAL)
-    YYACCEPT;
 
   /* Count tokens shifted since error; after three, turn off error
      status.  */
   if (yyerrstatus)
     yyerrstatus--;
 
-  /* Shift the look-ahead token.  */
+  /* Shift the lookahead token.  */
   YY_SYMBOL_PRINT ("Shifting", yytoken, &yylval, &yylloc);
-
-  /* Discard the shifted token unless it is eof.  */
-  if (yychar != YYEOF)
-    yychar = YYEMPTY;
-
   yystate = yyn;
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
   *++yylsp = yylloc;
+
+  /* Discard the shifted token.  */
+  yychar = YYEMPTY;
   goto yynewstate;
 
 
@@ -2195,14 +1998,14 @@ yydefault:
 
 
 /*-----------------------------.
-| yyreduce -- Do a reduction.  |
+| yyreduce -- do a reduction.  |
 `-----------------------------*/
 yyreduce:
   /* yyn is the number of a rule to reduce with.  */
   yylen = yyr2[yyn];
 
   /* If YYLEN is nonzero, implement the default value of the action:
-     `$$ = $1'.
+     '$$ = $1'.
 
      Otherwise, the following line sets YYVAL to garbage.
      This behavior is undocumented and Bison
@@ -2211,1094 +2014,1250 @@ yyreduce:
      GCC warning that YYVAL may be used uninitialized.  */
   yyval = yyvsp[1-yylen];
 
-  /* Default location.  */
+  /* Default location. */
   YYLLOC_DEFAULT (yyloc, (yylsp - yylen), yylen);
+  yyerror_range[1] = yyloc;
   YY_REDUCE_PRINT (yyn);
   switch (yyn)
     {
-        case 2:
+  case 2: /* prog: END_OF_INPUT  */
 #line 235 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Bison encountered end_of_input; ignored\n");
 #endif
                     return 0;
                 }
+#line 2032 "./grammar.tab.c"
     break;
 
-  case 3:
+  case 3: /* prog: '\n'  */
 #line 242 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Bison encountered newline; ignored\n");
 #endif
                     return 0;
                 }
+#line 2043 "./grammar.tab.c"
     break;
 
-  case 4:
+  case 4: /* prog: stmt_or_expr '\n'  */
 #line 249 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Bison trying to execute statement or expression\n");
 #endif
-                    int rv = parser.execute((yyvsp[(1) - (2)].syntaxElement), *executionEnvironment);
-                    delete (yyvsp[(1) - (2)].syntaxElement);
+                    int rv = parser.execute((yyvsp[-1].syntaxElement), *executionEnvironment);
+                    delete (yyvsp[-1].syntaxElement);
                     return rv;
                 }
+#line 2056 "./grammar.tab.c"
     break;
 
-  case 5:
+  case 5: /* prog: stmt_or_expr ';'  */
 #line 258 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Bison trying to execute statement or expression\n");
 #endif
-                    int rv =  parser.execute((yyvsp[(1) - (2)].syntaxElement), *executionEnvironment);
-                    delete (yyvsp[(1) - (2)].syntaxElement);
+                    int rv =  parser.execute((yyvsp[-1].syntaxElement), *executionEnvironment);
+                    delete (yyvsp[-1].syntaxElement);
                     return rv;
                 }
+#line 2069 "./grammar.tab.c"
     break;
 
-  case 6:
+  case 6: /* prog: declaration '\n'  */
 #line 267 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Bison trying to execute declaration\n");
 #endif
-                    int rv =  parser.execute((yyvsp[(1) - (2)].syntaxElement), *executionEnvironment);
-                    delete (yyvsp[(1) - (2)].syntaxElement);
+                    int rv =  parser.execute((yyvsp[-1].syntaxElement), *executionEnvironment);
+                    delete (yyvsp[-1].syntaxElement);
                     return rv;
                 }
+#line 2082 "./grammar.tab.c"
     break;
 
-  case 7:
+  case 7: /* prog: declaration ';'  */
 #line 276 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Bison trying to execute declaration\n");
 #endif
-                    int rv =  parser.execute((yyvsp[(1) - (2)].syntaxElement), *executionEnvironment);
-                    delete (yyvsp[(1) - (2)].syntaxElement);
+                    int rv =  parser.execute((yyvsp[-1].syntaxElement), *executionEnvironment);
+                    delete (yyvsp[-1].syntaxElement);
                     return rv;
                 }
+#line 2095 "./grammar.tab.c"
     break;
 
-  case 8:
+  case 8: /* prog: '?' identifier '\n'  */
 #line 285 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Bison trying to get help for symbol\n");
 #endif
-                    int rv =  parser.help(*(yyvsp[(2) - (3)].string));
-                    delete (yyvsp[(2) - (3)].string);
+                    int rv =  parser.help(*(yyvsp[-1].string));
+                    delete (yyvsp[-1].string);
                     return rv;
                 }
+#line 2108 "./grammar.tab.c"
     break;
 
-  case 9:
+  case 9: /* prog: '?' identifier ';'  */
 #line 294 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Bison trying to get help for symbol\n");
 #endif
-                    int rv =  parser.help(*(yyvsp[(2) - (3)].string));
-                    delete (yyvsp[(2) - (3)].string);
+                    int rv =  parser.help(*(yyvsp[-1].string));
+                    delete (yyvsp[-1].string);
                     return rv;
                 }
+#line 2121 "./grammar.tab.c"
     break;
 
-  case 10:
+  case 10: /* prog: '?' identifier '.' identifier '\n'  */
 #line 303 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Bison trying to get help for symbol\n");
 #endif
-                    int rv =  parser.help(*(yyvsp[(2) - (5)].string), *(yyvsp[(4) - (5)].string));
-                    delete (yyvsp[(2) - (5)].string);
-                    delete (yyvsp[(4) - (5)].string);
+                    int rv =  parser.help(*(yyvsp[-3].string), *(yyvsp[-1].string));
+                    delete (yyvsp[-3].string);
+                    delete (yyvsp[-1].string);
                     return rv;
                 }
+#line 2135 "./grammar.tab.c"
     break;
 
-  case 11:
+  case 11: /* prog: '?' identifier '.' identifier ';'  */
 #line 313 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                 printf("Bison trying to get help for symbol\n");
 #endif
-                int rv =  parser.help(*(yyvsp[(2) - (5)].string), *(yyvsp[(4) - (5)].string));
-                delete (yyvsp[(2) - (5)].string);
-                delete (yyvsp[(4) - (5)].string);
+                int rv =  parser.help(*(yyvsp[-3].string), *(yyvsp[-1].string));
+                delete (yyvsp[-3].string);
+                delete (yyvsp[-1].string);
                 return rv;
                 }
+#line 2149 "./grammar.tab.c"
     break;
 
-  case 12:
+  case 12: /* prog: '?' functionCall '\n'  */
 #line 323 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Bison trying to get help for function call\n");
 #endif
-                    int rv =  parser.help((yyvsp[(2) - (3)].syntaxFunctionCall));
-                    delete (yyvsp[(2) - (3)].syntaxFunctionCall);
+                    int rv =  parser.help((yyvsp[-1].syntaxFunctionCall));
+                    delete (yyvsp[-1].syntaxFunctionCall);
                     return rv;
                 }
+#line 2162 "./grammar.tab.c"
     break;
 
-  case 13:
+  case 13: /* prog: '?' functionCall ';'  */
 #line 332 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Bison trying to get help for function call\n");
 #endif
-                    int rv =  parser.help((yyvsp[(2) - (3)].syntaxFunctionCall));
-                    delete (yyvsp[(2) - (3)].syntaxFunctionCall);
+                    int rv =  parser.help((yyvsp[-1].syntaxFunctionCall));
+                    delete (yyvsp[-1].syntaxFunctionCall);
                     return rv;
                 }
+#line 2175 "./grammar.tab.c"
     break;
 
-  case 14:
+  case 14: /* prog: error '\n'  */
 #line 341 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Bison error when reading line %d position %d to line %d position %d\n", (yyloc).first_line, (yyloc).first_column, (yyloc).last_line, (yyloc).last_column);
 #endif
                     YYABORT;
                 }
+#line 2186 "./grammar.tab.c"
     break;
 
-  case 15:
+  case 15: /* prog: error ';'  */
 #line 348 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Bison error when reading line %d position %d to line %d position %d\n", (yyloc).first_line, (yyloc).first_column, (yyloc).last_line, (yyloc).last_column);
 #endif
                     YYABORT;
                 }
+#line 2197 "./grammar.tab.c"
     break;
 
-  case 16:
+  case 16: /* expression: constant  */
 #line 356 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                            { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 2203 "./grammar.tab.c"
     break;
 
-  case 17:
+  case 17: /* expression: vector  */
 #line 358 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxFunctionCall("v", (yyvsp[(1) - (1)].argumentList)); }
+                                            { (yyval.syntaxElement) = new SyntaxFunctionCall("v", (yyvsp[0].argumentList)); }
+#line 2209 "./grammar.tab.c"
     break;
 
-  case 18:
+  case 18: /* expression: '(' expression ')'  */
 #line 360 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(2) - (3)].syntaxElement); }
+                                            { (yyval.syntaxElement) = (yyvsp[-1].syntaxElement); }
+#line 2215 "./grammar.tab.c"
     break;
 
-  case 19:
+  case 19: /* expression: '-' expression  */
 #line 362 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxUnaryExpr(SyntaxUnaryExpr::UMinus, (yyvsp[(2) - (2)].syntaxElement)); }
+                                            { (yyval.syntaxElement) = new SyntaxUnaryExpr(SyntaxUnaryExpr::UMinus, (yyvsp[0].syntaxElement)); }
+#line 2221 "./grammar.tab.c"
     break;
 
-  case 20:
+  case 20: /* expression: '+' expression  */
 #line 363 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxUnaryExpr(SyntaxUnaryExpr::UPlus, (yyvsp[(2) - (2)].syntaxElement)); }
+                                            { (yyval.syntaxElement) = new SyntaxUnaryExpr(SyntaxUnaryExpr::UPlus, (yyvsp[0].syntaxElement)); }
+#line 2227 "./grammar.tab.c"
     break;
 
-  case 21:
+  case 21: /* expression: '!' expression  */
 #line 364 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxUnaryExpr(SyntaxUnaryExpr::UNot, (yyvsp[(2) - (2)].syntaxElement)); }
+                                            { (yyval.syntaxElement) = new SyntaxUnaryExpr(SyntaxUnaryExpr::UNot, (yyvsp[0].syntaxElement)); }
+#line 2233 "./grammar.tab.c"
     break;
 
-  case 22:
+  case 22: /* expression: AND expression  */
 #line 365 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxUnaryExpr(SyntaxUnaryExpr::UAnd, (yyvsp[(2) - (2)].syntaxElement)); }
+                                            { (yyval.syntaxElement) = new SyntaxUnaryExpr(SyntaxUnaryExpr::UAnd, (yyvsp[0].syntaxElement)); }
+#line 2239 "./grammar.tab.c"
     break;
 
-  case 23:
+  case 23: /* expression: DECREMENT variable  */
 #line 367 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxDecrement( (yyvsp[(2) - (2)].syntaxElement), false ); }
+                                            { (yyval.syntaxElement) = new SyntaxDecrement( (yyvsp[0].syntaxElement), false ); }
+#line 2245 "./grammar.tab.c"
     break;
 
-  case 24:
+  case 24: /* expression: variable DECREMENT  */
 #line 368 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxDecrement( (yyvsp[(1) - (2)].syntaxElement), true ); }
+                                            { (yyval.syntaxElement) = new SyntaxDecrement( (yyvsp[-1].syntaxElement), true ); }
+#line 2251 "./grammar.tab.c"
     break;
 
-  case 25:
+  case 25: /* expression: INCREMENT variable  */
 #line 369 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxIncrement( (yyvsp[(2) - (2)].syntaxElement), false ); }
+                                            { (yyval.syntaxElement) = new SyntaxIncrement( (yyvsp[0].syntaxElement), false ); }
+#line 2257 "./grammar.tab.c"
     break;
 
-  case 26:
+  case 26: /* expression: variable INCREMENT  */
 #line 370 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxIncrement( (yyvsp[(1) - (2)].syntaxElement), true ); }
+                                            { (yyval.syntaxElement) = new SyntaxIncrement( (yyvsp[-1].syntaxElement), true ); }
+#line 2263 "./grammar.tab.c"
     break;
 
-  case 27:
+  case 27: /* expression: expression ':' expression  */
 #line 372 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Range, (yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement)); }
+                                            { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Range, (yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement)); }
+#line 2269 "./grammar.tab.c"
     break;
 
-  case 28:
+  case 28: /* expression: expression '+' expression  */
 #line 374 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Add, (yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement)); }
+                                            { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Add, (yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement)); }
+#line 2275 "./grammar.tab.c"
     break;
 
-  case 29:
+  case 29: /* expression: expression '-' expression  */
 #line 375 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Sub, (yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement)); }
+                                            { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Sub, (yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement)); }
+#line 2281 "./grammar.tab.c"
     break;
 
-  case 30:
+  case 30: /* expression: expression '*' expression  */
 #line 376 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Mul, (yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement)); }
+                                            { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Mul, (yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement)); }
+#line 2287 "./grammar.tab.c"
     break;
 
-  case 31:
+  case 31: /* expression: expression '/' expression  */
 #line 377 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Div, (yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement)); }
+                                            { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Div, (yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement)); }
+#line 2293 "./grammar.tab.c"
     break;
 
-  case 32:
+  case 32: /* expression: expression '^' expression  */
 #line 378 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Exp, (yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement)); }
+                                            { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Exp, (yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement)); }
+#line 2299 "./grammar.tab.c"
     break;
 
-  case 33:
+  case 33: /* expression: expression '%' expression  */
 #line 379 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Mod, (yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement)); }
+                                            { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Mod, (yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement)); }
+#line 2305 "./grammar.tab.c"
     break;
 
-  case 34:
+  case 34: /* expression: expression LT expression  */
 #line 381 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Lt, (yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement)); }
+                                            { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Lt, (yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement)); }
+#line 2311 "./grammar.tab.c"
     break;
 
-  case 35:
+  case 35: /* expression: expression LE expression  */
 #line 382 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Le, (yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement)); }
+                                            { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Le, (yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement)); }
+#line 2317 "./grammar.tab.c"
     break;
 
-  case 36:
+  case 36: /* expression: expression EQ expression  */
 #line 383 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Eq, (yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement)); }
+                                            { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Eq, (yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement)); }
+#line 2323 "./grammar.tab.c"
     break;
 
-  case 37:
+  case 37: /* expression: expression NE expression  */
 #line 384 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Ne, (yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement)); }
+                                            { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Ne, (yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement)); }
+#line 2329 "./grammar.tab.c"
     break;
 
-  case 38:
+  case 38: /* expression: expression GE expression  */
 #line 385 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Ge, (yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement)); }
+                                            { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Ge, (yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement)); }
+#line 2335 "./grammar.tab.c"
     break;
 
-  case 39:
+  case 39: /* expression: expression GT expression  */
 #line 386 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Gt, (yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement)); }
+                                            { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Gt, (yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement)); }
+#line 2341 "./grammar.tab.c"
     break;
 
-  case 40:
+  case 40: /* expression: expression AND expression  */
 #line 388 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::And, (yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement)); }
+                                            { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::And, (yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement)); }
+#line 2347 "./grammar.tab.c"
     break;
 
-  case 41:
+  case 41: /* expression: expression OR expression  */
 #line 389 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Or, (yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement)); }
+                                            { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Or, (yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement)); }
+#line 2353 "./grammar.tab.c"
     break;
 
-  case 42:
+  case 42: /* expression: expression AND2 expression  */
 #line 390 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::And2, (yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement)); }
+                                            { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::And2, (yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement)); }
+#line 2359 "./grammar.tab.c"
     break;
 
-  case 43:
+  case 43: /* expression: expression OR2 expression  */
 #line 391 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Or2, (yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement)); }
+                                            { (yyval.syntaxElement) = new SyntaxBinaryExpr(SyntaxBinaryExpr::Or2, (yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement)); }
+#line 2365 "./grammar.tab.c"
     break;
 
-  case 44:
+  case 44: /* expression: arrowAssign  */
 #line 393 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                            { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 2371 "./grammar.tab.c"
     break;
 
-  case 45:
+  case 45: /* expression: equationAssign  */
 #line 394 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                            { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 2377 "./grammar.tab.c"
     break;
 
-  case 46:
+  case 46: /* expression: tildeAssign  */
 #line 395 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                            { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 2383 "./grammar.tab.c"
     break;
 
-  case 47:
+  case 47: /* expression: workspaceAssign  */
 #line 396 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                            { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 2389 "./grammar.tab.c"
     break;
 
-  case 48:
+  case 48: /* expression: referenceAssign  */
 #line 397 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                            { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 2395 "./grammar.tab.c"
     break;
 
-  case 49:
+  case 49: /* expression: additionAssign  */
 #line 399 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                            { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 2401 "./grammar.tab.c"
     break;
 
-  case 50:
+  case 50: /* expression: subtractionAssign  */
 #line 400 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                            { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 2407 "./grammar.tab.c"
     break;
 
-  case 51:
+  case 51: /* expression: multiplicationAssign  */
 #line 401 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                            { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 2413 "./grammar.tab.c"
     break;
 
-  case 52:
+  case 52: /* expression: divisionAssign  */
 #line 402 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                            { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 2419 "./grammar.tab.c"
     break;
 
-  case 53:
+  case 53: /* expression: functionCall  */
 #line 404 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxFunctionCall); }
+                                            { (yyval.syntaxElement) = (yyvsp[0].syntaxFunctionCall); }
+#line 2425 "./grammar.tab.c"
     break;
 
-  case 54:
+  case 54: /* expression: variable  */
 #line 406 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                            { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 2431 "./grammar.tab.c"
     break;
 
-  case 55:
+  case 55: /* arrowAssign: expression ARROW_ASSIGN expression  */
 #line 410 "./grammar.y"
-    { 
+                    { 
 #ifdef DEBUG_BISON_FLEX
                         printf("Parser inserting arrow assignment (ARROW_ASSIGN) in syntax tree\n");
 #endif
-                        (yyval.syntaxElement) = new SyntaxConstantAssignment((yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement));
+                        (yyval.syntaxElement) = new SyntaxConstantAssignment((yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement));
                     }
+#line 2442 "./grammar.tab.c"
     break;
 
-  case 56:
+  case 56: /* tildeAssign: expression TILDE_ASSIGN expression  */
 #line 419 "./grammar.y"
-    {
+                    {
 #ifdef DEBUG_BISON_FLEX
                         printf("Parser inserting tilde assignment (TILDE_ASSIGN) in syntax tree\n");
 #endif
-                        (yyval.syntaxElement) = new SyntaxStochasticAssignment((yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement));
+                        (yyval.syntaxElement) = new SyntaxStochasticAssignment((yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement));
                     }
+#line 2453 "./grammar.tab.c"
     break;
 
-  case 57:
+  case 57: /* equationAssign: expression EQUATION_ASSIGN expression  */
 #line 428 "./grammar.y"
-    {
+                    {
 #ifdef DEBUG_BISON_FLEX
                         printf("Parser inserting equation assignment (EQUATION_ASSIGN) in syntax tree\n");
 #endif
-                        (yyval.syntaxElement) = new SyntaxDeterministicAssignment((yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement)); 
+                        (yyval.syntaxElement) = new SyntaxDeterministicAssignment((yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement)); 
                     }
+#line 2464 "./grammar.tab.c"
     break;
 
-  case 58:
+  case 58: /* workspaceAssign: expression EQUAL expression  */
 #line 437 "./grammar.y"
-    {
+                    {
 #ifdef DEBUG_BISON_FLEX
                         printf("Parser inserting workspace assignment (WORKSPACE_ASSIGN) in syntax tree\n");
 #endif
-                        (yyval.syntaxElement) = new SyntaxWorkspaceVariableAssignment((yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement));
+                        (yyval.syntaxElement) = new SyntaxWorkspaceVariableAssignment((yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement));
                     }
+#line 2475 "./grammar.tab.c"
     break;
 
-  case 59:
+  case 59: /* referenceAssign: expression REFERENCE_ASSIGN expression  */
 #line 446 "./grammar.y"
-    {
+                    {
 #ifdef DEBUG_BISON_FLEX
                         printf("Parser inserting reference assignment (REFERENCE_ASSIGN) in syntax tree\n");
 #endif
-                        (yyval.syntaxElement) = new SyntaxReferenceAssignment((yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement));
+                        (yyval.syntaxElement) = new SyntaxReferenceAssignment((yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement));
                     }
+#line 2486 "./grammar.tab.c"
     break;
 
-  case 60:
+  case 60: /* additionAssign: expression ADDITION_ASSIGN expression  */
 #line 455 "./grammar.y"
-    {
+                    {
 #ifdef DEBUG_BISON_FLEX
                         printf("Parser inserting addition assignment (ADDITION_ASSIGN) in syntax tree\n");
 #endif
-                        (yyval.syntaxElement) = new SyntaxAdditionAssignment((yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement)); 
+                        (yyval.syntaxElement) = new SyntaxAdditionAssignment((yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement)); 
                     }
+#line 2497 "./grammar.tab.c"
     break;
 
-  case 61:
+  case 61: /* subtractionAssign: expression SUBTRACTION_ASSIGN expression  */
 #line 464 "./grammar.y"
-    {
+                        {
 #ifdef DEBUG_BISON_FLEX
                             printf("Parser inserting subtraction assignment (SUBTRACTION_ASSIGN) in syntax tree\n");
 #endif
-                            (yyval.syntaxElement) = new SyntaxSubtractionAssignment((yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement)); 
+                            (yyval.syntaxElement) = new SyntaxSubtractionAssignment((yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement)); 
                         }
+#line 2508 "./grammar.tab.c"
     break;
 
-  case 62:
+  case 62: /* multiplicationAssign: expression MULTIPLICATION_ASSIGN expression  */
 #line 473 "./grammar.y"
-    {
+                            {
 #ifdef DEBUG_BISON_FLEX
                                 printf("Parser inserting multiplication assignment (MULTIPLICATION_ASSIGN) in syntax tree\n");
 #endif
-                                (yyval.syntaxElement) = new SyntaxMultiplicationAssignment((yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement)); 
+                                (yyval.syntaxElement) = new SyntaxMultiplicationAssignment((yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement)); 
                             }
+#line 2519 "./grammar.tab.c"
     break;
 
-  case 63:
+  case 63: /* divisionAssign: expression DIVISION_ASSIGN expression  */
 #line 482 "./grammar.y"
-    {
+                    {
 #ifdef DEBUG_BISON_FLEX
                         printf("Parser inserting division assignment (DIVISION_ASSIGN) in syntax tree\n");
 #endif
-                        (yyval.syntaxElement) = new SyntaxDivisionAssignment((yyvsp[(1) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElement)); 
+                        (yyval.syntaxElement) = new SyntaxDivisionAssignment((yyvsp[-2].syntaxElement), (yyvsp[0].syntaxElement)); 
                     }
+#line 2530 "./grammar.tab.c"
     break;
 
-  case 64:
+  case 64: /* variable: identifier optElements  */
 #line 491 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Parser inserting variable (NAMED_VAR) in syntax tree\n");
 #endif
-                    (yyval.syntaxElement) = new SyntaxVariable(*(yyvsp[(1) - (2)].string));
-                    for (std::list<SyntaxElement*>::iterator it=(yyvsp[(2) - (2)].syntaxElementList)->begin(); it!=(yyvsp[(2) - (2)].syntaxElementList)->end(); ++it)
+                    (yyval.syntaxElement) = new SyntaxVariable(*(yyvsp[-1].string));
+                    for (std::list<SyntaxElement*>::iterator it=(yyvsp[0].syntaxElementList)->begin(); it!=(yyvsp[0].syntaxElementList)->end(); ++it)
                     {
                         (yyval.syntaxElement) = new SyntaxIndexOperation((yyval.syntaxElement),*it);
                     }
-                    delete (yyvsp[(1) - (2)].string);
-                    delete (yyvsp[(2) - (2)].syntaxElementList);
+                    delete (yyvsp[-1].string);
+                    delete (yyvsp[0].syntaxElementList);
                 }
+#line 2547 "./grammar.tab.c"
     break;
 
-  case 65:
+  case 65: /* variable: fxnCall '[' expression ']' optElements  */
 #line 504 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Parser inserting variable (FUNCTION_VAR) in syntax tree\n");
 #endif
-                    (yyval.syntaxElement) = new SyntaxIndexOperation((yyvsp[(1) - (5)].syntaxFunctionCall),(yyvsp[(3) - (5)].syntaxElement));
-                    for (std::list<SyntaxElement*>::iterator it=(yyvsp[(5) - (5)].syntaxElementList)->begin(); it!=(yyvsp[(5) - (5)].syntaxElementList)->end(); ++it)
+                    (yyval.syntaxElement) = new SyntaxIndexOperation((yyvsp[-4].syntaxFunctionCall),(yyvsp[-2].syntaxElement));
+                    for (std::list<SyntaxElement*>::iterator it=(yyvsp[0].syntaxElementList)->begin(); it!=(yyvsp[0].syntaxElementList)->end(); ++it)
                     {
                         (yyval.syntaxElement) = new SyntaxIndexOperation((yyval.syntaxElement),*it);
                     }
-                    delete (yyvsp[(5) - (5)].syntaxElementList);
+                    delete (yyvsp[0].syntaxElementList);
                 }
+#line 2563 "./grammar.tab.c"
     break;
 
-  case 66:
+  case 66: /* variable: '(' expression ')' '[' expression ']' optElements  */
 #line 516 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Parser inserting variable (EXPRESSION_VAR) in syntax tree\n");
 #endif
-                    (yyval.syntaxElement) = new SyntaxIndexOperation((yyvsp[(2) - (7)].syntaxElement),(yyvsp[(5) - (7)].syntaxElement));
-                    for (std::list<SyntaxElement*>::iterator it=(yyvsp[(7) - (7)].syntaxElementList)->begin(); it!=(yyvsp[(7) - (7)].syntaxElementList)->end(); ++it)
+                    (yyval.syntaxElement) = new SyntaxIndexOperation((yyvsp[-5].syntaxElement),(yyvsp[-2].syntaxElement));
+                    for (std::list<SyntaxElement*>::iterator it=(yyvsp[0].syntaxElementList)->begin(); it!=(yyvsp[0].syntaxElementList)->end(); ++it)
                     {
                         (yyval.syntaxElement) = new SyntaxIndexOperation((yyval.syntaxElement),*it);
                     }
-                    delete (yyvsp[(7) - (7)].syntaxElementList);
+                    delete (yyvsp[0].syntaxElementList);
                 }
+#line 2579 "./grammar.tab.c"
     break;
 
-  case 67:
+  case 67: /* variable: variable '.' fxnCall '[' expression ']' optElements  */
 #line 528 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Parser inserting member variable (FUNCTION_VAR) in syntax tree\n");
 #endif
-                    (yyvsp[(3) - (7)].syntaxFunctionCall)->setBaseVariable((yyvsp[(1) - (7)].syntaxElement));
-                    (yyval.syntaxElement) = new SyntaxIndexOperation((yyvsp[(3) - (7)].syntaxFunctionCall),(yyvsp[(5) - (7)].syntaxElement));
-                    for (std::list<SyntaxElement*>::iterator it=(yyvsp[(7) - (7)].syntaxElementList)->begin(); it!=(yyvsp[(7) - (7)].syntaxElementList)->end(); ++it)
+                    (yyvsp[-4].syntaxFunctionCall)->setBaseVariable((yyvsp[-6].syntaxElement));
+                    (yyval.syntaxElement) = new SyntaxIndexOperation((yyvsp[-4].syntaxFunctionCall),(yyvsp[-2].syntaxElement));
+                    for (std::list<SyntaxElement*>::iterator it=(yyvsp[0].syntaxElementList)->begin(); it!=(yyvsp[0].syntaxElementList)->end(); ++it)
                     {
                         (yyval.syntaxElement) = new SyntaxIndexOperation((yyval.syntaxElement),*it);
                     }
-                    delete (yyvsp[(7) - (7)].syntaxElementList);
+                    delete (yyvsp[0].syntaxElementList);
                 }
+#line 2596 "./grammar.tab.c"
     break;
 
-  case 68:
+  case 68: /* optElements: %empty  */
 #line 542 "./grammar.y"
-    { (yyval.syntaxElementList) = new std::list<SyntaxElement*>(); }
+                                                { (yyval.syntaxElementList) = new std::list<SyntaxElement*>(); }
+#line 2602 "./grammar.tab.c"
     break;
 
-  case 69:
+  case 69: /* optElements: elementList  */
 #line 543 "./grammar.y"
-    { (yyval.syntaxElementList) = (yyvsp[(1) - (1)].syntaxElementList); }
+                                                { (yyval.syntaxElementList) = (yyvsp[0].syntaxElementList); }
+#line 2608 "./grammar.tab.c"
     break;
 
-  case 70:
+  case 70: /* elementList: '[' expression ']'  */
 #line 546 "./grammar.y"
-    { (yyval.syntaxElementList) = new std::list<SyntaxElement*>(1, (yyvsp[(2) - (3)].syntaxElement)); }
+                                                { (yyval.syntaxElementList) = new std::list<SyntaxElement*>(1, (yyvsp[-1].syntaxElement)); }
+#line 2614 "./grammar.tab.c"
     break;
 
-  case 71:
+  case 71: /* elementList: '[' ']'  */
 #line 547 "./grammar.y"
-    { (yyval.syntaxElementList) = new std::list<SyntaxElement*>(); }
+                                                { (yyval.syntaxElementList) = new std::list<SyntaxElement*>(); }
+#line 2620 "./grammar.tab.c"
     break;
 
-  case 72:
+  case 72: /* elementList: elementList '[' expression ']'  */
 #line 548 "./grammar.y"
-    { (yyvsp[(1) - (4)].syntaxElementList)->push_back((yyvsp[(3) - (4)].syntaxElement)); (yyval.syntaxElementList) = (yyvsp[(1) - (4)].syntaxElementList); }
+                                                { (yyvsp[-3].syntaxElementList)->push_back((yyvsp[-1].syntaxElement)); (yyval.syntaxElementList) = (yyvsp[-3].syntaxElementList); }
+#line 2626 "./grammar.tab.c"
     break;
 
-  case 73:
+  case 73: /* elementList: elementList '[' ']'  */
 #line 549 "./grammar.y"
-    { (yyvsp[(1) - (3)].syntaxElementList)->push_back( NULL ); (yyval.syntaxElementList) = (yyvsp[(1) - (3)].syntaxElementList); }
+                                                { (yyvsp[-2].syntaxElementList)->push_back( NULL ); (yyval.syntaxElementList) = (yyvsp[-2].syntaxElementList); }
+#line 2632 "./grammar.tab.c"
     break;
 
-  case 74:
+  case 74: /* fxnCall: identifier '(' optArguments ')'  */
 #line 553 "./grammar.y"
-    {
-                    (yyval.syntaxFunctionCall) = new SyntaxFunctionCall(*(yyvsp[(1) - (4)].string), (yyvsp[(3) - (4)].argumentList));
-                    delete (yyvsp[(1) - (4)].string);
+                {
+                    (yyval.syntaxFunctionCall) = new SyntaxFunctionCall(*(yyvsp[-3].string), (yyvsp[-1].argumentList));
+                    delete (yyvsp[-3].string);
                 }
+#line 2641 "./grammar.tab.c"
     break;
 
-  case 75:
+  case 75: /* functionCall: fxnCall  */
 #line 561 "./grammar.y"
-    {
+                    {
 #ifdef DEBUG_BISON_FLEX
                         printf("Parser inserting function call in syntax tree\n");
 #endif
-                        (yyval.syntaxFunctionCall) = (yyvsp[(1) - (1)].syntaxFunctionCall);
+                        (yyval.syntaxFunctionCall) = (yyvsp[0].syntaxFunctionCall);
                     }
+#line 2652 "./grammar.tab.c"
     break;
 
-  case 76:
+  case 76: /* functionCall: variable '.' fxnCall  */
 #line 568 "./grammar.y"
-    {
+                    {
 #ifdef DEBUG_BISON_FLEX
                         printf("Parser inserting member call in syntax tree\n");
 #endif
-                        (yyvsp[(3) - (3)].syntaxFunctionCall)->setBaseVariable((yyvsp[(1) - (3)].syntaxElement));
-                        (yyval.syntaxFunctionCall) = (yyvsp[(3) - (3)].syntaxFunctionCall);
+                        (yyvsp[0].syntaxFunctionCall)->setBaseVariable((yyvsp[-2].syntaxElement));
+                        (yyval.syntaxFunctionCall) = (yyvsp[0].syntaxFunctionCall);
                     }
+#line 2664 "./grammar.tab.c"
     break;
 
-  case 77:
+  case 77: /* functionCall: functionCall '.' fxnCall  */
 #line 576 "./grammar.y"
-    {
+                    {
 #ifdef DEBUG_BISON_FLEX
                         printf("Parser inserting member call in syntax tree\n");
 #endif
-                        (yyvsp[(3) - (3)].syntaxFunctionCall)->setBaseVariable((yyvsp[(1) - (3)].syntaxFunctionCall));
-                        (yyval.syntaxFunctionCall) = (yyvsp[(3) - (3)].syntaxFunctionCall);
+                        (yyvsp[0].syntaxFunctionCall)->setBaseVariable((yyvsp[-2].syntaxFunctionCall));
+                        (yyval.syntaxFunctionCall) = (yyvsp[0].syntaxFunctionCall);
                     }
+#line 2676 "./grammar.tab.c"
     break;
 
-  case 78:
+  case 78: /* optArguments: %empty  */
 #line 586 "./grammar.y"
-    { (yyval.argumentList) = new std::list<SyntaxLabeledExpr*>(); }
+                                            { (yyval.argumentList) = new std::list<SyntaxLabeledExpr*>(); }
+#line 2682 "./grammar.tab.c"
     break;
 
-  case 79:
+  case 79: /* optArguments: argumentList  */
 #line 587 "./grammar.y"
-    { (yyval.argumentList) = (yyvsp[(1) - (1)].argumentList); }
+                                            { (yyval.argumentList) = (yyvsp[0].argumentList); }
+#line 2688 "./grammar.tab.c"
     break;
 
-  case 80:
+  case 80: /* argumentList: argument  */
 #line 590 "./grammar.y"
-    { (yyval.argumentList) = new std::list<SyntaxLabeledExpr*>(1,(yyvsp[(1) - (1)].syntaxLabeledExpr)); }
+                                                { (yyval.argumentList) = new std::list<SyntaxLabeledExpr*>(1,(yyvsp[0].syntaxLabeledExpr)); }
+#line 2694 "./grammar.tab.c"
     break;
 
-  case 81:
+  case 81: /* argumentList: argumentList ',' argument  */
 #line 591 "./grammar.y"
-    { (yyvsp[(1) - (3)].argumentList)->push_back((yyvsp[(3) - (3)].syntaxLabeledExpr)); (yyval.argumentList) = (yyvsp[(1) - (3)].argumentList); }
+                                                { (yyvsp[-2].argumentList)->push_back((yyvsp[0].syntaxLabeledExpr)); (yyval.argumentList) = (yyvsp[-2].argumentList); }
+#line 2700 "./grammar.tab.c"
     break;
 
-  case 82:
+  case 82: /* argument: expression  */
 #line 595 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Parser inserting unlabeled argument in syntax tree\n");
 #endif
-                    (yyval.syntaxLabeledExpr) = new SyntaxLabeledExpr( "", (yyvsp[(1) - (1)].syntaxElement));
+                    (yyval.syntaxLabeledExpr) = new SyntaxLabeledExpr( "", (yyvsp[0].syntaxElement));
                 }
+#line 2711 "./grammar.tab.c"
     break;
 
-  case 83:
+  case 83: /* argument: identifier EQUAL expression  */
 #line 602 "./grammar.y"
-    { 
+                { 
 #ifdef DEBUG_BISON_FLEX
                     printf("Parser inserting labeled argument in syntax tree\n");
 #endif
-                    (yyval.syntaxLabeledExpr) = new SyntaxLabeledExpr(*(yyvsp[(1) - (3)].string), (yyvsp[(3) - (3)].syntaxElement));
-                    delete (yyvsp[(1) - (3)].string);
+                    (yyval.syntaxLabeledExpr) = new SyntaxLabeledExpr(*(yyvsp[-2].string), (yyvsp[0].syntaxElement));
+                    delete (yyvsp[-2].string);
                 }
+#line 2723 "./grammar.tab.c"
     break;
 
-  case 84:
+  case 84: /* functionDef: FUNCTION identifier '(' optFormals ')' stmts  */
 #line 612 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Parser inserting function definition in syntax tree\n");
 #endif
-                    (yyval.syntaxElement) = new SyntaxFunctionDef("", *(yyvsp[(2) - (6)].string), (yyvsp[(4) - (6)].formalList), (yyvsp[(6) - (6)].syntaxElementList));
-                    delete (yyvsp[(2) - (6)].string);
+                    (yyval.syntaxElement) = new SyntaxFunctionDef("", *(yyvsp[-4].string), (yyvsp[-2].formalList), (yyvsp[0].syntaxElementList));
+                    delete (yyvsp[-4].string);
                 }
+#line 2735 "./grammar.tab.c"
     break;
 
-  case 85:
+  case 85: /* functionDef: FUNCTION identifier optDims identifier '(' optFormals ')' stmts  */
 #line 621 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Parser inserting typed function definition in syntax tree\n");
 #endif
-                    (yyvsp[(2) - (8)].string)->append(*(yyvsp[(3) - (8)].string));
-                    (yyval.syntaxElement) = new SyntaxFunctionDef(*(yyvsp[(2) - (8)].string), *(yyvsp[(4) - (8)].string), (yyvsp[(6) - (8)].formalList), (yyvsp[(8) - (8)].syntaxElementList));
-                    delete (yyvsp[(2) - (8)].string);
-                    delete (yyvsp[(3) - (8)].string);
-                    delete (yyvsp[(4) - (8)].string);
+                    (yyvsp[-6].string)->append(*(yyvsp[-5].string));
+                    (yyval.syntaxElement) = new SyntaxFunctionDef(*(yyvsp[-6].string), *(yyvsp[-4].string), (yyvsp[-2].formalList), (yyvsp[0].syntaxElementList));
+                    delete (yyvsp[-6].string);
+                    delete (yyvsp[-5].string);
+                    delete (yyvsp[-4].string);
                 }
+#line 2750 "./grammar.tab.c"
     break;
 
-  case 86:
+  case 86: /* procedureDef: PROCEDURE identifier '(' optFormals ')' stmts  */
 #line 634 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Parser inserting procedure definition in syntax tree\n");
 #endif
-                    (yyval.syntaxElement) = new SyntaxFunctionDef("", *(yyvsp[(2) - (6)].string), (yyvsp[(4) - (6)].formalList), (yyvsp[(6) - (6)].syntaxElementList), true);
-                    delete (yyvsp[(2) - (6)].string);
+                    (yyval.syntaxElement) = new SyntaxFunctionDef("", *(yyvsp[-4].string), (yyvsp[-2].formalList), (yyvsp[0].syntaxElementList), true);
+                    delete (yyvsp[-4].string);
                 }
+#line 2762 "./grammar.tab.c"
     break;
 
-  case 87:
+  case 87: /* procedureDef: PROCEDURE identifier optDims identifier '(' optFormals ')' stmts  */
 #line 643 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Parser inserting typed procedure definition in syntax tree\n");
 #endif
-                    (yyvsp[(2) - (8)].string)->append(*(yyvsp[(3) - (8)].string));
-                    (yyval.syntaxElement) = new SyntaxFunctionDef(*(yyvsp[(2) - (8)].string), *(yyvsp[(4) - (8)].string), (yyvsp[(6) - (8)].formalList), (yyvsp[(8) - (8)].syntaxElementList), true);
-                    delete (yyvsp[(2) - (8)].string);
-                    delete (yyvsp[(3) - (8)].string);
-                    delete (yyvsp[(4) - (8)].string);
+                    (yyvsp[-6].string)->append(*(yyvsp[-5].string));
+                    (yyval.syntaxElement) = new SyntaxFunctionDef(*(yyvsp[-6].string), *(yyvsp[-4].string), (yyvsp[-2].formalList), (yyvsp[0].syntaxElementList), true);
+                    delete (yyvsp[-6].string);
+                    delete (yyvsp[-5].string);
+                    delete (yyvsp[-4].string);
                 }
+#line 2777 "./grammar.tab.c"
     break;
 
-  case 88:
+  case 88: /* optFormals: %empty  */
 #line 655 "./grammar.y"
-    { (yyval.formalList) = new std::list<SyntaxFormal*>(); }
+                                        { (yyval.formalList) = new std::list<SyntaxFormal*>(); }
+#line 2783 "./grammar.tab.c"
     break;
 
-  case 89:
+  case 89: /* optFormals: formalList  */
 #line 656 "./grammar.y"
-    { (yyval.formalList) = (yyvsp[(1) - (1)].formalList); }
+                                        { (yyval.formalList) = (yyvsp[0].formalList); }
+#line 2789 "./grammar.tab.c"
     break;
 
-  case 90:
+  case 90: /* formalList: formal  */
 #line 659 "./grammar.y"
-    { (yyval.formalList) = new std::list<SyntaxFormal*>(1, (yyvsp[(1) - (1)].syntaxFormal)); }
+                                        { (yyval.formalList) = new std::list<SyntaxFormal*>(1, (yyvsp[0].syntaxFormal)); }
+#line 2795 "./grammar.tab.c"
     break;
 
-  case 91:
+  case 91: /* formalList: formalList ',' formal  */
 #line 660 "./grammar.y"
-    { (yyvsp[(1) - (3)].formalList)->push_back((yyvsp[(3) - (3)].syntaxFormal)); (yyval.formalList) = (yyvsp[(1) - (3)].formalList); }
+                                        { (yyvsp[-2].formalList)->push_back((yyvsp[0].syntaxFormal)); (yyval.formalList) = (yyvsp[-2].formalList); }
+#line 2801 "./grammar.tab.c"
     break;
 
-  case 92:
+  case 92: /* formal: identifier  */
 #line 664 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Inserting labeled formal argument without default in syntax tree\n");
 #endif
-                    (yyval.syntaxFormal) = new SyntaxFormal(*(yyvsp[(1) - (1)].string), NULL );
-                    delete (yyvsp[(1) - (1)].string);
+                    (yyval.syntaxFormal) = new SyntaxFormal(*(yyvsp[0].string), NULL );
+                    delete (yyvsp[0].string);
                 }
+#line 2813 "./grammar.tab.c"
     break;
 
-  case 93:
+  case 93: /* formal: identifier EQUAL expression  */
 #line 672 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Inserting labeled formal argument with default in syntax tree\n");
 #endif
-                    (yyval.syntaxFormal) = new SyntaxFormal(*(yyvsp[(1) - (3)].string), (yyvsp[(3) - (3)].syntaxElement));
-                    delete (yyvsp[(1) - (3)].string);
+                    (yyval.syntaxFormal) = new SyntaxFormal(*(yyvsp[-2].string), (yyvsp[0].syntaxElement));
+                    delete (yyvsp[-2].string);
                 }
+#line 2825 "./grammar.tab.c"
     break;
 
-  case 94:
+  case 94: /* formal: typeSpec identifier  */
 #line 680 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Inserting typed labeled formal argument without default in syntax tree\n");
 #endif
-                    (yyval.syntaxFormal) = new SyntaxFormal(*(yyvsp[(1) - (2)].string), *(yyvsp[(2) - (2)].string), NULL);
-                    delete (yyvsp[(1) - (2)].string);
-                    delete (yyvsp[(2) - (2)].string);
+                    (yyval.syntaxFormal) = new SyntaxFormal(*(yyvsp[-1].string), *(yyvsp[0].string), NULL);
+                    delete (yyvsp[-1].string);
+                    delete (yyvsp[0].string);
                 }
+#line 2838 "./grammar.tab.c"
     break;
 
-  case 95:
+  case 95: /* formal: typeSpec identifier EQUAL expression  */
 #line 689 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                     printf("Inserting typed labeled formal argument with default in syntax tree\n");
 #endif
-                    (yyval.syntaxFormal) = new SyntaxFormal(*(yyvsp[(1) - (4)].string), *(yyvsp[(2) - (4)].string), (yyvsp[(4) - (4)].syntaxElement));
-                    delete (yyvsp[(1) - (4)].string);
-                    delete (yyvsp[(2) - (4)].string);
+                    (yyval.syntaxFormal) = new SyntaxFormal(*(yyvsp[-3].string), *(yyvsp[-2].string), (yyvsp[0].syntaxElement));
+                    delete (yyvsp[-3].string);
+                    delete (yyvsp[-2].string);
                 }
+#line 2851 "./grammar.tab.c"
     break;
 
-  case 96:
+  case 96: /* typeSpec: identifier optDims  */
 #line 699 "./grammar.y"
-    { (yyvsp[(1) - (2)].string)->append(*((yyvsp[(2) - (2)].string))); delete (yyvsp[(2) - (2)].string); (yyval.string) = (yyvsp[(1) - (2)].string); }
+                                                        { (yyvsp[-1].string)->append(*((yyvsp[0].string))); delete (yyvsp[0].string); (yyval.string) = (yyvsp[-1].string); }
+#line 2857 "./grammar.tab.c"
     break;
 
-  case 97:
+  case 97: /* typeSpec: MOD_CONST identifier optDims  */
 #line 700 "./grammar.y"
-    { (yyvsp[(2) - (3)].string)->append(*((yyvsp[(3) - (3)].string))); (yyvsp[(2) - (3)].string)->insert(0, "const ");           delete (yyvsp[(3) - (3)].string); (yyval.string) = (yyvsp[(2) - (3)].string); }
+                                                        { (yyvsp[-1].string)->append(*((yyvsp[0].string))); (yyvsp[-1].string)->insert(0, "const ");           delete (yyvsp[0].string); (yyval.string) = (yyvsp[-1].string); }
+#line 2863 "./grammar.tab.c"
     break;
 
-  case 98:
+  case 98: /* typeSpec: MOD_DYNAMIC identifier optDims  */
 #line 701 "./grammar.y"
-    { (yyvsp[(2) - (3)].string)->append(*((yyvsp[(3) - (3)].string))); (yyvsp[(2) - (3)].string)->insert(0, "dynamic ");         delete (yyvsp[(3) - (3)].string); (yyval.string) = (yyvsp[(2) - (3)].string); }
+                                                        { (yyvsp[-1].string)->append(*((yyvsp[0].string))); (yyvsp[-1].string)->insert(0, "dynamic ");         delete (yyvsp[0].string); (yyval.string) = (yyvsp[-1].string); }
+#line 2869 "./grammar.tab.c"
     break;
 
-  case 99:
+  case 99: /* typeSpec: MOD_STOCHASTIC identifier optDims  */
 #line 702 "./grammar.y"
-    { (yyvsp[(2) - (3)].string)->append(*((yyvsp[(3) - (3)].string))); (yyvsp[(2) - (3)].string)->insert(0, "stochastic ");      delete (yyvsp[(3) - (3)].string); (yyval.string) = (yyvsp[(2) - (3)].string); }
+                                                        { (yyvsp[-1].string)->append(*((yyvsp[0].string))); (yyvsp[-1].string)->insert(0, "stochastic ");      delete (yyvsp[0].string); (yyval.string) = (yyvsp[-1].string); }
+#line 2875 "./grammar.tab.c"
     break;
 
-  case 100:
+  case 100: /* typeSpec: MOD_DETERMINISTIC identifier optDims  */
 #line 703 "./grammar.y"
-    { (yyvsp[(2) - (3)].string)->append(*((yyvsp[(3) - (3)].string))); (yyvsp[(2) - (3)].string)->insert(0, "deterministic ");   delete (yyvsp[(3) - (3)].string); (yyval.string) = (yyvsp[(2) - (3)].string); }
+                                                        { (yyvsp[-1].string)->append(*((yyvsp[0].string))); (yyvsp[-1].string)->insert(0, "deterministic ");   delete (yyvsp[0].string); (yyval.string) = (yyvsp[-1].string); }
+#line 2881 "./grammar.tab.c"
     break;
 
-  case 101:
+  case 101: /* optDims: %empty  */
 #line 706 "./grammar.y"
-    { (yyval.string) = new std::string(""); }
+                                            { (yyval.string) = new std::string(""); }
+#line 2887 "./grammar.tab.c"
     break;
 
-  case 102:
+  case 102: /* optDims: dimList  */
 #line 707 "./grammar.y"
-    { (yyval.string) = (yyvsp[(1) - (1)].string); }
+                                            { (yyval.string) = (yyvsp[0].string); }
+#line 2893 "./grammar.tab.c"
     break;
 
-  case 103:
+  case 103: /* dimList: '[' ']'  */
 #line 710 "./grammar.y"
-    { (yyval.string) = new std::string("[]"); }
+                                            { (yyval.string) = new std::string("[]"); }
+#line 2899 "./grammar.tab.c"
     break;
 
-  case 104:
+  case 104: /* dimList: dimList '[' ']'  */
 #line 711 "./grammar.y"
-    { (yyvsp[(1) - (3)].string)->append("[]"); (yyval.string) = (yyvsp[(1) - (3)].string); }
+                                            { (yyvsp[-2].string)->append("[]"); (yyval.string) = (yyvsp[-2].string); }
+#line 2905 "./grammar.tab.c"
     break;
 
-  case 105:
+  case 105: /* stmts: '{' stmtList '}'  */
 #line 714 "./grammar.y"
-    { (yyval.syntaxElementList) = (yyvsp[(2) - (3)].syntaxElementList); }
+                                                { (yyval.syntaxElementList) = (yyvsp[-1].syntaxElementList); }
+#line 2911 "./grammar.tab.c"
     break;
 
-  case 106:
+  case 106: /* stmts: stmt_or_expr  */
 #line 716 "./grammar.y"
-    {
+                {
                     std::list<SyntaxElement*>* stmts = new std::list<SyntaxElement*>();
-                    stmts->push_back((yyvsp[(1) - (1)].syntaxElement));
+                    stmts->push_back((yyvsp[0].syntaxElement));
                     (yyval.syntaxElementList) = stmts;
                 }
+#line 2921 "./grammar.tab.c"
     break;
 
-  case 107:
+  case 107: /* stmtList: %empty  */
 #line 723 "./grammar.y"
-    { (yyval.syntaxElementList) = new std::list<SyntaxElement*>(); }
+                                            { (yyval.syntaxElementList) = new std::list<SyntaxElement*>(); }
+#line 2927 "./grammar.tab.c"
     break;
 
-  case 108:
+  case 108: /* stmtList: stmt_or_expr  */
 #line 724 "./grammar.y"
-    { (yyval.syntaxElementList) = new std::list<SyntaxElement*>(1, (yyvsp[(1) - (1)].syntaxElement)); }
+                                            { (yyval.syntaxElementList) = new std::list<SyntaxElement*>(1, (yyvsp[0].syntaxElement)); }
+#line 2933 "./grammar.tab.c"
     break;
 
-  case 109:
+  case 109: /* stmtList: stmtList ';' stmt_or_expr  */
 #line 725 "./grammar.y"
-    { (yyvsp[(1) - (3)].syntaxElementList)->push_back((yyvsp[(3) - (3)].syntaxElement)); (yyval.syntaxElementList) = (yyvsp[(1) - (3)].syntaxElementList); }
+                                            { (yyvsp[-2].syntaxElementList)->push_back((yyvsp[0].syntaxElement)); (yyval.syntaxElementList) = (yyvsp[-2].syntaxElementList); }
+#line 2939 "./grammar.tab.c"
     break;
 
-  case 110:
+  case 110: /* stmtList: stmtList ';'  */
 #line 726 "./grammar.y"
-    { (yyval.syntaxElementList) = (yyvsp[(1) - (2)].syntaxElementList); }
+                                            { (yyval.syntaxElementList) = (yyvsp[-1].syntaxElementList); }
+#line 2945 "./grammar.tab.c"
     break;
 
-  case 111:
+  case 111: /* stmtList: stmtList '\n' stmt_or_expr  */
 #line 727 "./grammar.y"
-    { (yyvsp[(1) - (3)].syntaxElementList)->push_back((yyvsp[(3) - (3)].syntaxElement)); (yyval.syntaxElementList) = (yyvsp[(1) - (3)].syntaxElementList); }
+                                            { (yyvsp[-2].syntaxElementList)->push_back((yyvsp[0].syntaxElement)); (yyval.syntaxElementList) = (yyvsp[-2].syntaxElementList); }
+#line 2951 "./grammar.tab.c"
     break;
 
-  case 112:
+  case 112: /* stmtList: stmtList '\n'  */
 #line 728 "./grammar.y"
-    { (yyval.syntaxElementList) = (yyvsp[(1) - (2)].syntaxElementList); }
+                                            { (yyval.syntaxElementList) = (yyvsp[-1].syntaxElementList); }
+#line 2957 "./grammar.tab.c"
     break;
 
-  case 113:
+  case 113: /* statement: ifStatement  */
 #line 731 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                        { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 2963 "./grammar.tab.c"
     break;
 
-  case 114:
+  case 114: /* statement: forStatement  */
 #line 732 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                        { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 2969 "./grammar.tab.c"
     break;
 
-  case 115:
+  case 115: /* statement: whileStatement  */
 #line 733 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                        { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 2975 "./grammar.tab.c"
     break;
 
-  case 116:
+  case 116: /* statement: nextStatement  */
 #line 734 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                        { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 2981 "./grammar.tab.c"
     break;
 
-  case 117:
+  case 117: /* statement: breakStatement  */
 #line 735 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                        { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 2987 "./grammar.tab.c"
     break;
 
-  case 118:
+  case 118: /* statement: returnStatement  */
 #line 736 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                        { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 2993 "./grammar.tab.c"
     break;
 
-  case 119:
+  case 119: /* stmt_or_expr: statement  */
 #line 739 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                        { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 2999 "./grammar.tab.c"
     break;
 
-  case 120:
+  case 120: /* stmt_or_expr: expression  */
 #line 740 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                        { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 3005 "./grammar.tab.c"
     break;
 
-  case 121:
+  case 121: /* declaration: classDef  */
 #line 743 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                        { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 3011 "./grammar.tab.c"
     break;
 
-  case 122:
+  case 122: /* declaration: functionDef  */
 #line 744 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                        { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 3017 "./grammar.tab.c"
     break;
 
-  case 123:
+  case 123: /* declaration: procedureDef  */
 #line 745 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                        { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 3023 "./grammar.tab.c"
     break;
 
-  case 124:
+  case 124: /* declaration: identifier optElements identifier  */
 #line 747 "./grammar.y"
-    {
+                    {
 #ifdef DEBUG_BISON_FLEX
                         printf("Parser inserting variable declaration in syntax tree\n");
 #endif
-                        (yyval.syntaxElement) = new SyntaxVariableDecl(*(yyvsp[(1) - (3)].string), (yyvsp[(2) - (3)].syntaxElementList), *(yyvsp[(3) - (3)].string));
-                        delete (yyvsp[(1) - (3)].string);
-                        delete (yyvsp[(3) - (3)].string);
+                        (yyval.syntaxElement) = new SyntaxVariableDecl(*(yyvsp[-2].string), (yyvsp[-1].syntaxElementList), *(yyvsp[0].string));
+                        delete (yyvsp[-2].string);
+                        delete (yyvsp[0].string);
                     }
+#line 3036 "./grammar.tab.c"
     break;
 
-  case 125:
+  case 125: /* memberDefs: %empty  */
 #line 757 "./grammar.y"
-    { (yyval.syntaxElementList) = new std::list<SyntaxElement*>(); }
+                                                { (yyval.syntaxElementList) = new std::list<SyntaxElement*>(); }
+#line 3042 "./grammar.tab.c"
     break;
 
-  case 126:
+  case 126: /* memberDefs: memberDef  */
 #line 758 "./grammar.y"
-    { (yyval.syntaxElementList) = new std::list<SyntaxElement*>(1, (yyvsp[(1) - (1)].syntaxElement)); }
+                                                { (yyval.syntaxElementList) = new std::list<SyntaxElement*>(1, (yyvsp[0].syntaxElement)); }
+#line 3048 "./grammar.tab.c"
     break;
 
-  case 127:
+  case 127: /* memberDefs: memberDefs ';' memberDef  */
 #line 759 "./grammar.y"
-    { (yyvsp[(1) - (3)].syntaxElementList)->push_back((yyvsp[(3) - (3)].syntaxElement)); (yyval.syntaxElementList) = (yyvsp[(1) - (3)].syntaxElementList); }
+                                                { (yyvsp[-2].syntaxElementList)->push_back((yyvsp[0].syntaxElement)); (yyval.syntaxElementList) = (yyvsp[-2].syntaxElementList); }
+#line 3054 "./grammar.tab.c"
     break;
 
-  case 128:
+  case 128: /* memberDefs: memberDefs ';'  */
 #line 760 "./grammar.y"
-    { (yyval.syntaxElementList) = (yyvsp[(1) - (2)].syntaxElementList); }
+                                                { (yyval.syntaxElementList) = (yyvsp[-1].syntaxElementList); }
+#line 3060 "./grammar.tab.c"
     break;
 
-  case 129:
+  case 129: /* memberDefs: memberDefs '\n' memberDef  */
 #line 761 "./grammar.y"
-    { (yyvsp[(1) - (3)].syntaxElementList)->push_back((yyvsp[(3) - (3)].syntaxElement)); (yyval.syntaxElementList) = (yyvsp[(1) - (3)].syntaxElementList); }
+                                                { (yyvsp[-2].syntaxElementList)->push_back((yyvsp[0].syntaxElement)); (yyval.syntaxElementList) = (yyvsp[-2].syntaxElementList); }
+#line 3066 "./grammar.tab.c"
     break;
 
-  case 130:
+  case 130: /* memberDefs: memberDefs '\n'  */
 #line 762 "./grammar.y"
-    { (yyval.syntaxElementList) = (yyvsp[(1) - (2)].syntaxElementList); }
+                                                { (yyval.syntaxElementList) = (yyvsp[-1].syntaxElementList); }
+#line 3072 "./grammar.tab.c"
     break;
 
-  case 131:
+  case 131: /* memberDef: formal  */
 #line 765 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxFormal); }
+                                    { (yyval.syntaxElement) = (yyvsp[0].syntaxFormal); }
+#line 3078 "./grammar.tab.c"
     break;
 
-  case 132:
+  case 132: /* memberDef: PROTECTED formal  */
 #line 766 "./grammar.y"
-    { (yyvsp[(2) - (2)].syntaxFormal)->setIsProtected(); (yyval.syntaxElement) = (yyvsp[(2) - (2)].syntaxFormal); }
+                                    { (yyvsp[0].syntaxFormal)->setIsProtected(); (yyval.syntaxElement) = (yyvsp[0].syntaxFormal); }
+#line 3084 "./grammar.tab.c"
     break;
 
-  case 133:
+  case 133: /* memberDef: functionDef  */
 #line 767 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                    { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 3090 "./grammar.tab.c"
     break;
 
-  case 134:
+  case 134: /* memberDef: procedureDef  */
 #line 768 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(1) - (1)].syntaxElement); }
+                                    { (yyval.syntaxElement) = (yyvsp[0].syntaxElement); }
+#line 3096 "./grammar.tab.c"
     break;
 
-  case 135:
+  case 135: /* classDef: CLASS identifier ':' identifier '{' memberDefs '}'  */
 #line 772 "./grammar.y"
-    {
+                {
 #ifdef DEBUG_BISON_FLEX
                 printf("Parser inserting class definition (CLASS_DEF) in syntax tree\n");
 #endif
-                    (yyval.syntaxElement) = new SyntaxClassDef(*(yyvsp[(2) - (7)].string), *(yyvsp[(4) - (7)].string), (yyvsp[(6) - (7)].syntaxElementList));
-                    delete (yyvsp[(2) - (7)].string);
-                    delete (yyvsp[(4) - (7)].string);
+                    (yyval.syntaxElement) = new SyntaxClassDef(*(yyvsp[-5].string), *(yyvsp[-3].string), (yyvsp[-1].syntaxElementList));
+                    delete (yyvsp[-5].string);
+                    delete (yyvsp[-3].string);
                 }
+#line 3109 "./grammar.tab.c"
     break;
 
-  case 136:
+  case 136: /* ifStatement: IF cond stmts  */
 #line 782 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxStatement(SyntaxStatement::If, (yyvsp[(2) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElementList)); }
+                                            { (yyval.syntaxElement) = new SyntaxStatement(SyntaxStatement::If, (yyvsp[-1].syntaxElement), (yyvsp[0].syntaxElementList)); }
+#line 3115 "./grammar.tab.c"
     break;
 
-  case 137:
+  case 137: /* ifStatement: IF cond stmts ELSE stmts  */
 #line 783 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxStatement(SyntaxStatement::IfElse, (yyvsp[(2) - (5)].syntaxElement), (yyvsp[(3) - (5)].syntaxElementList), (yyvsp[(5) - (5)].syntaxElementList)); }
+                                            { (yyval.syntaxElement) = new SyntaxStatement(SyntaxStatement::IfElse, (yyvsp[-3].syntaxElement), (yyvsp[-2].syntaxElementList), (yyvsp[0].syntaxElementList)); }
+#line 3121 "./grammar.tab.c"
     break;
 
-  case 138:
+  case 138: /* cond: '(' expression ')'  */
 #line 785 "./grammar.y"
-    { (yyval.syntaxElement) = (yyvsp[(2) - (3)].syntaxElement); }
+                                  { (yyval.syntaxElement) = (yyvsp[-1].syntaxElement); }
+#line 3127 "./grammar.tab.c"
     break;
 
-  case 139:
+  case 139: /* forStatement: FOR forCond stmts  */
 #line 788 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxStatement(SyntaxStatement::For, (yyvsp[(2) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElementList)); }
+                                        { (yyval.syntaxElement) = new SyntaxStatement(SyntaxStatement::For, (yyvsp[-1].syntaxElement), (yyvsp[0].syntaxElementList)); }
+#line 3133 "./grammar.tab.c"
     break;
 
-  case 140:
+  case 140: /* forCond: '(' identifier IN expression ')'  */
 #line 791 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxForLoop(*(yyvsp[(2) - (5)].string), (yyvsp[(4) - (5)].syntaxElement)); delete (yyvsp[(2) - (5)].string); }
+                                                    { (yyval.syntaxElement) = new SyntaxForLoop(*(yyvsp[-3].string), (yyvsp[-1].syntaxElement)); delete (yyvsp[-3].string); }
+#line 3139 "./grammar.tab.c"
     break;
 
-  case 141:
+  case 141: /* whileStatement: WHILE cond stmts  */
 #line 794 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxStatement(SyntaxStatement::While, (yyvsp[(2) - (3)].syntaxElement), (yyvsp[(3) - (3)].syntaxElementList)); }
+                                        { (yyval.syntaxElement) = new SyntaxStatement(SyntaxStatement::While, (yyvsp[-1].syntaxElement), (yyvsp[0].syntaxElementList)); }
+#line 3145 "./grammar.tab.c"
     break;
 
-  case 142:
+  case 142: /* nextStatement: NEXT  */
 #line 797 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxStatement(SyntaxStatement::Next); }
+                            { (yyval.syntaxElement) = new SyntaxStatement(SyntaxStatement::Next); }
+#line 3151 "./grammar.tab.c"
     break;
 
-  case 143:
+  case 143: /* breakStatement: BREAK  */
 #line 800 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxStatement(SyntaxStatement::Break); }
+                            { (yyval.syntaxElement) = new SyntaxStatement(SyntaxStatement::Break); }
+#line 3157 "./grammar.tab.c"
     break;
 
-  case 144:
+  case 144: /* returnStatement: RETURN  */
 #line 803 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxStatement(SyntaxStatement::Return); }
+                                        { (yyval.syntaxElement) = new SyntaxStatement(SyntaxStatement::Return); }
+#line 3163 "./grammar.tab.c"
     break;
 
-  case 145:
+  case 145: /* returnStatement: RETURN expression  */
 #line 804 "./grammar.y"
-    { (yyval.syntaxElement) = new SyntaxStatement(SyntaxStatement::Return, (yyvsp[(2) - (2)].syntaxElement)); }
+                                        { (yyval.syntaxElement) = new SyntaxStatement(SyntaxStatement::Return, (yyvsp[0].syntaxElement)); }
+#line 3169 "./grammar.tab.c"
     break;
 
-  case 146:
+  case 146: /* identifier: NAME  */
 #line 807 "./grammar.y"
-    { (yyval.string) = new std::string((yyvsp[(1) - (1)].c_string)); }
+                        { (yyval.string) = new std::string((yyvsp[0].c_string)); }
+#line 3175 "./grammar.tab.c"
     break;
 
-  case 147:
+  case 147: /* vector: '[' vectorList ']'  */
 #line 811 "./grammar.y"
-    { (yyval.argumentList) = (yyvsp[(2) - (3)].argumentList); }
+                                        { (yyval.argumentList) = (yyvsp[-1].argumentList); }
+#line 3181 "./grammar.tab.c"
     break;
 
-  case 148:
+  case 148: /* vectorList: vectorList ',' expression  */
 #line 814 "./grammar.y"
-    { (yyvsp[(1) - (3)].argumentList)->push_back(new SyntaxLabeledExpr( "", (yyvsp[(3) - (3)].syntaxElement)) ); (yyval.argumentList) = (yyvsp[(1) - (3)].argumentList); }
+                                            { (yyvsp[-2].argumentList)->push_back(new SyntaxLabeledExpr( "", (yyvsp[0].syntaxElement)) ); (yyval.argumentList) = (yyvsp[-2].argumentList); }
+#line 3187 "./grammar.tab.c"
     break;
 
-  case 149:
+  case 149: /* vectorList: expression  */
 #line 816 "./grammar.y"
-    {
-                (yyval.argumentList) = new std::list<SyntaxLabeledExpr*>(1, new SyntaxLabeledExpr("", (yyvsp[(1) - (1)].syntaxElement)) );
+                {
+                (yyval.argumentList) = new std::list<SyntaxLabeledExpr*>(1, new SyntaxLabeledExpr("", (yyvsp[0].syntaxElement)) );
                 }
+#line 3195 "./grammar.tab.c"
     break;
 
-  case 150:
+  case 150: /* constant: FALSE  */
 #line 822 "./grammar.y"
-    {
+                {
                     (yyval.syntaxElement) = new SyntaxConstant(new RlBoolean(false) );
                 }
+#line 3203 "./grammar.tab.c"
     break;
 
-  case 151:
+  case 151: /* constant: TRUE  */
 #line 826 "./grammar.y"
-    {
+                {
                     (yyval.syntaxElement) = new SyntaxConstant(new RlBoolean(true) );
                 }
+#line 3211 "./grammar.tab.c"
     break;
 
-  case 152:
+  case 152: /* constant: RBNULL  */
 #line 830 "./grammar.y"
-    {
+                {
                     (yyval.syntaxElement) = new SyntaxConstant( NULL );
                 }
+#line 3219 "./grammar.tab.c"
     break;
 
-  case 153:
+  case 153: /* constant: RBTAB  */
 #line 834 "./grammar.y"
-    {
+                {
                     (yyval.syntaxElement) = new SyntaxConstant( new RlString("\t") );
                 }
+#line 3227 "./grammar.tab.c"
     break;
 
-  case 154:
+  case 154: /* constant: RBINF  */
 #line 838 "./grammar.y"
-    {
+                {
                     (yyval.syntaxElement) = new SyntaxConstant( new RealPos( RbConstants::Double::inf ) );
                 }
+#line 3235 "./grammar.tab.c"
     break;
 
-  case 155:
+  case 155: /* constant: INT  */
 #line 842 "./grammar.y"
-    {
-                    if ( (yyvsp[(1) - (1)].longIntValue) < 0 ) {
-                        (yyval.syntaxElement) = new SyntaxConstant(new Integer((yyvsp[(1) - (1)].longIntValue)) );
+                {
+                    if ( (yyvsp[0].longIntValue) < 0 ) {
+                        (yyval.syntaxElement) = new SyntaxConstant(new Integer((yyvsp[0].longIntValue)) );
                     }
                     else { 
-                        (yyval.syntaxElement) = new SyntaxConstant(new Natural((yyvsp[(1) - (1)].longIntValue)) );
+                        (yyval.syntaxElement) = new SyntaxConstant(new Natural((yyvsp[0].longIntValue)) );
                     }
                 }
+#line 3248 "./grammar.tab.c"
     break;
 
-  case 156:
+  case 156: /* constant: STRING  */
 #line 851 "./grammar.y"
-    {
-                    (yyval.syntaxElement) = new SyntaxConstant(new RlString((yyvsp[(1) - (1)].c_string)) );
+                {
+                    (yyval.syntaxElement) = new SyntaxConstant(new RlString((yyvsp[0].c_string)) );
                 }
+#line 3256 "./grammar.tab.c"
     break;
 
-  case 157:
+  case 157: /* constant: REAL  */
 #line 855 "./grammar.y"
-    {
+                {
                     /* This code records and preserves input format of the real */
                     /*
                     int prec;
@@ -3337,123 +3296,101 @@ yyreduce:
                     real->setScientific(sci);
                     */
                     
-                    if ((yyvsp[(1) - (1)].realValue) >= 0.0 && (yyvsp[(1) - (1)].realValue) <= 1.0) {
+                    if ((yyvsp[0].realValue) >= 0.0 && (yyvsp[0].realValue) <= 1.0) {
                         #ifdef DEBUG_BISON_FLEX
                         printf("Parser inserting RealPos constant in syntax tree \n");
                         #endif
-                        (yyval.syntaxElement) = new SyntaxConstant(new Probability((yyvsp[(1) - (1)].realValue)) );
+                        (yyval.syntaxElement) = new SyntaxConstant(new Probability((yyvsp[0].realValue)) );
                     }
-                    else if ((yyvsp[(1) - (1)].realValue) >= 0.0) {
+                    else if ((yyvsp[0].realValue) >= 0.0) {
 #ifdef DEBUG_BISON_FLEX
                         printf("Parser inserting RealPos constant in syntax tree \n");
 #endif
-                        (yyval.syntaxElement) = new SyntaxConstant(new RealPos((yyvsp[(1) - (1)].realValue)) );
+                        (yyval.syntaxElement) = new SyntaxConstant(new RealPos((yyvsp[0].realValue)) );
                     }
                     else {
 #ifdef DEBUG_BISON_FLEX
                         printf("Parser inserting Real constant in syntax tree \n");
 #endif
-                        (yyval.syntaxElement) = new SyntaxConstant(new Real((yyvsp[(1) - (1)].realValue)) );
+                        (yyval.syntaxElement) = new SyntaxConstant(new Real((yyvsp[0].realValue)) );
                     }
                 }
+#line 3319 "./grammar.tab.c"
     break;
 
 
-/* Line 1267 of yacc.c.  */
-#line 3359 "./grammar.tab.c"
+#line 3323 "./grammar.tab.c"
+
       default: break;
     }
-  YY_SYMBOL_PRINT ("-> $$ =", yyr1[yyn], &yyval, &yyloc);
+  /* User semantic actions sometimes alter yychar, and that requires
+     that yytoken be updated with the new translation.  We take the
+     approach of translating immediately before every use of yytoken.
+     One alternative is translating here after every semantic action,
+     but that translation would be missed if the semantic action invokes
+     YYABORT, YYACCEPT, or YYERROR immediately after altering yychar or
+     if it invokes YYBACKUP.  In the case of YYABORT or YYACCEPT, an
+     incorrect destructor might then be invoked immediately.  In the
+     case of YYERROR or YYBACKUP, subsequent parser actions might lead
+     to an incorrect destructor call or verbose syntax error message
+     before the lookahead is translated.  */
+  YY_SYMBOL_PRINT ("-> $$ =", YY_CAST (yysymbol_kind_t, yyr1[yyn]), &yyval, &yyloc);
 
   YYPOPSTACK (yylen);
   yylen = 0;
-  YY_STACK_PRINT (yyss, yyssp);
 
   *++yyvsp = yyval;
   *++yylsp = yyloc;
 
-  /* Now `shift' the result of the reduction.  Determine what state
+  /* Now 'shift' the result of the reduction.  Determine what state
      that goes to, based on the state we popped back to and the rule
      number reduced by.  */
-
-  yyn = yyr1[yyn];
-
-  yystate = yypgoto[yyn - YYNTOKENS] + *yyssp;
-  if (0 <= yystate && yystate <= YYLAST && yycheck[yystate] == *yyssp)
-    yystate = yytable[yystate];
-  else
-    yystate = yydefgoto[yyn - YYNTOKENS];
+  {
+    const int yylhs = yyr1[yyn] - YYNTOKENS;
+    const int yyi = yypgoto[yylhs] + *yyssp;
+    yystate = (0 <= yyi && yyi <= YYLAST && yycheck[yyi] == *yyssp
+               ? yytable[yyi]
+               : yydefgoto[yylhs]);
+  }
 
   goto yynewstate;
 
 
-/*------------------------------------.
-| yyerrlab -- here on detecting error |
-`------------------------------------*/
+/*--------------------------------------.
+| yyerrlab -- here on detecting error.  |
+`--------------------------------------*/
 yyerrlab:
+  /* Make sure we have latest lookahead translation.  See comments at
+     user semantic actions for why this is necessary.  */
+  yytoken = yychar == YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
   /* If not already recovering from an error, report this error.  */
   if (!yyerrstatus)
     {
       ++yynerrs;
-#if ! YYERROR_VERBOSE
       yyerror (YY_("syntax error"));
-#else
-      {
-	YYSIZE_T yysize = yysyntax_error (0, yystate, yychar);
-	if (yymsg_alloc < yysize && yymsg_alloc < YYSTACK_ALLOC_MAXIMUM)
-	  {
-	    YYSIZE_T yyalloc = 2 * yysize;
-	    if (! (yysize <= yyalloc && yyalloc <= YYSTACK_ALLOC_MAXIMUM))
-	      yyalloc = YYSTACK_ALLOC_MAXIMUM;
-	    if (yymsg != yymsgbuf)
-	      YYSTACK_FREE (yymsg);
-	    yymsg = (char *) YYSTACK_ALLOC (yyalloc);
-	    if (yymsg)
-	      yymsg_alloc = yyalloc;
-	    else
-	      {
-		yymsg = yymsgbuf;
-		yymsg_alloc = sizeof yymsgbuf;
-	      }
-	  }
-
-	if (0 < yysize && yysize <= yymsg_alloc)
-	  {
-	    (void) yysyntax_error (yymsg, yystate, yychar);
-	    yyerror (yymsg);
-	  }
-	else
-	  {
-	    yyerror (YY_("syntax error"));
-	    if (yysize != 0)
-	      goto yyexhaustedlab;
-	  }
-      }
-#endif
     }
 
-  yyerror_range[0] = yylloc;
-
+  yyerror_range[1] = yylloc;
   if (yyerrstatus == 3)
     {
-      /* If just tried and failed to reuse look-ahead token after an
-	 error, discard it.  */
+      /* If just tried and failed to reuse lookahead token after an
+         error, discard it.  */
 
       if (yychar <= YYEOF)
-	{
-	  /* Return failure if at end of input.  */
-	  if (yychar == YYEOF)
-	    YYABORT;
-	}
+        {
+          /* Return failure if at end of input.  */
+          if (yychar == YYEOF)
+            YYABORT;
+        }
       else
-	{
-	  yydestruct ("Error: discarding",
-		      yytoken, &yylval, &yylloc);
-	  yychar = YYEMPTY;
-	}
+        {
+          yydestruct ("Error: discarding",
+                      yytoken, &yylval, &yylloc);
+          yychar = YYEMPTY;
+        }
     }
 
-  /* Else will try to reuse look-ahead token after shifting the error
+  /* Else will try to reuse lookahead token after shifting the error
      token.  */
   goto yyerrlab1;
 
@@ -3462,15 +3399,13 @@ yyerrlab:
 | yyerrorlab -- error raised explicitly by YYERROR.  |
 `---------------------------------------------------*/
 yyerrorlab:
+  /* Pacify compilers when the user code never invokes YYERROR and the
+     label yyerrorlab therefore never appears in user code.  */
+  if (0)
+    YYERROR;
+  ++yynerrs;
 
-  /* Pacify compilers like GCC when the user code never invokes
-     YYERROR and the label yyerrorlab therefore never appears in user
-     code.  */
-  if (/*CONSTCOND*/ 0)
-     goto yyerrorlab;
-
-  yyerror_range[0] = yylsp[1-yylen];
-  /* Do not reclaim the symbols of the rule which action triggered
+  /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
   YYPOPSTACK (yylen);
   yylen = 0;
@@ -3483,47 +3418,45 @@ yyerrorlab:
 | yyerrlab1 -- common code for both syntax error and YYERROR.  |
 `-------------------------------------------------------------*/
 yyerrlab1:
-  yyerrstatus = 3;	/* Each real token shifted decrements this.  */
+  yyerrstatus = 3;      /* Each real token shifted decrements this.  */
 
+  /* Pop stack until we find a state that shifts the error token.  */
   for (;;)
     {
       yyn = yypact[yystate];
-      if (yyn != YYPACT_NINF)
-	{
-	  yyn += YYTERROR;
-	  if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYTERROR)
-	    {
-	      yyn = yytable[yyn];
-	      if (0 < yyn)
-		break;
-	    }
-	}
+      if (!yypact_value_is_default (yyn))
+        {
+          yyn += YYSYMBOL_YYerror;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_YYerror)
+            {
+              yyn = yytable[yyn];
+              if (0 < yyn)
+                break;
+            }
+        }
 
       /* Pop the current state because it cannot handle the error token.  */
       if (yyssp == yyss)
-	YYABORT;
+        YYABORT;
 
-      yyerror_range[0] = *yylsp;
+      yyerror_range[1] = *yylsp;
       yydestruct ("Error: popping",
-		  yystos[yystate], yyvsp, yylsp);
+                  YY_ACCESSING_SYMBOL (yystate), yyvsp, yylsp);
       YYPOPSTACK (1);
       yystate = *yyssp;
       YY_STACK_PRINT (yyss, yyssp);
     }
 
-  if (yyn == YYFINAL)
-    YYACCEPT;
-
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 
-  yyerror_range[1] = yylloc;
-  /* Using YYLLOC is tempting, but would change the location of
-     the look-ahead.  YYLOC is available though.  */
-  YYLLOC_DEFAULT (yyloc, (yyerror_range - 1), 2);
-  *++yylsp = yyloc;
+  yyerror_range[2] = yylloc;
+  ++yylsp;
+  YYLLOC_DEFAULT (*yylsp, yyerror_range, 2);
 
   /* Shift the error token.  */
-  YY_SYMBOL_PRINT ("Shifting", yystos[yyn], yyvsp, yylsp);
+  YY_SYMBOL_PRINT ("Shifting", YY_ACCESSING_SYMBOL (yyn), yyvsp, yylsp);
 
   yystate = yyn;
   goto yynewstate;
@@ -3534,51 +3467,55 @@ yyerrlab1:
 `-------------------------------------*/
 yyacceptlab:
   yyresult = 0;
-  goto yyreturn;
+  goto yyreturnlab;
+
 
 /*-----------------------------------.
 | yyabortlab -- YYABORT comes here.  |
 `-----------------------------------*/
 yyabortlab:
   yyresult = 1;
-  goto yyreturn;
+  goto yyreturnlab;
 
-#ifndef yyoverflow
-/*-------------------------------------------------.
-| yyexhaustedlab -- memory exhaustion comes here.  |
-`-------------------------------------------------*/
+
+/*-----------------------------------------------------------.
+| yyexhaustedlab -- YYNOMEM (memory exhaustion) comes here.  |
+`-----------------------------------------------------------*/
 yyexhaustedlab:
   yyerror (YY_("memory exhausted"));
   yyresult = 2;
-  /* Fall through.  */
-#endif
+  goto yyreturnlab;
 
-yyreturn:
-  if (yychar != YYEOF && yychar != YYEMPTY)
-     yydestruct ("Cleanup: discarding lookahead",
-		 yytoken, &yylval, &yylloc);
-  /* Do not reclaim the symbols of the rule which action triggered
+
+/*----------------------------------------------------------.
+| yyreturnlab -- parsing is finished, clean up and return.  |
+`----------------------------------------------------------*/
+yyreturnlab:
+  if (yychar != YYEMPTY)
+    {
+      /* Make sure we have latest lookahead translation.  See comments at
+         user semantic actions for why this is necessary.  */
+      yytoken = YYTRANSLATE (yychar);
+      yydestruct ("Cleanup: discarding lookahead",
+                  yytoken, &yylval, &yylloc);
+    }
+  /* Do not reclaim the symbols of the rule whose action triggered
      this YYABORT or YYACCEPT.  */
   YYPOPSTACK (yylen);
   YY_STACK_PRINT (yyss, yyssp);
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-		  yystos[*yyssp], yyvsp, yylsp);
+                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp, yylsp);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
   if (yyss != yyssa)
     YYSTACK_FREE (yyss);
 #endif
-#if YYERROR_VERBOSE
-  if (yymsg != yymsgbuf)
-    YYSTACK_FREE (yymsg);
-#endif
-  /* Make sure YYID is used.  */
-  return YYID (yyresult);
-}
 
+  return yyresult;
+}
 
 #line 915 "./grammar.y"
 
@@ -3600,6 +3537,5 @@ int yyerror(const char *msg)
 
     return 1;
 }
-
 
 

--- a/src/revlanguage/parser/grammar.tab.h
+++ b/src/revlanguage/parser/grammar.tab.h
@@ -1,14 +1,14 @@
-/* A Bison parser, made by GNU Bison 2.3.  */
+/* A Bison parser, made by GNU Bison 3.8.2.  */
 
-/* Skeleton interface for Bison's Yacc-like parsers in C
+/* Bison interface for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989, 1990, 2000, 2001, 2002, 2003, 2004, 2005, 2006
-   Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2021 Free Software Foundation,
+   Inc.
 
-   This program is free software; you can redistribute it and/or modify
+   This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
-   the Free Software Foundation; either version 2, or (at your option)
-   any later version.
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
 
    This program is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -16,9 +16,7 @@
    GNU General Public License for more details.
 
    You should have received a copy of the GNU General Public License
-   along with this program; if not, write to the Free Software
-   Foundation, Inc., 51 Franklin Street, Fifth Floor,
-   Boston, MA 02110-1301, USA.  */
+   along with this program.  If not, see <https://www.gnu.org/licenses/>.  */
 
 /* As a special exception, you may create a larger work that contains
    part or all of the Bison parser skeleton and distribute that work
@@ -33,67 +31,89 @@
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
-/* Tokens.  */
+/* DO NOT RELY ON FEATURES THAT ARE NOT DOCUMENTED in the manual,
+   especially those whose name start with YY_ or yy_.  They are
+   private implementation details that can be changed or removed.  */
+
+#ifndef YY_YY_GRAMMAR_TAB_H_INCLUDED
+# define YY_YY_GRAMMAR_TAB_H_INCLUDED
+/* Debug traces.  */
+#ifndef YYDEBUG
+# define YYDEBUG 0
+#endif
+#if YYDEBUG
+extern int yydebug;
+#endif
+
+/* Token kinds.  */
 #ifndef YYTOKENTYPE
 # define YYTOKENTYPE
-   /* Put the tokens into the symbol table, so that GDB and other debuggers
-      know about them.  */
-   enum yytokentype {
-     REAL = 258,
-     INT = 259,
-     NAME = 260,
-     STRING = 261,
-     RBNULL = 262,
-     RBTAB = 263,
-     FALSE = 264,
-     TRUE = 265,
-     RBINF = 266,
-     FUNCTION = 267,
-     PROCEDURE = 268,
-     CLASS = 269,
-     FOR = 270,
-     IN = 271,
-     IF = 272,
-     ELSE = 273,
-     WHILE = 274,
-     NEXT = 275,
-     BREAK = 276,
-     RETURN = 277,
-     MOD_CONST = 278,
-     MOD_DYNAMIC = 279,
-     MOD_STOCHASTIC = 280,
-     MOD_DETERMINISTIC = 281,
-     PROTECTED = 282,
-     ARROW_ASSIGN = 283,
-     TILDE_ASSIGN = 284,
-     EQUATION_ASSIGN = 285,
-     WORKSPACE_ASSIGN = 286,
-     REFERENCE_ASSIGN = 287,
-     ADDITION_ASSIGN = 288,
-     SUBTRACTION_ASSIGN = 289,
-     MULTIPLICATION_ASSIGN = 290,
-     DIVISION_ASSIGN = 291,
-     DECREMENT = 292,
-     INCREMENT = 293,
-     EQUAL = 294,
-     AND = 295,
-     OR = 296,
-     AND2 = 297,
-     OR2 = 298,
-     GT = 299,
-     GE = 300,
-     LT = 301,
-     LE = 302,
-     EQ = 303,
-     NE = 304,
-     END_OF_INPUT = 305,
-     UNOT = 306,
-     UPLUS = 307,
-     UMINUS = 308,
-     UAND = 309
-   };
+  enum yytokentype
+  {
+    YYEMPTY = -2,
+    YYEOF = 0,                     /* "end of file"  */
+    YYerror = 256,                 /* error  */
+    YYUNDEF = 257,                 /* "invalid token"  */
+    REAL = 258,                    /* REAL  */
+    INT = 259,                     /* INT  */
+    NAME = 260,                    /* NAME  */
+    STRING = 261,                  /* STRING  */
+    RBNULL = 262,                  /* RBNULL  */
+    RBTAB = 263,                   /* RBTAB  */
+    FALSE = 264,                   /* FALSE  */
+    TRUE = 265,                    /* TRUE  */
+    RBINF = 266,                   /* RBINF  */
+    FUNCTION = 267,                /* FUNCTION  */
+    PROCEDURE = 268,               /* PROCEDURE  */
+    CLASS = 269,                   /* CLASS  */
+    FOR = 270,                     /* FOR  */
+    IN = 271,                      /* IN  */
+    IF = 272,                      /* IF  */
+    ELSE = 273,                    /* ELSE  */
+    WHILE = 274,                   /* WHILE  */
+    NEXT = 275,                    /* NEXT  */
+    BREAK = 276,                   /* BREAK  */
+    RETURN = 277,                  /* RETURN  */
+    MOD_CONST = 278,               /* MOD_CONST  */
+    MOD_DYNAMIC = 279,             /* MOD_DYNAMIC  */
+    MOD_STOCHASTIC = 280,          /* MOD_STOCHASTIC  */
+    MOD_DETERMINISTIC = 281,       /* MOD_DETERMINISTIC  */
+    PROTECTED = 282,               /* PROTECTED  */
+    ARROW_ASSIGN = 283,            /* ARROW_ASSIGN  */
+    TILDE_ASSIGN = 284,            /* TILDE_ASSIGN  */
+    EQUATION_ASSIGN = 285,         /* EQUATION_ASSIGN  */
+    WORKSPACE_ASSIGN = 286,        /* WORKSPACE_ASSIGN  */
+    REFERENCE_ASSIGN = 287,        /* REFERENCE_ASSIGN  */
+    ADDITION_ASSIGN = 288,         /* ADDITION_ASSIGN  */
+    SUBTRACTION_ASSIGN = 289,      /* SUBTRACTION_ASSIGN  */
+    MULTIPLICATION_ASSIGN = 290,   /* MULTIPLICATION_ASSIGN  */
+    DIVISION_ASSIGN = 291,         /* DIVISION_ASSIGN  */
+    DECREMENT = 292,               /* DECREMENT  */
+    INCREMENT = 293,               /* INCREMENT  */
+    EQUAL = 294,                   /* EQUAL  */
+    AND = 295,                     /* AND  */
+    OR = 296,                      /* OR  */
+    AND2 = 297,                    /* AND2  */
+    OR2 = 298,                     /* OR2  */
+    GT = 299,                      /* GT  */
+    GE = 300,                      /* GE  */
+    LT = 301,                      /* LT  */
+    LE = 302,                      /* LE  */
+    EQ = 303,                      /* EQ  */
+    NE = 304,                      /* NE  */
+    END_OF_INPUT = 305,            /* END_OF_INPUT  */
+    UNOT = 306,                    /* UNOT  */
+    UMINUS = 307,                  /* UMINUS  */
+    UPLUS = 308,                   /* UPLUS  */
+    UAND = 309                     /* UAND  */
+  };
+  typedef enum yytokentype yytoken_kind_t;
 #endif
-/* Tokens.  */
+/* Token kinds.  */
+#define YYEMPTY -2
+#define YYEOF 0
+#define YYerror 256
+#define YYUNDEF 257
 #define REAL 258
 #define INT 259
 #define NAME 260
@@ -143,21 +163,20 @@
 #define NE 304
 #define END_OF_INPUT 305
 #define UNOT 306
-#define UPLUS 307
-#define UMINUS 308
+#define UMINUS 307
+#define UPLUS 308
 #define UAND 309
 
-
-
-
+/* Value type.  */
 #if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
-typedef union YYSTYPE
-#line 80 "./grammar.y"
+union YYSTYPE
 {
+#line 80 "./grammar.y"
+
     char*                                           c_string;
     std::string*                                    string;
     double                                          realValue;
-    long                                            longIntValue;
+    long                                             longIntValue;
     bool                                            boolValue;
     RevLanguage::SyntaxElement*                     syntaxElement;
     RevLanguage::SyntaxVariable*                    syntaxVariable;
@@ -167,28 +186,34 @@ typedef union YYSTYPE
     std::list<RevLanguage::SyntaxElement*>*         syntaxElementList;
     std::list<RevLanguage::SyntaxLabeledExpr*>*     argumentList;
     std::list<RevLanguage::SyntaxFormal*>*          formalList;
-}
-/* Line 1529 of yacc.c.  */
-#line 173 "./grammar.tab.h"
-	YYSTYPE;
-# define yystype YYSTYPE /* obsolescent; will be withdrawn */
-# define YYSTYPE_IS_DECLARED 1
+
+#line 191 "./grammar.tab.h"
+
+};
+typedef union YYSTYPE YYSTYPE;
 # define YYSTYPE_IS_TRIVIAL 1
+# define YYSTYPE_IS_DECLARED 1
 #endif
 
-extern YYSTYPE yylval;
-
+/* Location type.  */
 #if ! defined YYLTYPE && ! defined YYLTYPE_IS_DECLARED
-typedef struct YYLTYPE
+typedef struct YYLTYPE YYLTYPE;
+struct YYLTYPE
 {
   int first_line;
   int first_column;
   int last_line;
   int last_column;
-} YYLTYPE;
-# define yyltype YYLTYPE /* obsolescent; will be withdrawn */
+};
 # define YYLTYPE_IS_DECLARED 1
 # define YYLTYPE_IS_TRIVIAL 1
 #endif
 
+
+extern YYSTYPE yylval;
 extern YYLTYPE yylloc;
+
+int yyparse (void);
+
+
+#endif /* !YY_YY_GRAMMAR_TAB_H_INCLUDED  */

--- a/src/revlanguage/parser/lex.yy.cpp
+++ b/src/revlanguage/parser/lex.yy.cpp
@@ -8,8 +8,8 @@
 
 #define FLEX_SCANNER
 #define YY_FLEX_MAJOR_VERSION 2
-#define YY_FLEX_MINOR_VERSION 5
-#define YY_FLEX_SUBMINOR_VERSION 35
+#define YY_FLEX_MINOR_VERSION 6
+#define YY_FLEX_SUBMINOR_VERSION 4
 #if YY_FLEX_SUBMINOR_VERSION > 0
 #define FLEX_BETA
 #endif
@@ -47,7 +47,6 @@ typedef int16_t flex_int16_t;
 typedef uint16_t flex_uint16_t;
 typedef int32_t flex_int32_t;
 typedef uint32_t flex_uint32_t;
-typedef uint64_t flex_uint64_t;
 #else
 typedef signed char flex_int8_t;
 typedef short int flex_int16_t;
@@ -55,7 +54,6 @@ typedef int flex_int32_t;
 typedef unsigned char flex_uint8_t; 
 typedef unsigned short int flex_uint16_t;
 typedef unsigned int flex_uint32_t;
-#endif /* ! C99 */
 
 /* Limits of integral types. */
 #ifndef INT8_MIN
@@ -86,63 +84,61 @@ typedef unsigned int flex_uint32_t;
 #define UINT32_MAX             (4294967295U)
 #endif
 
+#ifndef SIZE_MAX
+#define SIZE_MAX               (~(size_t)0)
+#endif
+
+#endif /* ! C99 */
+
 #endif /* ! FLEXINT_H */
 
-#ifdef __cplusplus
+/* begin standard C++ headers. */
 
-/* The "const" storage-class-modifier is valid. */
-#define YY_USE_CONST
-
-#else	/* ! __cplusplus */
-
-/* C99 requires __STDC__ to be defined as 1. */
-#if defined (__STDC__)
-
-#define YY_USE_CONST
-
-#endif	/* defined (__STDC__) */
-#endif	/* ! __cplusplus */
-
-#ifdef YY_USE_CONST
+/* TODO: this is always defined, so inline it */
 #define yyconst const
+
+#if defined(__GNUC__) && __GNUC__ >= 3
+#define yynoreturn __attribute__((__noreturn__))
 #else
-#define yyconst
+#define yynoreturn
 #endif
 
 /* Returned upon end-of-file. */
 #define YY_NULL 0
 
-/* Promotes a possibly negative, possibly signed char to an unsigned
- * integer for use as an array index.  If the signed char is negative,
- * we want to instead treat it as an 8-bit unsigned char, hence the
- * double cast.
+/* Promotes a possibly negative, possibly signed char to an
+ *   integer in range [0..255] for use as an array index.
  */
-#define YY_SC_TO_UI(c) ((unsigned int) (unsigned char) c)
+#define YY_SC_TO_UI(c) ((YY_CHAR) (c))
 
 /* Enter a start condition.  This macro really ought to take a parameter,
  * but we do it the disgusting crufty way forced on us by the ()-less
  * definition of BEGIN.
  */
 #define BEGIN (yy_start) = 1 + 2 *
-
 /* Translate the current start state into a value that can be later handed
  * to BEGIN to return to the state.  The YYSTATE alias is for lex
  * compatibility.
  */
 #define YY_START (((yy_start) - 1) / 2)
 #define YYSTATE YY_START
-
 /* Action number for EOF rule of a given start state. */
 #define YY_STATE_EOF(state) (YY_END_OF_BUFFER + state + 1)
-
 /* Special action meaning "start processing a new file". */
-#define YY_NEW_FILE yyrestart(yyin  )
-
+#define YY_NEW_FILE yyrestart( yyin  )
 #define YY_END_OF_BUFFER_CHAR 0
 
 /* Size of default input buffer. */
 #ifndef YY_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k.
+ * Moreover, YY_BUF_SIZE is 2*YY_READ_BUF_SIZE in the general case.
+ * Ditto for the __ia64__ case accordingly.
+ */
+#define YY_BUF_SIZE 32768
+#else
 #define YY_BUF_SIZE 16384
+#endif /* __ia64__ */
 #endif
 
 /* The state buf must be large enough to hold one state per character in the main buffer.
@@ -159,15 +155,16 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern yy_size_t yyleng;
+extern int yyleng;
 
 extern FILE *yyin, *yyout;
 
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
 #define EOB_ACT_LAST_MATCH 2
-
+    
     #define YY_LESS_LINENO(n)
+    #define YY_LINENO_REWIND_TO(ptr)
     
 /* Return all but the first "n" matched characters back to the input stream. */
 #define yyless(n) \
@@ -182,7 +179,6 @@ extern FILE *yyin, *yyout;
 		YY_DO_BEFORE_ACTION; /* set up yytext again */ \
 		} \
 	while ( 0 )
-
 #define unput(c) yyunput( c, (yytext_ptr)  )
 
 #ifndef YY_STRUCT_YY_BUFFER_STATE
@@ -197,12 +193,12 @@ struct yy_buffer_state
 	/* Size of input buffer in bytes, not including room for EOB
 	 * characters.
 	 */
-	yy_size_t yy_buf_size;
+	int yy_buf_size;
 
 	/* Number of characters read into yy_ch_buf, not including EOB
 	 * characters.
 	 */
-	yy_size_t yy_n_chars;
+	int yy_n_chars;
 
 	/* Whether we "own" the buffer - i.e., we know we created it,
 	 * and can realloc() it to grow it, and should free() it to
@@ -225,7 +221,7 @@ struct yy_buffer_state
 
     int yy_bs_lineno; /**< The line count. */
     int yy_bs_column; /**< The column count. */
-    
+
 	/* Whether to try to fill the input buffer when we reach the
 	 * end of it.
 	 */
@@ -253,7 +249,7 @@ struct yy_buffer_state
 /* Stack of input buffers. */
 static size_t yy_buffer_stack_top = 0; /**< index of top of stack. */
 static size_t yy_buffer_stack_max = 0; /**< capacity of stack. */
-static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
+static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
 
 /* We provide macros for accessing buffer states in case in the
  * future we want to put the buffer states in a more general
@@ -264,7 +260,6 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 #define YY_CURRENT_BUFFER ( (yy_buffer_stack) \
                           ? (yy_buffer_stack)[(yy_buffer_stack_top)] \
                           : NULL)
-
 /* Same as previous macro, but useful when we know that the buffer stack is not
  * NULL or when we need an lvalue. For internal use only.
  */
@@ -272,11 +267,11 @@ static YY_BUFFER_STATE * yy_buffer_stack = 0; /**< Stack as an array. */
 
 /* yy_hold_char holds the character lost when yytext is formed. */
 static char yy_hold_char;
-static yy_size_t yy_n_chars;		/* number of characters read into yy_ch_buf */
-yy_size_t yyleng;
+static int yy_n_chars;		/* number of characters read into yy_ch_buf */
+int yyleng;
 
 /* Points to current character in buffer. */
-static char *yy_c_buf_p = (char *) 0;
+static char *yy_c_buf_p = NULL;
 static int yy_init = 0;		/* whether we need to initialize */
 static int yy_start = 0;	/* start state number */
 
@@ -285,82 +280,78 @@ static int yy_start = 0;	/* start state number */
  */
 static int yy_did_buffer_switch_on_eof;
 
-void yyrestart (FILE *input_file  );
-void yy_switch_to_buffer (YY_BUFFER_STATE new_buffer  );
-YY_BUFFER_STATE yy_create_buffer (FILE *file,int size  );
-void yy_delete_buffer (YY_BUFFER_STATE b  );
-void yy_flush_buffer (YY_BUFFER_STATE b  );
-void yypush_buffer_state (YY_BUFFER_STATE new_buffer  );
-void yypop_buffer_state (void );
+void yyrestart ( FILE *input_file  );
+void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
+YY_BUFFER_STATE yy_create_buffer ( FILE *file, int size  );
+void yy_delete_buffer ( YY_BUFFER_STATE b  );
+void yy_flush_buffer ( YY_BUFFER_STATE b  );
+void yypush_buffer_state ( YY_BUFFER_STATE new_buffer  );
+void yypop_buffer_state ( void );
 
-static void yyensure_buffer_stack (void );
-static void yy_load_buffer_state (void );
-static void yy_init_buffer (YY_BUFFER_STATE b,FILE *file  );
+static void yyensure_buffer_stack ( void );
+static void yy_load_buffer_state ( void );
+static void yy_init_buffer ( YY_BUFFER_STATE b, FILE *file  );
+#define YY_FLUSH_BUFFER yy_flush_buffer( YY_CURRENT_BUFFER )
 
-#define YY_FLUSH_BUFFER yy_flush_buffer(YY_CURRENT_BUFFER )
+YY_BUFFER_STATE yy_scan_buffer ( char *base, yy_size_t size  );
+YY_BUFFER_STATE yy_scan_string ( const char *yy_str  );
+YY_BUFFER_STATE yy_scan_bytes ( const char *bytes, int len  );
 
-YY_BUFFER_STATE yy_scan_buffer (char *base,yy_size_t size  );
-YY_BUFFER_STATE yy_scan_string (yyconst char *yy_str  );
-YY_BUFFER_STATE yy_scan_bytes (yyconst char *bytes,yy_size_t len  );
-
-void *yyalloc (yy_size_t  );
-void *yyrealloc (void *,yy_size_t  );
-void yyfree (void *  );
+void *yyalloc ( yy_size_t  );
+void *yyrealloc ( void *, yy_size_t  );
+void yyfree ( void *  );
 
 #define yy_new_buffer yy_create_buffer
-
 #define yy_set_interactive(is_interactive) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){ \
         yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer(yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_is_interactive = is_interactive; \
 	}
-
 #define yy_set_bol(at_bol) \
 	{ \
 	if ( ! YY_CURRENT_BUFFER ){\
         yyensure_buffer_stack (); \
 		YY_CURRENT_BUFFER_LVALUE =    \
-            yy_create_buffer(yyin,YY_BUF_SIZE ); \
+            yy_create_buffer( yyin, YY_BUF_SIZE ); \
 	} \
 	YY_CURRENT_BUFFER_LVALUE->yy_at_bol = at_bol; \
 	}
-
 #define YY_AT_BOL() (YY_CURRENT_BUFFER_LVALUE->yy_at_bol)
 
 /* Begin user sect3 */
+typedef flex_uint8_t YY_CHAR;
 
-typedef unsigned char YY_CHAR;
-
-FILE *yyin = (FILE *) 0, *yyout = (FILE *) 0;
+FILE *yyin = NULL, *yyout = NULL;
 
 typedef int yy_state_type;
 
 extern int yylineno;
-
 int yylineno = 1;
 
 extern char *yytext;
+#ifdef yytext_ptr
+#undef yytext_ptr
+#endif
 #define yytext_ptr yytext
 
-static yy_state_type yy_get_previous_state (void );
-static yy_state_type yy_try_NUL_trans (yy_state_type current_state  );
-static int yy_get_next_buffer (void );
-static void yy_fatal_error (yyconst char msg[]  );
+static yy_state_type yy_get_previous_state ( void );
+static yy_state_type yy_try_NUL_trans ( yy_state_type current_state  );
+static int yy_get_next_buffer ( void );
+static void yynoreturn yy_fatal_error ( const char* msg  );
 
 /* Done after the current pattern has been matched and before the
  * corresponding action - sets up yytext.
  */
 #define YY_DO_BEFORE_ACTION \
 	(yytext_ptr) = yy_bp; \
-	yyleng = (yy_size_t) (yy_cp - yy_bp); \
+	yyleng = (int) (yy_cp - yy_bp); \
 	(yy_hold_char) = *yy_cp; \
 	*yy_cp = '\0'; \
 	(yy_c_buf_p) = yy_cp;
-
 #define YY_NUM_RULES 58
 #define YY_END_OF_BUFFER 59
 /* This struct is not used in this scanner,
@@ -370,7 +361,7 @@ struct yy_trans_info
 	flex_int32_t yy_verify;
 	flex_int32_t yy_nxt;
 	};
-static yyconst flex_int16_t yy_accept[190] =
+static const flex_int16_t yy_accept[190] =
     {   0,
         0,    0,   59,   57,   54,   55,   57,   57,   32,   44,
        57,   57,   57,   57,   57,   29,   57,   56,   50,   43,
@@ -394,7 +385,7 @@ static yyconst flex_int16_t yy_accept[190] =
         2,   25,   30,   30,   23,   30,   30,   24,    0
     } ;
 
-static yyconst flex_int32_t yy_ec[256] =
+static const YY_CHAR yy_ec[256] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    2,    3,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -426,7 +417,7 @@ static yyconst flex_int32_t yy_ec[256] =
         1,    1,    1,    1,    1
     } ;
 
-static yyconst flex_int32_t yy_meta[56] =
+static const YY_CHAR yy_meta[56] =
     {   0,
         1,    1,    2,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    3,    1,    1,    1,    1,    1,    4,    4,
@@ -436,7 +427,7 @@ static yyconst flex_int32_t yy_meta[56] =
         4,    4,    4,    1,    1
     } ;
 
-static yyconst flex_int16_t yy_base[195] =
+static const flex_int16_t yy_base[195] =
     {   0,
         0,    0,  246,  247,  243,  247,  227,   51,    0,  236,
       225,   48,   49,  228,  223,   47,  222,  247,   51,  221,
@@ -462,7 +453,7 @@ static yyconst flex_int16_t yy_base[195] =
 
     } ;
 
-static yyconst flex_int16_t yy_def[195] =
+static const flex_int16_t yy_def[195] =
     {   0,
       189,    1,  189,  189,  189,  189,  189,  190,  191,  189,
       189,  189,  189,  189,  189,  189,  189,  189,  189,  189,
@@ -488,7 +479,7 @@ static yyconst flex_int16_t yy_def[195] =
 
     } ;
 
-static yyconst flex_int16_t yy_nxt[303] =
+static const flex_int16_t yy_nxt[303] =
     {   0,
         4,    5,    6,    7,    8,    9,   10,   11,   12,   13,
        14,   15,   16,   17,   18,   19,   20,   21,   22,   22,
@@ -526,7 +517,7 @@ static yyconst flex_int16_t yy_nxt[303] =
       189,  189
     } ;
 
-static yyconst flex_int16_t yy_chk[303] =
+static const flex_int16_t yy_chk[303] =
     {   0,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
         1,    1,    1,    1,    1,    1,    1,    1,    1,    1,
@@ -635,7 +626,8 @@ size_t yycolumn;
 
 #define YY_USER_ACTION yycolumn += yyleng;
 
-#line 639 "./lex.yy.cpp"
+#line 630 "./lex.yy.cpp"
+#line 631 "./lex.yy.cpp"
 
 #define INITIAL 0
 
@@ -651,36 +643,36 @@ size_t yycolumn;
 #define YY_EXTRA_TYPE void *
 #endif
 
-static int yy_init_globals (void );
+static int yy_init_globals ( void );
 
 /* Accessor methods to globals.
    These are made visible to non-reentrant scanners for convenience. */
 
-int yylex_destroy (void );
+int yylex_destroy ( void );
 
-int yyget_debug (void );
+int yyget_debug ( void );
 
-void yyset_debug (int debug_flag  );
+void yyset_debug ( int debug_flag  );
 
-YY_EXTRA_TYPE yyget_extra (void );
+YY_EXTRA_TYPE yyget_extra ( void );
 
-void yyset_extra (YY_EXTRA_TYPE user_defined  );
+void yyset_extra ( YY_EXTRA_TYPE user_defined  );
 
-FILE *yyget_in (void );
+FILE *yyget_in ( void );
 
-void yyset_in  (FILE * in_str  );
+void yyset_in  ( FILE * _in_str  );
 
-FILE *yyget_out (void );
+FILE *yyget_out ( void );
 
-void yyset_out  (FILE * out_str  );
+void yyset_out  ( FILE * _out_str  );
 
-yy_size_t yyget_leng (void );
+			int yyget_leng ( void );
 
-char *yyget_text (void );
+char *yyget_text ( void );
 
-int yyget_lineno (void );
+int yyget_lineno ( void );
 
-void yyset_lineno (int line_number  );
+void yyset_lineno ( int _line_number  );
 
 /* Macros after this point can all be overridden by user definitions in
  * section 1.
@@ -688,35 +680,43 @@ void yyset_lineno (int line_number  );
 
 #ifndef YY_SKIP_YYWRAP
 #ifdef __cplusplus
-extern "C" int yywrap (void );
+extern "C" int yywrap ( void );
 #else
-extern int yywrap (void );
+extern int yywrap ( void );
 #endif
 #endif
 
-    static void yyunput (int c,char *buf_ptr  );
+#ifndef YY_NO_UNPUT
     
+    static void yyunput ( int c, char *buf_ptr  );
+    
+#endif
+
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char *,yyconst char *,int );
+static void yy_flex_strncpy ( char *, const char *, int );
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * );
+static int yy_flex_strlen ( const char * );
 #endif
 
 #ifndef YY_NO_INPUT
-
 #ifdef __cplusplus
-static int yyinput (void );
+static int yyinput ( void );
 #else
-static int input (void );
+static int input ( void );
 #endif
 
 #endif
 
 /* Amount of stuff to slurp up with each read. */
 #ifndef YY_READ_BUF_SIZE
+#ifdef __ia64__
+/* On IA-64, the buffer size is 16k, not 8k */
+#define YY_READ_BUF_SIZE 16384
+#else
 #define YY_READ_BUF_SIZE 8192
+#endif /* __ia64__ */
 #endif
 
 /* Copy whatever the last rule matched to the standard output. */
@@ -724,7 +724,7 @@ static int input (void );
 /* This used to be an fputs(), but since the string might contain NUL's,
  * we now use fwrite().
  */
-#define ECHO fwrite( yytext, yyleng, 1, yyout )
+#define ECHO do { if (fwrite( yytext, (size_t) yyleng, 1, yyout )) {} } while (0)
 #endif
 
 /* Gets input and stuffs it into "buf".  number of characters read, or YY_NULL,
@@ -735,7 +735,7 @@ static int input (void );
 	if ( YY_CURRENT_BUFFER_LVALUE->yy_is_interactive ) \
 		{ \
 		int c = '*'; \
-		yy_size_t n; \
+		int n; \
 		for ( n = 0; n < max_size && \
 			     (c = getc( yyin )) != EOF && c != '\n'; ++n ) \
 			buf[n] = (char) c; \
@@ -748,7 +748,7 @@ static int input (void );
 	else \
 		{ \
 		errno=0; \
-		while ( (result = fread(buf, 1, max_size, yyin))==0 && ferror(yyin)) \
+		while ( (result = (int) fread(buf, 1, (yy_size_t) max_size, yyin)) == 0 && ferror(yyin)) \
 			{ \
 			if( errno != EINTR) \
 				{ \
@@ -803,7 +803,7 @@ extern int yylex (void);
 
 /* Code executed at the end of each rule. */
 #ifndef YY_BREAK
-#define YY_BREAK break;
+#define YY_BREAK /*LINTED*/break;
 #endif
 
 #define YY_RULE_SETUP \
@@ -813,14 +813,10 @@ extern int yylex (void);
  */
 YY_DECL
 {
-	register yy_state_type yy_current_state;
-	register char *yy_cp, *yy_bp;
-	register int yy_act;
+	yy_state_type yy_current_state;
+	char *yy_cp, *yy_bp;
+	int yy_act;
     
-#line 65 "./lex.l"
-
-#line 823 "./lex.yy.cpp"
-
 	if ( !(yy_init) )
 		{
 		(yy_init) = 1;
@@ -841,13 +837,18 @@ YY_DECL
 		if ( ! YY_CURRENT_BUFFER ) {
 			yyensure_buffer_stack ();
 			YY_CURRENT_BUFFER_LVALUE =
-				yy_create_buffer(yyin,YY_BUF_SIZE );
+				yy_create_buffer( yyin, YY_BUF_SIZE );
 		}
 
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 		}
 
-	while ( 1 )		/* loops until end-of-file is reached */
+	{
+#line 65 "./lex.l"
+
+#line 850 "./lex.yy.cpp"
+
+	while ( /*CONSTCOND*/1 )		/* loops until end-of-file is reached */
 		{
 		yy_cp = (yy_c_buf_p);
 
@@ -863,7 +864,7 @@ YY_DECL
 yy_match:
 		do
 			{
-			register YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)];
+			YY_CHAR yy_c = yy_ec[YY_SC_TO_UI(*yy_cp)] ;
 			if ( yy_accept[yy_current_state] )
 				{
 				(yy_last_accepting_state) = yy_current_state;
@@ -873,9 +874,9 @@ yy_match:
 				{
 				yy_current_state = (int) yy_def[yy_current_state];
 				if ( yy_current_state >= 190 )
-					yy_c = yy_meta[(unsigned int) yy_c];
+					yy_c = yy_meta[yy_c];
 				}
-			yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+			yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 			++yy_cp;
 			}
 		while ( yy_base[yy_current_state] != 247 );
@@ -1121,7 +1122,7 @@ YY_RULE_SETUP
 	YY_BREAK
 case 30:
 YY_RULE_SETUP
-#line 164 "./lex.l"
+#line 167 "./lex.l"
 {
                                             yylval.c_string = yytext;
                                             return NAME;
@@ -1130,7 +1131,7 @@ YY_RULE_SETUP
 case 31:
 /* rule 31 can match eol */
 YY_RULE_SETUP
-#line 168 "./lex.l"
+#line 171 "./lex.l"
 {
                                             /* Strip quotes from string */
                                             yytext[strlen(yytext)-1] = '\0';
@@ -1140,161 +1141,161 @@ YY_RULE_SETUP
 	YY_BREAK
 case 32:
 YY_RULE_SETUP
-#line 174 "./lex.l"
+#line 177 "./lex.l"
 {
                                             /* Ignore comment */
                                         }
 	YY_BREAK
 case 33:
 YY_RULE_SETUP
-#line 177 "./lex.l"
+#line 180 "./lex.l"
 {
                                             return ARROW_ASSIGN;
                                         }
 	YY_BREAK
 case 34:
 YY_RULE_SETUP
-#line 180 "./lex.l"
+#line 183 "./lex.l"
 {
                                             return EQUATION_ASSIGN;
                                         }
 	YY_BREAK
 case 35:
 YY_RULE_SETUP
-#line 183 "./lex.l"
+#line 186 "./lex.l"
 {
                                             return TILDE_ASSIGN;
                                         }
 	YY_BREAK
 case 36:
 YY_RULE_SETUP
-#line 186 "./lex.l"
+#line 189 "./lex.l"
 {
                                             return REFERENCE_ASSIGN;
                                         }
 	YY_BREAK
 case 37:
 YY_RULE_SETUP
-#line 189 "./lex.l"
+#line 192 "./lex.l"
 {
                                             return ADDITION_ASSIGN;
                                         }
 	YY_BREAK
 case 38:
 YY_RULE_SETUP
-#line 192 "./lex.l"
+#line 195 "./lex.l"
 {
                                             return SUBTRACTION_ASSIGN;
                                         }
 	YY_BREAK
 case 39:
 YY_RULE_SETUP
-#line 195 "./lex.l"
+#line 198 "./lex.l"
 {
                                             return MULTIPLICATION_ASSIGN;
                                         }
 	YY_BREAK
 case 40:
 YY_RULE_SETUP
-#line 198 "./lex.l"
+#line 201 "./lex.l"
 {
                                             return DIVISION_ASSIGN;
                                         }
 	YY_BREAK
 case 41:
 YY_RULE_SETUP
-#line 201 "./lex.l"
+#line 204 "./lex.l"
 {
                                             return INCREMENT;
                                         }
 	YY_BREAK
 case 42:
 YY_RULE_SETUP
-#line 204 "./lex.l"
+#line 207 "./lex.l"
 {
                                             return DECREMENT;
                                         }
 	YY_BREAK
 case 43:
 YY_RULE_SETUP
-#line 207 "./lex.l"
+#line 210 "./lex.l"
 {
                                             return EQUAL;
                                         }
 	YY_BREAK
 case 44:
 YY_RULE_SETUP
-#line 210 "./lex.l"
+#line 213 "./lex.l"
 {
                                             return AND;
                                         }
 	YY_BREAK
 case 45:
 YY_RULE_SETUP
-#line 213 "./lex.l"
+#line 216 "./lex.l"
 {
                                             return OR;
                                         }
 	YY_BREAK
 case 46:
 YY_RULE_SETUP
-#line 216 "./lex.l"
+#line 219 "./lex.l"
 {
                                             return AND;
                                         }
 	YY_BREAK
 case 47:
 YY_RULE_SETUP
-#line 219 "./lex.l"
+#line 222 "./lex.l"
 {
                                             return OR;
                                         }
 	YY_BREAK
 case 48:
 YY_RULE_SETUP
-#line 222 "./lex.l"
+#line 225 "./lex.l"
 {
                                             return GT;
                                         }
 	YY_BREAK
 case 49:
 YY_RULE_SETUP
-#line 225 "./lex.l"
+#line 228 "./lex.l"
 {
                                             return GE;
                                         }
 	YY_BREAK
 case 50:
 YY_RULE_SETUP
-#line 228 "./lex.l"
+#line 231 "./lex.l"
 {
                                             return LT;
                                         }
 	YY_BREAK
 case 51:
 YY_RULE_SETUP
-#line 231 "./lex.l"
+#line 234 "./lex.l"
 {
                                             return LE;
                                         }
 	YY_BREAK
 case 52:
 YY_RULE_SETUP
-#line 234 "./lex.l"
+#line 237 "./lex.l"
 {
                                             return EQ;
                                         }
 	YY_BREAK
 case 53:
 YY_RULE_SETUP
-#line 237 "./lex.l"
+#line 240 "./lex.l"
 {
                                             return NE;
                                         }
 	YY_BREAK
 case 54:
 YY_RULE_SETUP
-#line 240 "./lex.l"
+#line 243 "./lex.l"
 {
                                             /* Ignore white space */
                                         }
@@ -1302,7 +1303,7 @@ YY_RULE_SETUP
 case 55:
 /* rule 55 can match eol */
 YY_RULE_SETUP
-#line 243 "./lex.l"
+#line 246 "./lex.l"
 {
                                             foundNewline = true;
                                             return yytext[0];
@@ -1310,14 +1311,14 @@ YY_RULE_SETUP
 	YY_BREAK
 case 56:
 YY_RULE_SETUP
-#line 247 "./lex.l"
+#line 250 "./lex.l"
 {
                                             return yytext[0];
                                         }
 	YY_BREAK
 case 57:
 YY_RULE_SETUP
-#line 250 "./lex.l"
+#line 253 "./lex.l"
 {
                                             /* any character not matching existing rules */
                                             /* pass it onto the parser and let the parser handle it */
@@ -1326,10 +1327,10 @@ YY_RULE_SETUP
 	YY_BREAK
 case 58:
 YY_RULE_SETUP
-#line 255 "./lex.l"
+#line 258 "./lex.l"
 ECHO;
 	YY_BREAK
-#line 1330 "./lex.yy.cpp"
+#line 1334 "./lex.yy.cpp"
 case YY_STATE_EOF(INITIAL):
 	yyterminate();
 
@@ -1407,7 +1408,7 @@ case YY_STATE_EOF(INITIAL):
 				{
 				(yy_did_buffer_switch_on_eof) = 0;
 
-				if ( yywrap( ) )
+				if ( yywrap(  ) )
 					{
 					/* Note: because we've taken care in
 					 * yy_get_next_buffer() to have set up
@@ -1460,6 +1461,7 @@ case YY_STATE_EOF(INITIAL):
 			"fatal flex scanner internal error--no action found" );
 	} /* end of action switch */
 		} /* end of scanning one token */
+	} /* end of user's declarations */
 } /* end of yylex */
 
 /* yy_get_next_buffer - try to read in a new buffer
@@ -1471,9 +1473,9 @@ case YY_STATE_EOF(INITIAL):
  */
 static int yy_get_next_buffer (void)
 {
-    	register char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
-	register char *source = (yytext_ptr);
-	register int number_to_move, i;
+    	char *dest = YY_CURRENT_BUFFER_LVALUE->yy_ch_buf;
+	char *source = (yytext_ptr);
+	int number_to_move, i;
 	int ret_val;
 
 	if ( (yy_c_buf_p) > &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[(yy_n_chars) + 1] )
@@ -1502,7 +1504,7 @@ static int yy_get_next_buffer (void)
 	/* Try to read more data. */
 
 	/* First move last chars to start of buffer. */
-	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr)) - 1;
+	number_to_move = (int) ((yy_c_buf_p) - (yytext_ptr) - 1);
 
 	for ( i = 0; i < number_to_move; ++i )
 		*(dest++) = *(source++);
@@ -1515,21 +1517,21 @@ static int yy_get_next_buffer (void)
 
 	else
 		{
-			yy_size_t num_to_read =
+			int num_to_read =
 			YY_CURRENT_BUFFER_LVALUE->yy_buf_size - number_to_move - 1;
 
 		while ( num_to_read <= 0 )
 			{ /* Not enough room in the buffer - grow it. */
 
 			/* just a shorter name for the current buffer */
-			YY_BUFFER_STATE b = YY_CURRENT_BUFFER;
+			YY_BUFFER_STATE b = YY_CURRENT_BUFFER_LVALUE;
 
 			int yy_c_buf_p_offset =
 				(int) ((yy_c_buf_p) - b->yy_ch_buf);
 
 			if ( b->yy_is_our_buffer )
 				{
-				yy_size_t new_size = b->yy_buf_size * 2;
+				int new_size = b->yy_buf_size * 2;
 
 				if ( new_size <= 0 )
 					b->yy_buf_size += b->yy_buf_size / 8;
@@ -1538,11 +1540,12 @@ static int yy_get_next_buffer (void)
 
 				b->yy_ch_buf = (char *)
 					/* Include room in for 2 EOB chars. */
-					yyrealloc((void *) b->yy_ch_buf,b->yy_buf_size + 2  );
+					yyrealloc( (void *) b->yy_ch_buf,
+							 (yy_size_t) (b->yy_buf_size + 2)  );
 				}
 			else
 				/* Can't grow it, we don't own it. */
-				b->yy_ch_buf = 0;
+				b->yy_ch_buf = NULL;
 
 			if ( ! b->yy_ch_buf )
 				YY_FATAL_ERROR(
@@ -1570,7 +1573,7 @@ static int yy_get_next_buffer (void)
 		if ( number_to_move == YY_MORE_ADJ )
 			{
 			ret_val = EOB_ACT_END_OF_FILE;
-			yyrestart(yyin  );
+			yyrestart( yyin  );
 			}
 
 		else
@@ -1584,12 +1587,15 @@ static int yy_get_next_buffer (void)
 	else
 		ret_val = EOB_ACT_CONTINUE_SCAN;
 
-	if ((yy_size_t) ((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
+	if (((yy_n_chars) + number_to_move) > YY_CURRENT_BUFFER_LVALUE->yy_buf_size) {
 		/* Extend the array by 50%, plus the number we really need. */
-		yy_size_t new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
-		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc((void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf,new_size  );
+		int new_size = (yy_n_chars) + number_to_move + ((yy_n_chars) >> 1);
+		YY_CURRENT_BUFFER_LVALUE->yy_ch_buf = (char *) yyrealloc(
+			(void *) YY_CURRENT_BUFFER_LVALUE->yy_ch_buf, (yy_size_t) new_size  );
 		if ( ! YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
 			YY_FATAL_ERROR( "out of dynamic memory in yy_get_next_buffer()" );
+		/* "- 2" to take care of EOB's */
+		YY_CURRENT_BUFFER_LVALUE->yy_buf_size = (int) (new_size - 2);
 	}
 
 	(yy_n_chars) += number_to_move;
@@ -1605,14 +1611,14 @@ static int yy_get_next_buffer (void)
 
     static yy_state_type yy_get_previous_state (void)
 {
-	register yy_state_type yy_current_state;
-	register char *yy_cp;
+	yy_state_type yy_current_state;
+	char *yy_cp;
     
 	yy_current_state = (yy_start);
 
 	for ( yy_cp = (yytext_ptr) + YY_MORE_ADJ; yy_cp < (yy_c_buf_p); ++yy_cp )
 		{
-		register YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
+		YY_CHAR yy_c = (*yy_cp ? yy_ec[YY_SC_TO_UI(*yy_cp)] : 1);
 		if ( yy_accept[yy_current_state] )
 			{
 			(yy_last_accepting_state) = yy_current_state;
@@ -1622,9 +1628,9 @@ static int yy_get_next_buffer (void)
 			{
 			yy_current_state = (int) yy_def[yy_current_state];
 			if ( yy_current_state >= 190 )
-				yy_c = yy_meta[(unsigned int) yy_c];
+				yy_c = yy_meta[yy_c];
 			}
-		yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+		yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 		}
 
 	return yy_current_state;
@@ -1637,10 +1643,10 @@ static int yy_get_next_buffer (void)
  */
     static yy_state_type yy_try_NUL_trans  (yy_state_type yy_current_state )
 {
-	register int yy_is_jam;
-    	register char *yy_cp = (yy_c_buf_p);
+	int yy_is_jam;
+    	char *yy_cp = (yy_c_buf_p);
 
-	register YY_CHAR yy_c = 1;
+	YY_CHAR yy_c = 1;
 	if ( yy_accept[yy_current_state] )
 		{
 		(yy_last_accepting_state) = yy_current_state;
@@ -1650,17 +1656,19 @@ static int yy_get_next_buffer (void)
 		{
 		yy_current_state = (int) yy_def[yy_current_state];
 		if ( yy_current_state >= 190 )
-			yy_c = yy_meta[(unsigned int) yy_c];
+			yy_c = yy_meta[yy_c];
 		}
-	yy_current_state = yy_nxt[yy_base[yy_current_state] + (unsigned int) yy_c];
+	yy_current_state = yy_nxt[yy_base[yy_current_state] + yy_c];
 	yy_is_jam = (yy_current_state == 189);
 
-	return yy_is_jam ? 0 : yy_current_state;
+		return yy_is_jam ? 0 : yy_current_state;
 }
 
-    static void yyunput (int c, register char * yy_bp )
+#ifndef YY_NO_UNPUT
+
+    static void yyunput (int c, char * yy_bp )
 {
-	register char *yy_cp;
+	char *yy_cp;
     
     yy_cp = (yy_c_buf_p);
 
@@ -1670,10 +1678,10 @@ static int yy_get_next_buffer (void)
 	if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 		{ /* need to shift things up to make room */
 		/* +2 for EOB chars. */
-		register yy_size_t number_to_move = (yy_n_chars) + 2;
-		register char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
+		int number_to_move = (yy_n_chars) + 2;
+		char *dest = &YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[
 					YY_CURRENT_BUFFER_LVALUE->yy_buf_size + 2];
-		register char *source =
+		char *source =
 				&YY_CURRENT_BUFFER_LVALUE->yy_ch_buf[number_to_move];
 
 		while ( source > YY_CURRENT_BUFFER_LVALUE->yy_ch_buf )
@@ -1682,7 +1690,7 @@ static int yy_get_next_buffer (void)
 		yy_cp += (int) (dest - source);
 		yy_bp += (int) (dest - source);
 		YY_CURRENT_BUFFER_LVALUE->yy_n_chars =
-			(yy_n_chars) = YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
+			(yy_n_chars) = (int) YY_CURRENT_BUFFER_LVALUE->yy_buf_size;
 
 		if ( yy_cp < YY_CURRENT_BUFFER_LVALUE->yy_ch_buf + 2 )
 			YY_FATAL_ERROR( "flex scanner push-back overflow" );
@@ -1694,6 +1702,8 @@ static int yy_get_next_buffer (void)
 	(yy_hold_char) = *yy_cp;
 	(yy_c_buf_p) = yy_cp;
 }
+
+#endif
 
 #ifndef YY_NO_INPUT
 #ifdef __cplusplus
@@ -1719,7 +1729,7 @@ static int yy_get_next_buffer (void)
 
 		else
 			{ /* need more input */
-			yy_size_t offset = (yy_c_buf_p) - (yytext_ptr);
+			int offset = (int) ((yy_c_buf_p) - (yytext_ptr));
 			++(yy_c_buf_p);
 
 			switch ( yy_get_next_buffer(  ) )
@@ -1736,13 +1746,13 @@ static int yy_get_next_buffer (void)
 					 */
 
 					/* Reset buffer status. */
-					yyrestart(yyin );
+					yyrestart( yyin );
 
 					/*FALLTHROUGH*/
 
 				case EOB_ACT_END_OF_FILE:
 					{
-					if ( yywrap( ) )
+					if ( yywrap(  ) )
 						return 0;
 
 					if ( ! (yy_did_buffer_switch_on_eof) )
@@ -1780,11 +1790,11 @@ static int yy_get_next_buffer (void)
 	if ( ! YY_CURRENT_BUFFER ){
         yyensure_buffer_stack ();
 		YY_CURRENT_BUFFER_LVALUE =
-            yy_create_buffer(yyin,YY_BUF_SIZE );
+            yy_create_buffer( yyin, YY_BUF_SIZE );
 	}
 
-	yy_init_buffer(YY_CURRENT_BUFFER,input_file );
-	yy_load_buffer_state( );
+	yy_init_buffer( YY_CURRENT_BUFFER, input_file );
+	yy_load_buffer_state(  );
 }
 
 /** Switch to a different input buffer.
@@ -1812,7 +1822,7 @@ static int yy_get_next_buffer (void)
 		}
 
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
-	yy_load_buffer_state( );
+	yy_load_buffer_state(  );
 
 	/* We don't actually know whether we did this switch during
 	 * EOF (yywrap()) processing, but the only time this flag
@@ -1840,7 +1850,7 @@ static void yy_load_buffer_state  (void)
 {
 	YY_BUFFER_STATE b;
     
-	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
@@ -1849,13 +1859,13 @@ static void yy_load_buffer_state  (void)
 	/* yy_ch_buf has to be 2 characters longer than the size given because
 	 * we need to put in 2 end-of-buffer characters.
 	 */
-	b->yy_ch_buf = (char *) yyalloc(b->yy_buf_size + 2  );
+	b->yy_ch_buf = (char *) yyalloc( (yy_size_t) (b->yy_buf_size + 2)  );
 	if ( ! b->yy_ch_buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_create_buffer()" );
 
 	b->yy_is_our_buffer = 1;
 
-	yy_init_buffer(b,file );
+	yy_init_buffer( b, file );
 
 	return b;
 }
@@ -1874,15 +1884,11 @@ static void yy_load_buffer_state  (void)
 		YY_CURRENT_BUFFER_LVALUE = (YY_BUFFER_STATE) 0;
 
 	if ( b->yy_is_our_buffer )
-		yyfree((void *) b->yy_ch_buf  );
+		yyfree( (void *) b->yy_ch_buf  );
 
-	yyfree((void *) b  );
+	yyfree( (void *) b  );
 }
 
-#ifndef __cplusplus
-extern int isatty (int );
-#endif /* __cplusplus */
-    
 /* Initializes or reinitializes a buffer.
  * This function is sometimes called more than once on the same buffer,
  * such as during a yyrestart() or at EOF.
@@ -1892,7 +1898,7 @@ extern int isatty (int );
 {
 	int oerrno = errno;
     
-	yy_flush_buffer(b );
+	yy_flush_buffer( b );
 
 	b->yy_input_file = file;
 	b->yy_fill_buffer = 1;
@@ -1935,7 +1941,7 @@ extern int isatty (int );
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
 	if ( b == YY_CURRENT_BUFFER )
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 }
 
 /** Pushes the new state onto the stack. The new state becomes
@@ -1966,7 +1972,7 @@ void yypush_buffer_state (YY_BUFFER_STATE new_buffer )
 	YY_CURRENT_BUFFER_LVALUE = new_buffer;
 
 	/* copied from yy_switch_to_buffer. */
-	yy_load_buffer_state( );
+	yy_load_buffer_state(  );
 	(yy_did_buffer_switch_on_eof) = 1;
 }
 
@@ -1985,7 +1991,7 @@ void yypop_buffer_state (void)
 		--(yy_buffer_stack_top);
 
 	if (YY_CURRENT_BUFFER) {
-		yy_load_buffer_state( );
+		yy_load_buffer_state(  );
 		(yy_did_buffer_switch_on_eof) = 1;
 	}
 }
@@ -2003,15 +2009,15 @@ static void yyensure_buffer_stack (void)
 		 * scanner will even need a stack. We use 2 instead of 1 to avoid an
 		 * immediate realloc on the next call.
          */
-		num_to_alloc = 1;
+      num_to_alloc = 1; /* After all that talk, this was set to 1 anyways... */
 		(yy_buffer_stack) = (struct yy_buffer_state**)yyalloc
 								(num_to_alloc * sizeof(struct yy_buffer_state*)
 								);
 		if ( ! (yy_buffer_stack) )
 			YY_FATAL_ERROR( "out of dynamic memory in yyensure_buffer_stack()" );
-								  
+
 		memset((yy_buffer_stack), 0, num_to_alloc * sizeof(struct yy_buffer_state*));
-				
+
 		(yy_buffer_stack_max) = num_to_alloc;
 		(yy_buffer_stack_top) = 0;
 		return;
@@ -2020,7 +2026,7 @@ static void yyensure_buffer_stack (void)
 	if ((yy_buffer_stack_top) >= ((yy_buffer_stack_max)) - 1){
 
 		/* Increase the buffer to prepare for a possible push. */
-		int grow_size = 8 /* arbitrary grow size */;
+		yy_size_t grow_size = 8 /* arbitrary grow size */;
 
 		num_to_alloc = (yy_buffer_stack_max) + grow_size;
 		(yy_buffer_stack) = (struct yy_buffer_state**)yyrealloc
@@ -2040,7 +2046,7 @@ static void yyensure_buffer_stack (void)
  * @param base the character buffer
  * @param size the size in bytes of the character buffer
  * 
- * @return the newly allocated buffer state object. 
+ * @return the newly allocated buffer state object.
  */
 YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 {
@@ -2050,23 +2056,23 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
 	     base[size-2] != YY_END_OF_BUFFER_CHAR ||
 	     base[size-1] != YY_END_OF_BUFFER_CHAR )
 		/* They forgot to leave room for the EOB's. */
-		return 0;
+		return NULL;
 
-	b = (YY_BUFFER_STATE) yyalloc(sizeof( struct yy_buffer_state )  );
+	b = (YY_BUFFER_STATE) yyalloc( sizeof( struct yy_buffer_state )  );
 	if ( ! b )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_buffer()" );
 
-	b->yy_buf_size = size - 2;	/* "- 2" to take care of EOB's */
+	b->yy_buf_size = (int) (size - 2);	/* "- 2" to take care of EOB's */
 	b->yy_buf_pos = b->yy_ch_buf = base;
 	b->yy_is_our_buffer = 0;
-	b->yy_input_file = 0;
+	b->yy_input_file = NULL;
 	b->yy_n_chars = b->yy_buf_size;
 	b->yy_is_interactive = 0;
 	b->yy_at_bol = 1;
 	b->yy_fill_buffer = 0;
 	b->yy_buffer_status = YY_BUFFER_NEW;
 
-	yy_switch_to_buffer(b  );
+	yy_switch_to_buffer( b  );
 
 	return b;
 }
@@ -2079,28 +2085,29 @@ YY_BUFFER_STATE yy_scan_buffer  (char * base, yy_size_t  size )
  * @note If you want to scan bytes that may contain NUL values, then use
  *       yy_scan_bytes() instead.
  */
-YY_BUFFER_STATE yy_scan_string (yyconst char * yystr )
+YY_BUFFER_STATE yy_scan_string (const char * yystr )
 {
     
-	return yy_scan_bytes(yystr,strlen(yystr) );
+	return yy_scan_bytes( yystr, (int) strlen(yystr) );
 }
 
 /** Setup the input buffer state to scan the given bytes. The next call to yylex() will
  * scan from a @e copy of @a bytes.
- * @param bytes the byte buffer to scan
- * @param len the number of bytes in the buffer pointed to by @a bytes.
+ * @param yybytes the byte buffer to scan
+ * @param _yybytes_len the number of bytes in the buffer pointed to by @a bytes.
  * 
  * @return the newly allocated buffer state object.
  */
-YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len )
+YY_BUFFER_STATE yy_scan_bytes  (const char * yybytes, int  _yybytes_len )
 {
 	YY_BUFFER_STATE b;
 	char *buf;
-	yy_size_t n, i;
+	yy_size_t n;
+	int i;
     
 	/* Get memory for full buffer, including space for trailing EOB's. */
-	n = _yybytes_len + 2;
-	buf = (char *) yyalloc(n  );
+	n = (yy_size_t) (_yybytes_len + 2);
+	buf = (char *) yyalloc( n  );
 	if ( ! buf )
 		YY_FATAL_ERROR( "out of dynamic memory in yy_scan_bytes()" );
 
@@ -2109,7 +2116,7 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len 
 
 	buf[_yybytes_len] = buf[_yybytes_len+1] = YY_END_OF_BUFFER_CHAR;
 
-	b = yy_scan_buffer(buf,n );
+	b = yy_scan_buffer( buf, n );
 	if ( ! b )
 		YY_FATAL_ERROR( "bad buffer in yy_scan_bytes()" );
 
@@ -2125,9 +2132,9 @@ YY_BUFFER_STATE yy_scan_bytes  (yyconst char * yybytes, yy_size_t  _yybytes_len 
 #define YY_EXIT_FAILURE 2
 #endif
 
-static void yy_fatal_error (yyconst char* msg )
+static void yynoreturn yy_fatal_error (const char* msg )
 {
-    	(void) fprintf( stderr, "%s\n", msg );
+			fprintf( stderr, "%s\n", msg );
 	exit( YY_EXIT_FAILURE );
 }
 
@@ -2155,7 +2162,7 @@ static void yy_fatal_error (yyconst char* msg )
  */
 int yyget_lineno  (void)
 {
-        
+    
     return yylineno;
 }
 
@@ -2178,7 +2185,7 @@ FILE *yyget_out  (void)
 /** Get the length of the current token.
  * 
  */
-yy_size_t yyget_leng  (void)
+int yyget_leng  (void)
 {
         return yyleng;
 }
@@ -2193,29 +2200,29 @@ char *yyget_text  (void)
 }
 
 /** Set the current line number.
- * @param line_number
+ * @param _line_number line number
  * 
  */
-void yyset_lineno (int  line_number )
+void yyset_lineno (int  _line_number )
 {
     
-    yylineno = line_number;
+    yylineno = _line_number;
 }
 
 /** Set the input stream. This does not discard the current
  * input buffer.
- * @param in_str A readable stream.
+ * @param _in_str A readable stream.
  * 
  * @see yy_switch_to_buffer
  */
-void yyset_in (FILE *  in_str )
+void yyset_in (FILE *  _in_str )
 {
-        yyin = in_str ;
+        yyin = _in_str ;
 }
 
-void yyset_out (FILE *  out_str )
+void yyset_out (FILE *  _out_str )
 {
-        yyout = out_str ;
+        yyout = _out_str ;
 }
 
 int yyget_debug  (void)
@@ -2223,9 +2230,9 @@ int yyget_debug  (void)
         return yy_flex_debug;
 }
 
-void yyset_debug (int  bdebug )
+void yyset_debug (int  _bdebug )
 {
-        yy_flex_debug = bdebug ;
+        yy_flex_debug = _bdebug ;
 }
 
 static int yy_init_globals (void)
@@ -2234,10 +2241,10 @@ static int yy_init_globals (void)
      * This function is called from yylex_destroy(), so don't allocate here.
      */
 
-    (yy_buffer_stack) = 0;
+    (yy_buffer_stack) = NULL;
     (yy_buffer_stack_top) = 0;
     (yy_buffer_stack_max) = 0;
-    (yy_c_buf_p) = (char *) 0;
+    (yy_c_buf_p) = NULL;
     (yy_init) = 0;
     (yy_start) = 0;
 
@@ -2246,8 +2253,8 @@ static int yy_init_globals (void)
     yyin = stdin;
     yyout = stdout;
 #else
-    yyin = (FILE *) 0;
-    yyout = (FILE *) 0;
+    yyin = NULL;
+    yyout = NULL;
 #endif
 
     /* For future reference: Set errno on error, since we are called by
@@ -2262,7 +2269,7 @@ int yylex_destroy  (void)
     
     /* Pop the buffer stack, destroying each element. */
 	while(YY_CURRENT_BUFFER){
-		yy_delete_buffer(YY_CURRENT_BUFFER  );
+		yy_delete_buffer( YY_CURRENT_BUFFER  );
 		YY_CURRENT_BUFFER_LVALUE = NULL;
 		yypop_buffer_state();
 	}
@@ -2283,18 +2290,19 @@ int yylex_destroy  (void)
  */
 
 #ifndef yytext_ptr
-static void yy_flex_strncpy (char* s1, yyconst char * s2, int n )
+static void yy_flex_strncpy (char* s1, const char * s2, int n )
 {
-	register int i;
+		
+	int i;
 	for ( i = 0; i < n; ++i )
 		s1[i] = s2[i];
 }
 #endif
 
 #ifdef YY_NEED_STRLEN
-static int yy_flex_strlen (yyconst char * s )
+static int yy_flex_strlen (const char * s )
 {
-	register int n;
+	int n;
 	for ( n = 0; s[n]; ++n )
 		;
 
@@ -2304,11 +2312,12 @@ static int yy_flex_strlen (yyconst char * s )
 
 void *yyalloc (yy_size_t  size )
 {
-	return (void *) malloc( size );
+			return malloc(size);
 }
 
 void *yyrealloc  (void * ptr, yy_size_t  size )
 {
+		
 	/* The cast to (char *) in the following accommodates both
 	 * implementations that use char* generic pointers, and those
 	 * that use void* generic pointers.  It works with the latter
@@ -2316,17 +2325,16 @@ void *yyrealloc  (void * ptr, yy_size_t  size )
 	 * any pointer type to void*, and deal with argument conversions
 	 * as though doing an assignment.
 	 */
-	return (void *) realloc( (char *) ptr, size );
+	return realloc(ptr, size);
 }
 
 void yyfree (void * ptr )
 {
-	free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
+			free( (char *) ptr );	/* see yyrealloc() for (char *) cast */
 }
 
 #define YYTABLES_NAME "yytables"
 
-#line 255 "./lex.l"
-
+#line 258 "./lex.l"
 
 


### PR DESCRIPTION
RevBayes won't compile out-of-the-box on current XCode,  This is because RevBayes uses some deprecated features in C++14 that are actually removed in C++17. XCode now defaults to C++17, and its libc++ implementation actually removes the deprecated features.  GCC also defaults to C++17. 

The removed features are mainly:
* use of the `register` keyword in the generated parser/lexer.
* use of `std::random_shuffle( )` in a few files.

With this PR, RevBayes continues to target C++14, but removes deprecated features so that it is possible to compile it in C++17 mode.
* the parser/lexer are regenerated using more modern flex/bison, and so don't use the `register` keyword
* a simple implementation of random_shuffle( ) is placed in namespace `deprecated`
* `std::random_shuffle( )` is replaced with `deprecated::random_shuffle( )`.  People should use `std::shuffle(start, end, rng)` instead.

To review this patch, I suggest just reading the 3 change sets.  Except that you can ignore the one that regenerates the parser & lexer code because that is computer-generated code that is not really readable.  I think if the tests pass, you don't really need to compile locally.