### PR TITLE
Fix constrained topo

### DIFF
--- a/src/core/datatypes/trees/Tree.cpp
+++ b/src/core/datatypes/trees/Tree.cpp
@@ -1733,6 +1733,11 @@ void Tree::resetTaxonBitSetMap( void )
 
 TopologyNode& Tree::reverseParentChild(TopologyNode &n)
 {
+    // This routine makes n the new root by
+    // * first making n.getParent() the new root, and then
+    // * making n.getParent() into a child of n.
+    // It returns the original root.
+
     TopologyNode* ret = &n;
 
     if ( !n.isRoot() )
@@ -1746,6 +1751,7 @@ TopologyNode& Tree::reverseParentChild(TopologyNode &n)
         p.setBranchLength(n.getBranchLength());
 
         p.removeChild( &n );
+        n.setParent( nullptr ); // Avoid loop in parent edges from n -> p -> n
         p.setParent( &n );
         n.addChild( &p );
     }

--- a/src/core/moves/proposal/tree/NearestNeighborInterchange_nonClockProposal.cpp
+++ b/src/core/moves/proposal/tree/NearestNeighborInterchange_nonClockProposal.cpp
@@ -273,8 +273,8 @@ void NearestNeighborInterchange_nonClockProposal::undoProposal( void )
         node_B->addChild( parent );
         node->addChild( node_A );
         parent->addChild( node );
-        node->setParent( parent );
         parent->setParent( node_B );
+        node->setParent( parent );
         node_A->setParent( node );
         
     }

--- a/src/core/moves/proposal/tree/NearestNeighborInterchange_nonClockProposal.cpp
+++ b/src/core/moves/proposal/tree/NearestNeighborInterchange_nonClockProposal.cpp
@@ -147,28 +147,18 @@ double NearestNeighborInterchange_nonClockProposal::doProposal( void )
         if (parent.getNumberOfChildren() < 3)
             throw RbException()<<"NearestNeighborInterchange_nonClockProposal::doProposal( ): root has only "<<parent.getNumberOfChildren()<<" children, but should be at least 3.";
 
+        std::vector<TopologyNode*> children;
+        for(auto child:  parent.getChildren())
+            if (child != node)
+                children.push_back(child);
         
-        // first start by checking if the chosen node is child 0
-        size_t child_offset = (node == &parent.getChild(0) ? 1 : 0);
-        
-        // now we can pick the second node, which can be either of the two remaining children
-        if ( rng->uniform01() < 0.5 )
-        {
-            // we picked the first remaining child
-            node_B = &parent.getChild(child_offset);
-        }
-        else
-        {
-            // we picked the second remaining child
-            node_B = &parent.getChild(child_offset+1);
-            if ( node_B == node )
-            {
-                node_B = &parent.getChild(child_offset+2);
-            }
-        }
-        
+        assert(children.size() >= 2);
+
+        int index = int(rng->uniform01() * children.size());
+        node_B = children[ index ];
+        assert(&node_B->getParent() == &parent);
+
         picked_uncle = true;
-        
     }
 
     // now we store all necessary values

--- a/src/core/moves/proposal/tree/NearestNeighborInterchange_nonClockProposal.cpp
+++ b/src/core/moves/proposal/tree/NearestNeighborInterchange_nonClockProposal.cpp
@@ -142,6 +142,11 @@ double NearestNeighborInterchange_nonClockProposal::doProposal( void )
     else
     {
         // the branch begins at the root
+
+        // If the root only has two children, then the switch we want to perform here isn't an NNI!
+        if (parent.getNumberOfChildren() < 3)
+            throw RbException()<<"NearestNeighborInterchange_nonClockProposal::doProposal( ): root has only "<<parent.getNumberOfChildren()<<" children, but should be at least 3.";
+
         
         // first start by checking if the chosen node is child 0
         size_t child_offset = (node == &parent.getChild(0) ? 1 : 0);


### PR DESCRIPTION
This PR fixes `Segmentation fault` errors in NNI and SPR.  In both cases, a loop was created in getParent() edges, and this lead to an infinite loop in recursive-dirty-flagging which overflowed the stack.

The PR also adds an error message indicating that the NNI proposal does not (currently) handle a root node with only 2 children.