### PR TITLE
Change standard from c++14 to c++17.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -2,7 +2,7 @@ project('RevBayes', ['cpp', 'c'],
         version: '1.2.0',
         default_options: [
           'buildtype=release',
-          'cpp_std=c++14',
+          'cpp_std=c++17',
           'b_ndebug=if-release'
         ],
         meson_version: '>= 0.57',

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,13 +5,7 @@ project(RevBayes)
 # -Wno-sign-compare
 # -D_GLIBCXX_DEBUG
 
-# This is the RIGHT way, but requires cmake version >=3:
-#   set(CMAKE_CXX_STANDARD 11)
-#
-# https://gitlab.kitware.com/cmake/community/-/wikis/CMake-Versions-on-Linux-Distros
-#
-# So, we add the flag directly instead.
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+set(CMAKE_CXX_STANDARD 17)
 
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)


### PR DESCRIPTION
This PR switches to building with c++17.  It does not do anything else.

The major changes in c++17 are:
* new class std::optional.  Allows switching from boost::optional. (https://en.cppreference.com/w/cpp/utility/optional)
* new system std::filesystem. Allows switch from boost::filesystem. (https://en.cppreference.com/w/cpp/filesystem)
* structured bindings.  Allows _readable_ decomposition of pairs, tuples, etc.: (https://en.cppreference.com/w/cpp/language/structured_binding)
     * `pair<int,double> [result1,result2] = function_that_returns_a_pair()`
     * `for(auto& [key,value]: container_of_pairs) {...`

Other changes include
* new class std::variant -- a type safe union. (https://en.cppreference.com/w/cpp/utility/variant)
* new class std::any -- can hold any copy-constructible type. (https://en.cppreference.com/w/cpp/utility/any)
* bug fixes to C++14

Example for structured bindings:
``` C++
for (std::map<RbBitSet,TopologyNode*>::iterator it=ref.begin(); it!=ref.end(); ++it) {
    toret[it->first]->setIndex( it->second->getIndex());
}
```
Could be changed to:
``` C++
for (auto& [bitset,node]: ref) {
    toret[bitset]->setIndex( node->getIndex());
}
```
I think this is much easier to read.  This should be easier for new C++ programmers as well.