### PR TITLE
Fix validation analysis.

### DIFF
--- a/src/core/analysis/ValidationAnalysis.cpp
+++ b/src/core/analysis/ValidationAnalysis.cpp
@@ -100,11 +100,8 @@ ValidationAnalysis::ValidationAnalysis( const MonteCarloAnalysis &m, size_t n, c
             current_analysis->setModel( current_model, false );
 #endif
             
-            std::stringstream ss;
-            ss << "Validation_Sim_" << i;
-        
             // set the monitor index
-            current_analysis->addFileMonitorExtension(ss.str(), true);
+            current_analysis->addFileMonitorExtension( "Validation_Sim_" + std::to_string(i), true);
         
             // add the current analysis to our vector of analyses
             runs[i] = current_analysis;
@@ -437,10 +434,7 @@ void ValidationAnalysis::summarizeAll( double credible_interval_size )
  **/
 void ValidationAnalysis::summarizeSim(double credible_interval_size, size_t idx)
 {
-    
-    std::stringstream ss;
-    ss << output_directory << "/Validation_Sim_" << idx << "/" << "posterior_samples.var";
-    std::string fn = ss.str();
+    path fn = output_directory / ("Validation_Sim_"+std::to_string(idx)) / "posterior_samples.var";
         
     TraceReader reader;
     std::vector<ModelTrace> traces = reader.readStochasticVariableTrace( fn, "\t");


### PR DESCRIPTION
ValidationAnalysis::summarizeAll( ) broke when we switched from the `RbFileManager` class to `boost::filesystem::path`.

ValidationAnalysis::summarizeAll( ) was using std::stringstream to join paths.  This worked before, when filenames were just `std::string`.  However filenames are now streamed in double-quoted form, which led to `ValidationAnalysis::summarizeAll( )` to create filenames with double-quotes in the actual name, like `""output_Beta"/Validation_Sim_1/posterior_samples.var"`.

Fix this by using the "/" operator to join paths.