### PR TITLE
Fix type conversion for vectors.

### DIFF
--- a/src/revlanguage/workspace/RevVariable.cpp
+++ b/src/revlanguage/workspace/RevVariable.cpp
@@ -188,6 +188,8 @@ RevObject& RevVariable::getRevObject(void) const
     
     if ( isVectorVariable() && needs_building )
     {
+        needs_building = false;
+
         std::vector<Argument> args;
         int i=1;
         for (auto& element_var: *vector_var_elements)
@@ -517,12 +519,10 @@ void RevVariable::setRequiredTypeSpec(const TypeSpec &ts)
     const RevObject& theObject = this->getRevObject();
     if ( theObject != RevNullObject::getInstance() )
     {
-        
         if ( theObject.isType( ts ) == false )
         {
-            throw RbException( "Existing RevVariable object is not of the required type" );
+            throw RbException()<<"setRequiredTypeSpec: failed setting object of type "<<theObject.getType()<<" to "<<ts.getType();
         }
-        
     }
     
     required_type_spec = ts;

--- a/src/revlanguage/workspace/RevVariable.h
+++ b/src/revlanguage/workspace/RevVariable.h
@@ -82,7 +82,7 @@ namespace RevLanguage {
 
         // variables related to building the components of a vector
         boost::optional<std::vector<RevPtr<RevVariable>>> vector_var_elements;          //!< Elements if this is a vector variable.
-        bool                    needs_building = false;                                 //!< Do we need to construct the revobject?
+        mutable bool            needs_building = false;                                 //!< Do we need to construct the revobject?
 
         bool                    is_element_var = false;                                 //!< Is this variable an element of a vector?
         bool                    is_hidden_var = false;                                  //!< Is this a hidden variable?


### PR DESCRIPTION
When reworking the `needs_building` functionality for vectors, I accidentally removed the line to set `needs_building = false` after building the vector.

This didn't break any of the existing tests, but made converting Natural[] to RealPos[] not work :grimacing: .

Fixed by remembering to set the flag.