### PR TITLE
Don't crash in setwd(dir) if dir does not exist.

### DIFF
--- a/src/revlanguage/functions/basic/Func_setwd.cpp
+++ b/src/revlanguage/functions/basic/Func_setwd.cpp
@@ -46,11 +46,15 @@ Func_setwd* Func_setwd::clone( void ) const
 /** Execute function */
 RevPtr<RevVariable> Func_setwd::execute( void )
 {
-    
-    const std::string &wd = static_cast<const RlString &>( args[0].getVariable()->getRevObject() ).getValue();
+    fs::path wd = static_cast<const RlString &>( args[0].getVariable()->getRevObject() ).getValue();
+
+    if ( not fs::exists( wd ))
+        throw RbException()<<"setwd: The path "<<wd<<" does not exist.";
+    else if (not fs::is_directory( wd ))
+        throw RbException()<<"setwd: The path "<<wd<<" exists but is not a directory.";
 
     fs::current_path( wd );
-    
+
     return NULL;
 }
 

--- a/src/revlanguage/parser/Parser.cpp
+++ b/src/revlanguage/parser/Parser.cpp
@@ -208,6 +208,13 @@ int RevLanguage::Parser::execute(SyntaxElement* root, Environment &env) const {
         // Return signal indicating problem
         return 2;
     }
+    // Don't crash the intepreter for non-Rb exceptions such as file-not-found.
+    catch (std::exception& e)
+    {
+        RBOUT(e.what());
+        // Return signal indicating problem
+        return 2;
+    }
 
     // Print result if the root is not an assign expression
     if ( root->isAssignment() == false  &&  result != NULL  &&  result->getRevObject() != RevNullObject::getInstance() )


### PR DESCRIPTION
Without the patch we get (for example):
```
> setwd("asdf")
terminate called after throwing an instance of 'boost::filesystem::filesystem_error'
  what():  boost::filesystem::current_path: No such file or directory: "asdf"
Aborted
```
With the patch, we get
```
> setwd("asdf")
   Error:	setwd: The path "asdf" does not exist.
```

The PR:
* checks if the filename exists and is a directory first, before we try and set it as the current directory.
* modifies the read-eval-print loop not to crash on exceptions that are not RbException, such as boost::filesystem::filesystem::error.

