### PR TITLE
Mention object type in error messages for missing method `object.method()`.

### DIFF
--- a/src/revlanguage/parser/SyntaxFunctionCall.cpp
+++ b/src/revlanguage/parser/SyntaxFunctionCall.cpp
@@ -181,7 +181,14 @@ RevPtr<RevVariable> SyntaxFunctionCall::evaluateContent( Environment& env, bool 
         
         const MethodTable& mt = the_member_object.getMethods();
         
-        Function* the_function = mt.getFunction( function_name, args, !dynamic ).clone();
+        const Function* the_const_function = mt.findFunction( function_name, args, !dynamic );
+
+        Function* the_function;
+        if (the_const_function)
+            the_function = the_const_function->clone();
+        else
+            throw RbException()<<"Variable of type '"<<the_member_object.getType()<<"' has no method called '"<<function_name<<"'.  You can use '.methods()' to find available methods.";
+
         the_function->processArguments(args, !dynamic);
         
         MemberMethod* theMemberMethod = dynamic_cast<MemberMethod*>( the_function );

--- a/src/revlanguage/workspace/Environment.cpp
+++ b/src/revlanguage/workspace/Environment.cpp
@@ -340,7 +340,6 @@ Environment* Environment::getChildEnvironment(const std::string &name)
 /** Get function. This call will throw an error if the name is missing or present multiple times. */
 Function* Environment::getFunction(const std::string& name)
 {
-    
     return function_table.getFunction(name);
 }
 
@@ -350,6 +349,13 @@ const Function& Environment::getFunction(const std::string& name, const std::vec
 {
     
     return function_table.getFunction(name, args, once);
+}
+
+
+/* Get function. This call will throw an error if the function is missing. */
+const Function* Environment::findFunction(const std::string& name, const std::vector<Argument>& args, bool once) const
+{
+    return function_table.findFunction(name, args, once);
 }
 
 

--- a/src/revlanguage/workspace/Environment.h
+++ b/src/revlanguage/workspace/Environment.h
@@ -69,6 +69,7 @@ class RevObject;
         Environment*                        getChildEnvironment(const std::string &name);                                               //!< Get child environment with the name
         Function*                           getFunction(const std::string& name);                                                       //!< Get function reference
         const Function&                     getFunction(const std::string& name, const std::vector<Argument>& args, bool once) const;   //!< Get function reference
+        const Function*                     findFunction(const std::string& name, const std::vector<Argument>& args, bool once) const;  //!< Get function reference
         const FunctionTable&                getFunctionTable(void) const;                                                               //!< Get function table (const)
         FunctionTable&                      getFunctionTable(void);                                                                     //!< Get function table (non-const)
         const RevObject&                    getRevObject(const std::string& name) const;                                                //!< Convenient alternative for [name]->getValue()

--- a/src/revlanguage/workspace/FunctionTable.cpp
+++ b/src/revlanguage/workspace/FunctionTable.cpp
@@ -287,7 +287,7 @@ std::vector<Function *> FunctionTable::findFunctions(const std::string& name) co
 
 
 /** Find function (also processes arguments) */
-const Function& FunctionTable::findFunction(const std::string& name, const std::vector<Argument>& args, bool once) const
+const Function* FunctionTable::findFunction(const std::string& name, const std::vector<Argument>& args, bool once) const
 {
     
     std::pair<std::multimap<std::string, Function *>::const_iterator,
@@ -305,7 +305,7 @@ const Function& FunctionTable::findFunction(const std::string& name, const std::
         }
         else
         {
-            throw RbException("No function named '"+ name + "'");
+            return nullptr;
         }
         
     }
@@ -376,7 +376,7 @@ const Function& FunctionTable::findFunction(const std::string& name, const std::
             msg << std::endl;
             throw RbException( msg.str() );
         }
-        return *ret_val.first->second;
+        return ret_val.first->second;
     }
     else 
     {
@@ -474,7 +474,7 @@ const Function& FunctionTable::findFunction(const std::string& name, const std::
         }
         else 
         {
-            return *best_match;
+            return best_match;
         }
         
     }
@@ -547,9 +547,12 @@ const Function& FunctionTable::getFunction(const std::string& name, const std::v
 {
     
     // find the template function
-    const Function& the_function = findFunction(name, args, once);
+    const Function* the_function = findFunction(name, args, once);
 
-    return the_function;
+    if (not the_function)
+        throw RbException("No function named '"+ name + "'");
+
+    return *the_function;
 }
 
 void FunctionTable::getFunctionNames(std::vector<std::string>& names) const

--- a/src/revlanguage/workspace/FunctionTable.cpp
+++ b/src/revlanguage/workspace/FunctionTable.cpp
@@ -305,6 +305,8 @@ const Function* FunctionTable::findFunction(const std::string& name, const std::
         }
         else
         {
+            // Here we just return a nullptr to indicate failure.
+            // The caller can produce better error messages, so it is the caller's job to throw an exception.
             return nullptr;
         }
         

--- a/src/revlanguage/workspace/FunctionTable.h
+++ b/src/revlanguage/workspace/FunctionTable.h
@@ -53,6 +53,7 @@ namespace RevLanguage {
         void                                    getFunctionNames(std::vector<std::string>& names) const;
         Function*                               getFirstFunction(const std::string& name) const;                                            //!< Get first function with given name
         Function*                               getFunction(const std::string& name) const;                                                 //!< Get function, throw an error if overloaded
+        const Function*                         findFunction(const std::string& name, const std::vector<Argument>& args, bool once) const;  //!< Get function
         const Function&                         getFunction(const std::string& name, const std::vector<Argument>& args, bool once) const;   //!< Get function
         bool                                    isDistinctFormal(const ArgumentRules& x, const ArgumentRules& y) const;                     //!< Are formals unique?
         bool                                    isProcedure(const std::string& fxnName) const;                                              //!< Is 'fxnName' a procedure?
@@ -61,9 +62,6 @@ namespace RevLanguage {
 
     protected:
         
-        const Function&                         findFunction(const std::string&           name,
-                                                             const std::vector<Argument>& args,
-                                                             bool                         once) const;                                            //!< Find function, process args
         void                                    testFunctionValidity(const std::string& name, Function* func) const;                        //!< Test whether function can be added
         
         // Member variables


### PR DESCRIPTION
This is motivated by the common problem where people write `T <- readTrees("data/primates_tree.nex")`.  

Since the subscript `[1]` is missing, T is not a tree and so method calls like `T.taxa()` don't work.  This results in bug reports like #239.

This patch generates the "no method" error from `SyntaxFunctionCall::evaluateContent( )` instead of from `FunctionTable::findFunction( )`.  SyntaxFunctionCall has access to the type of the base variable, so we can add that to the error message.  We also suggest using `.methods()`.

```
> T = readTrees("primates.tree")
   Attempting to read the contents of file "primates.tree"
   Successfully read file
> T.ntips()
   Error:	Variable of type 'TimeTree[]' has no method called 'ntips'.  You can use '.methods()' to find available methods.
```

This will hopefully prevent bug reports like #239, as well as making `.methods()` more discoverable.