### PR TITLE
Only try to create the parent directory if there is one.

### DIFF
--- a/src/core/utils/RbFileManager.cpp
+++ b/src/core/utils/RbFileManager.cpp
@@ -34,7 +34,8 @@ namespace RevBayesCore
 
 void createDirectoryForFile(const path& p)
 {
-    create_directories(p.parent_path());
+    if (not p.parent_path().empty())
+        create_directories(p.parent_path());
 }
 
 path appendToStem(const path& p, const std::string& s)


### PR DESCRIPTION
This is necessary to avoid a crash when you run `model.graph("file.dot")`.  Otherwise it throws an exception trying to create a directory from an empty path.