### PR TITLE
Accept constant rho and user-supplied starting trees in dnFBDP()

### DIFF
--- a/src/core/distributions/phylogenetics/tree/birthdeath/BirthDeathSamplingTreatmentProcess.cpp
+++ b/src/core/distributions/phylogenetics/tree/birthdeath/BirthDeathSamplingTreatmentProcess.cpp
@@ -161,15 +161,20 @@ BirthDeathSamplingTreatmentProcess::BirthDeathSamplingTreatmentProcess(const Typ
     prepareTimeline();
     prepareProbComputation();
 
-
-    // We employ a coalescent simulator to guarantee that the starting tree matches all time constraints
-    RbVector<Clade> constr;
-    StartingTreeSimulator simulator;
-    RevBayesCore::Tree *my_tree = simulator.simulateTree( taxa, constr );
-
-    // store the new value
     delete value;
-    value = my_tree;
+    
+    if (t != nullptr) {
+        value = t;
+    }
+    else
+    {
+        RbVector<Clade> constr;
+        // We employ a coalescent simulator to guarantee that the starting tree matches all time constraints
+        StartingTreeSimulator simulator;
+        RevBayesCore::Tree *my_tree = simulator.simulateTree( taxa, constr );
+        // store the new value
+        value = my_tree;
+    }
 
     countAllNodes();
 

--- a/src/revlanguage/distributions/phylogenetics/tree/Dist_FBDP.cpp
+++ b/src/revlanguage/distributions/phylogenetics/tree/Dist_FBDP.cpp
@@ -445,7 +445,7 @@ void Dist_FBDP::setConstParameter(const std::string& name, const RevPtr<const Re
     {
         Mu_timeline = var;
     }
-    else if ( name == "PhiTimeline" || name == "PsiTimeline" )
+    else if ( name == "PhiTimeline" || name == "rhoTimeline" )
     {
         Phi_timeline = var;
     }


### PR DESCRIPTION
This PR includes two simple fixes that address the following issues:

(1) While `dnBDSTP()` and its alias, `dnFBDP()`, currently accept an `initialTree` argument, they ignore it and proceed to simulate a starting tree regardless of whether a user-specified initial tree has been provided.

(2) While `dnBDSTP()` and `dnFBDP()` are indeed supposed to be aliases, their behavior differs when the `rho` argument (extant sampling fraction) is specified: the former accepts it, while the latter throws a seemingly unrelated error:

```
No parameter with name "rhoTimeline" found to set
```

Here, the code was changed to ensure that the `rho` argument is accepted by both aliases.