### PR TITLE
Fix false claim of conflicting constraints when simulating a constrained tree

### DIFF
--- a/src/core/datatypes/trees/Clade.cpp
+++ b/src/core/datatypes/trees/Clade.cpp
@@ -488,7 +488,7 @@ bool Clade::isNestedWithin(const Clade& c) const
  *
  * \return       The true/false value of whether the clade is a negative constraint.
  */
-bool Clade::isOptionalMatch(void) const
+bool Clade::isOptionalConstraint(void) const
 {
     return is_optional_match;
 }

--- a/src/core/datatypes/trees/Clade.cpp
+++ b/src/core/datatypes/trees/Clade.cpp
@@ -5,6 +5,7 @@
 #include <string>
 #include <utility>
 
+#include "StringUtilities.h"
 #include "RbVectorUtilities.h"
 #include "RbException.h"
 
@@ -672,22 +673,38 @@ size_t Clade::size(void) const
  */
 std::string Clade::toString( void ) const
 {
-    std::string s = "{";
-    
-    for (size_t i = 0; i < taxa.size(); ++i)
+    std::string s;
+
+    if (isOptionalConstraint())
     {
-        if ( i > 0 )
+        vector<string> cstrings;
+        for(auto& c: getOptionalConstraints())
         {
-            s += ",";
+            cstrings.push_back(c.toString());
         }
-        s += taxa[i].getName();
-        if ( std::find(mrca.begin(), mrca.end(), taxa[i]) != mrca.end() )
-        {
-            s += "*";
-        }
+
+
+        s = "(" + StringUtilities::join(cstrings, " OR ") + ")";
     }
-    s += "}";
-    
+    else
+    {
+        vector<string> tstrings;
+        for (size_t i = 0; i < taxa.size(); ++i)
+        {
+            string t = taxa[i].getName();
+            if ( std::find(mrca.begin(), mrca.end(), taxa[i]) != mrca.end() )
+            {
+                t += "*";
+            }
+            tstrings.push_back(t);
+        }
+
+        s  = "{" + StringUtilities::join(tstrings,", ") + "}";
+    }
+
+    if (isNegativeConstraint())
+        s = "NOT " + s;
+
     return s;
 }
 

--- a/src/core/datatypes/trees/Clade.cpp
+++ b/src/core/datatypes/trees/Clade.cpp
@@ -478,7 +478,7 @@ bool Clade::isOptionalConstraint(void) const
 /**
  * Does the provided clade overlaps with myself? An overlap is if we share at least one taxon.
  *
- * \param[in]    c    Theclade.
+ * \param[in]    c    The clade.
  *
  * \return       True/False, if there is an overlap.
  */
@@ -499,6 +499,36 @@ bool Clade::overlaps(const Clade& c) const
 
     return false;
 }
+
+/**
+ * Compute the set of overlapping taxa between clade c and myself.
+ *
+ * \param[in]    c    The clade.
+ *
+ * \return       The set of overlapping taxa.
+ *
+ * We use this method to give a more helpful error message
+ *  when we claim that clades conflict.
+ */
+set<Taxon> Clade::intersection(const Clade& c) const
+{
+    set<Taxon> both;
+    size_t N = taxa.size();
+    for ( size_t i=0; i<c.size(); ++i)
+    {
+        const Taxon& t = c.getTaxon(i);
+        for ( size_t j=0; j<N; ++j)
+        {
+            if ( taxa[j] == t )
+            {
+                both.insert(t);
+            }
+        }
+    }
+
+    return both;
+}
+
 
 
 /**

--- a/src/core/datatypes/trees/Clade.cpp
+++ b/src/core/datatypes/trees/Clade.cpp
@@ -750,7 +750,7 @@ void Clade::setAges(const std::vector<Taxon>& taxa)
 // We really should separate the idea of constraints (CladeConstraint,
 // NotCladeConstraint, OptionalCladeConstraint) from the idea of clades.
 
-bool clade_before(const Clade& c1, const Clade& c2)
+bool cladeBefore(const Clade& c1, const Clade& c2)
 {
     if (&c1 == &c2)
         return false;
@@ -765,7 +765,7 @@ bool clade_before(const Clade& c1, const Clade& c2)
         return c1.getAge() < c2.getAge();
 }
 
-bool clade_within(const Clade& c1, const Clade& c2)
+bool cladeWithin(const Clade& c1, const Clade& c2)
 {
     if (&c1 == &c2)
         return false;
@@ -801,7 +801,7 @@ bool clade_within(const Clade& c1, const Clade& c2)
     }
 }
 
-bool clade_within_and_before(const Clade& c1, const Clade& c2)
+bool cladeWithinAndBefore(const Clade& c1, const Clade& c2)
 {
     if (&c1 == &c2)
         return false;

--- a/src/core/datatypes/trees/Clade.cpp
+++ b/src/core/datatypes/trees/Clade.cpp
@@ -10,19 +10,16 @@
 
 using namespace RevBayesCore;
 
+using std::set;
+using std::string;
+using std::vector;
 
 /**
  * Default constructor required by the revlanguage code.
  * We use an empty string and an age of 0.0 for
  * this default object.
  */
-Clade::Clade( void ) :
-    age( 0.0 ),
-    clade_name(""),
-    num_missing( 0 ),
-    taxa(),
-    is_negative_constraint(false),
-    is_optional_match(false)
+Clade::Clade( void )
 {
     
 }
@@ -32,13 +29,8 @@ Clade::Clade( void ) :
  * Constructor with a single taxon.
  */
 Clade::Clade( const Taxon &t, const RbBitSet &b ) :
-    age( 0.0 ),
     bitset( b ),
-    clade_name( "" ),
-    num_missing( b.size() > 1 ? b.size() - 1 : 0 ),
-    taxa(),
-    is_negative_constraint(false),
-    is_optional_match(false)
+    num_missing( b.size() > 1 ? b.size() - 1 : 0 )
 {
     
     taxa.push_back( t );
@@ -52,13 +44,9 @@ Clade::Clade( const Taxon &t, const RbBitSet &b ) :
  * \param[in]   n    The vector containing the taxon names.
  */
 Clade::Clade(const std::vector<Taxon> &n, const RbBitSet &b) :
-    age( 0.0 ),
     bitset( b ),
-    clade_name( "" ),
     num_missing( b.size() > n.size() ? int(b.size()) - int(n.size()) : 0 ),
-    taxa( n ),
-    is_negative_constraint(false),
-    is_optional_match(false)
+    taxa( n )
 {
     
     VectorUtilities::sort( taxa );
@@ -72,13 +60,9 @@ Clade::Clade(const std::vector<Taxon> &n, const RbBitSet &b) :
  * \param[in]   n    The vector containing the taxon names.
  */
 Clade::Clade(const std::set<Taxon> &n, const RbBitSet &b) :
-    age( 0.0 ),
     bitset( b ),
     clade_name( "" ),
-    num_missing( b.size() > n.size() ? int(b.size()) - int(n.size()) : 0 ),
-    taxa(),
-    is_negative_constraint(false),
-    is_optional_match(false)
+    num_missing( b.size() > n.size() ? int(b.size()) - int(n.size()) : 0 )
 {
     
     for (std::set<Taxon>::const_iterator it=n.begin(); it!=n.end(); ++it)
@@ -97,12 +81,8 @@ Clade::Clade(const std::set<Taxon> &n, const RbBitSet &b) :
  * \param[in]   n    The vector containing the taxon names.
  */
 Clade::Clade(const RbBitSet &b, const std::vector<Taxon> &n) :
-    age( 0.0 ),
     bitset( b ),
-    clade_name( "" ),
-    num_missing( b.size() - b.count() ),
-    is_negative_constraint(false),
-    is_optional_match(false)
+    num_missing( b.size() - b.count() )
 {
 
     for (size_t i = 0; i < b.size(); i++)
@@ -289,7 +269,6 @@ bool Clade::conflicts(const Clade& c) const
     return overlaps(c) && ( isNestedWithin(c) == false ) && ( c.isNestedWithin(*this) == false );
 }
 
-
 /**
  * Add a taxon to the list.
  *
@@ -377,7 +356,8 @@ size_t Clade::getNumberOfTaxa( void ) const
 
 std::vector<Clade> Clade::getOptionalConstraints(void) const
 {
-    return optional_constraints;
+    assert(optional_constraints.has_value());
+    return *optional_constraints;
 }
 
 
@@ -484,13 +464,14 @@ bool Clade::isNestedWithin(const Clade& c) const
 
 
 /**
- * Is this clade a negative clade constraint (used with e.g. dnConstrainedTopology).
+ * Is this clade an optional constraint (used with e.g. dnConstrainedTopology).
+ * An "optional" constraint means that at least one of the referenced clades must be true.
  *
- * \return       The true/false value of whether the clade is a negative constraint.
+ * \return       The true/false value of whether the clade is an optional constraint.
  */
 bool Clade::isOptionalConstraint(void) const
 {
-    return is_optional_match;
+    return optional_constraints.has_value();
 }
 
 
@@ -632,25 +613,12 @@ void Clade::setNegativeConstraint(bool tf)
 }
 
 /**
- * Set flag for negative clade constraint.
- *
- * \param[in]    tf   Flag indicating if clade is a negative constraint.
- *
- */
-void Clade::setOptionalMatch(bool tf)
-{
-    is_optional_match = tf;
-}
-
-
-
-/**
  * Set optional clade constraints, e.g. dnConstrainedTopology must satisfy one of any clades in the set of clades
  *
  * \param[in]   c   Vector of optional clade constraints
  *
  */
-void Clade::setOptionalConstraints(std::vector<Clade> c)
+void Clade::setOptionalConstraints(const std::vector<Clade>& c)
 {
     optional_constraints = c;
 }

--- a/src/core/datatypes/trees/Clade.cpp
+++ b/src/core/datatypes/trees/Clade.cpp
@@ -718,8 +718,6 @@ std::ostream& operator<<(std::ostream& o, const Clade& x) {
     return o;
 }
 
-}
-
 void Clade::setAges(const std::vector<Taxon>& taxa)
 {
     size_t N = size();
@@ -743,3 +741,117 @@ void Clade::setAges(const std::vector<Taxon>& taxa)
         }
     }
 }
+
+// These should provide a "strict weak ordering" that returns
+// true only if c1 is ordered with respect to c2, and c1 < c2.
+// We do not treat conflicting constraints as unordered.
+//
+// Its not really clear how to handle negative constraints or optional constraints.
+// We really should separate the idea of constraints (CladeConstraint,
+// NotCladeConstraint, OptionalCladeConstraint) from the idea of clades.
+
+bool clade_before(const Clade& c1, const Clade& c2)
+{
+    if (&c1 == &c2)
+        return false;
+
+    // Negative constraints and Optional constraints are unordered after all regular constraints.
+    else if (not (c1.isNegativeConstraint() or c1.isOptionalConstraint()) and (c2.isNegativeConstraint() or c2.isOptionalConstraint()))
+        return true;
+    else if (c1.isNegativeConstraint() or c1.isOptionalConstraint() or c2.isNegativeConstraint() or c2.isOptionalConstraint())
+        return false;
+
+    else
+        return c1.getAge() < c2.getAge();
+}
+
+bool clade_within(const Clade& c1, const Clade& c2)
+{
+    if (&c1 == &c2)
+        return false;
+
+    // Negative constraints and Optional constraints are unordered after all regular constraints.
+    else if (not (c1.isNegativeConstraint() or c1.isOptionalConstraint()) and (c2.isNegativeConstraint() or c2.isOptionalConstraint()))
+        return true;
+    else if (c1.isNegativeConstraint() or c1.isOptionalConstraint() or c2.isNegativeConstraint() or c2.isOptionalConstraint())
+        return false;
+
+    // c2 is nested with c1
+    else if (c1.isNestedWithin(c2))
+        return false;
+    // c1 is nested with c2, but not the reverse
+    else if (c2.isNestedWithin(c1))
+        return true;
+    else if (c1.overlaps(c2))
+    {
+        auto both = c1.intersection(c2);
+        RbException e;
+        e<<"Cannot simulate tree: conflicting monophyletic clade constraints:\n"
+         <<"  Clade1 = "<<c1<<"\n"
+         <<"  Clade2 = "<<c2<<"\n"
+         <<"  Overlap = ";
+        for(auto& taxon: both)
+            e<<taxon.getName()<<" ";
+        throw e;
+    }
+    else
+    {
+        // unordered!
+        return false;
+    }
+}
+
+bool clade_within_and_before(const Clade& c1, const Clade& c2)
+{
+    if (&c1 == &c2)
+        return false;
+
+    // Negative constraints and Optional constraints are unordered after all regular constraints.
+    else if (not (c1.isNegativeConstraint() or c1.isOptionalConstraint()) and (c2.isNegativeConstraint() or c2.isOptionalConstraint()))
+        return true;
+    else if (c1.isNegativeConstraint() or c1.isOptionalConstraint() or c2.isNegativeConstraint() or c2.isOptionalConstraint())
+        return false;
+
+    // c2 is nested with c1
+    else if (c1.isNestedWithin(c2))
+    {
+        // .. AND c1 is nested within c2!
+        if (c2.isNestedWithin(c1))
+            return (c1.getAge() < c2.getAge());
+
+        if ( c1.getAge() < c2.getAge() )
+            throw RbException()<<"Conflicting clades: nested Clade1 constraint has larger Age than containing Clade2!\n"
+                               <<"  Clade1 = "<<c2<<"\n"
+                               <<"  Clade2 = "<<c1<<"\n";
+        return false;
+    }
+    // c1 is nested with c2, but not the reverse
+    else if (c2.isNestedWithin(c1))
+    {
+        if ( c2.getAge() < c1.getAge() )
+            throw RbException()<<"Conflicting clades: nested Clade1 constraint has larger Age than containing Clade2!\n"
+                               <<"  Clade1 = "<<c1<<"\n"
+                               <<"  Clade2 = "<<c2<<"\n";
+        return true;
+    }
+    else if (c1.overlaps(c2))
+    {
+        RbException e;
+        e<<"Cannot simulate tree: conflicting monophyletic clade constraints:\n"
+         <<"  Clade1 = "<<c1<<"\n"
+         <<"  Clade2 = "<<c2<<"\n"
+         <<"  Overlap = ";
+        for(auto& taxon: c1.intersection(c2))
+            e<<taxon.getName()<<" ";
+        throw e;
+    }
+    else
+    {
+        // unordered!
+        return false;
+    }
+};
+        
+
+}
+

--- a/src/core/datatypes/trees/Clade.h
+++ b/src/core/datatypes/trees/Clade.h
@@ -65,8 +65,8 @@ namespace RevBayesCore {
         const Taxon&                                getTaxon(size_t i) const;                                   //!< Get a single taxon name.
         const std::string&                          getTaxonName(size_t i) const;                               //!< Get a single taxon name.
         bool                                        isNegativeConstraint(void) const;                           //!< Get negative constraint flag.
+        bool                                        isOptionalConstraint(void) const;                           //!< Get negative constraint flag.
         bool                                        isNestedWithin(const Clade& c) const;                       //!< Is the provided clade nested within me?
-        bool                                        isOptionalMatch(void) const;                                //!< Get negative constraint flag.
         bool                                        overlaps(const Clade& c) const;                              //!< Does the provided clade overlap with me?
         void                                        resetTaxonBitset(const std::map<std::string, size_t> map);
         void                                        setAge(double a);                                           //!< Set the age of the clade.

--- a/src/core/datatypes/trees/Clade.h
+++ b/src/core/datatypes/trees/Clade.h
@@ -68,7 +68,8 @@ namespace RevBayesCore {
         bool                                        isNegativeConstraint(void) const;                           //!< Get negative constraint flag.
         bool                                        isOptionalConstraint(void) const;                           //!< Get negative constraint flag.
         bool                                        isNestedWithin(const Clade& c) const;                       //!< Is the provided clade nested within me?
-        bool                                        overlaps(const Clade& c) const;                              //!< Does the provided clade overlap with me?
+        bool                                        overlaps(const Clade& c) const;                             //!< Does the provided clade overlap with me?
+        std::set<Taxon>                             intersection(const Clade&) const;                           //!< Get the taxa that both clades have in common.
         void                                        resetTaxonBitset(const std::map<std::string, size_t> map);
         void                                        setAge(double a);                                           //!< Set the age of the clade.
         void                                        setAges(const std::vector<Taxon>& taxa);                         //!< Set the aged of the taxa based on this set.

--- a/src/core/datatypes/trees/Clade.h
+++ b/src/core/datatypes/trees/Clade.h
@@ -101,11 +101,11 @@ namespace RevBayesCore {
     // Global functions using the class
     std::ostream&                       operator<<(std::ostream& o, const Clade& x);                             //!< Overloaded output operator
 
-    bool clade_within_and_before(const Clade& c1, const Clade& c2);
+    bool cladeWithinAndBefore(const Clade& c1, const Clade& c2);
 
-    bool clade_within(const Clade& c1, const Clade& c2);
+    bool cladeWithin(const Clade& c1, const Clade& c2);
 
-    bool clade_before(const Clade& c1, const Clade& c2);
+    bool cladeBefore(const Clade& c1, const Clade& c2);
 }
 
 #endif

--- a/src/core/datatypes/trees/Clade.h
+++ b/src/core/datatypes/trees/Clade.h
@@ -101,6 +101,11 @@ namespace RevBayesCore {
     // Global functions using the class
     std::ostream&                       operator<<(std::ostream& o, const Clade& x);                             //!< Overloaded output operator
 
+    bool clade_within_and_before(const Clade& c1, const Clade& c2);
+
+    bool clade_within(const Clade& c1, const Clade& c2);
+
+    bool clade_before(const Clade& c1, const Clade& c2);
 }
 
 #endif

--- a/src/core/datatypes/trees/Clade.h
+++ b/src/core/datatypes/trees/Clade.h
@@ -6,6 +6,7 @@
 #include <set>
 #include <vector>
 #include <iosfwd>
+#include <boost/optional.hpp>
 
 #include "RbBitSet.h"
 #include "Taxon.h"
@@ -73,12 +74,11 @@ namespace RevBayesCore {
         void                                        setAges(const std::vector<Taxon>& taxa);                         //!< Set the aged of the taxa based on this set.
         void                                        setBitRepresentation(const RbBitSet &b);
         void                                        setCladeName(const std::string& n);                         //!< Set the name of the clade.
-        void                                        setOptionalConstraints(std::vector<Clade> c);               //!< Set optional clade constraints.
+        void                                        setOptionalConstraints(const std::vector<Clade>& c);        //!< Set optional clade constraints.
         void                                        setMrca(const std::set<Taxon>&);                            //!< Set the mrca taxon, if applicable.
         void                                        setNumberMissingTaxa(int n);                                //!< Set the number of missing taxa in this clade.
         void                                        setTaxonAge(size_t i, double age);                          //!< Set a single taxon's age.
         void                                        setNegativeConstraint(bool);                                //!< Set clade to be a negative constraint
-        void                                        setOptionalMatch(bool);                                     //!< Set clade to be an optional-match constraint
         size_t                                      size(void) const;                                           //!< Get the number of taxa.
         std::string                                 toString(void) const;                                       //!< Convert this value into a string.
         
@@ -87,16 +87,14 @@ namespace RevBayesCore {
     private: 
         
         // members
-        double                                      age;
+        double                                      age = 0.0;
         RbBitSet                                    bitset;
         std::string                                 clade_name;
-        int                                         num_missing;
+        int                                         num_missing = 0;
         std::set<Taxon>                             mrca;
         std::vector<Taxon>                          taxa;
-        bool                                        is_negative_constraint;
-        bool                                        is_optional_match;
-        std::vector<Clade>                          optional_constraints;
-        
+        bool                                        is_negative_constraint = false;
+        boost::optional<std::vector<Clade>>         optional_constraints;
     };
     
     // Global functions using the class

--- a/src/core/distributions/phylogenetics/tree/TopologyConstrainedTreeDistribution.cpp
+++ b/src/core/distributions/phylogenetics/tree/TopologyConstrainedTreeDistribution.cpp
@@ -721,7 +721,7 @@ Tree* TopologyConstrainedTreeDistribution::simulateRootedTree( void )
     sorted_clades.push_back(all_species);
 
     size_t num_clades = sorted_clades.size();
-    std::sort(sorted_clades.begin(), sorted_clades.end(), clade_within_and_before);
+    std::sort(sorted_clades.begin(), sorted_clades.end(), cladeWithinAndBefore);
 
     /*
      * Walk clade constraints from tips to root.

--- a/src/core/distributions/phylogenetics/tree/TopologyConstrainedTreeDistribution.cpp
+++ b/src/core/distributions/phylogenetics/tree/TopologyConstrainedTreeDistribution.cpp
@@ -648,7 +648,6 @@ void TopologyConstrainedTreeDistribution::setBackbone(const TypedDagNode<Tree> *
     }
 }
 
-
 /**
  *
  */
@@ -721,40 +720,8 @@ Tree* TopologyConstrainedTreeDistribution::simulateRootedTree( void )
     all_species.setAge( ra );
     sorted_clades.push_back(all_species);
 
-
-    // try this crummy bubble sort
     size_t num_clades = sorted_clades.size();
-    for (int i = 0; i < num_clades - 1; i++)
-    {
-        for (int j = 0; j < num_clades - i - 1; j++)
-        {
-
-            if ( sorted_clades[j].isNestedWithin(sorted_clades[j+1]) == true )
-            {
-                if ( sorted_clades[j].getAge() < sorted_clades[j+1].getAge() )
-                {
-                    throw RbException("TopologyConstrainedTreeDistribution - cannot simulate tree: nested clade 1 constraint has larger Age");
-                }
-                std::swap(sorted_clades[j], sorted_clades[j+1]);
-            }
-            else if ( sorted_clades[j+1].isNestedWithin(sorted_clades[j]) == true )
-            {
-                if (sorted_clades[j+1].getAge() < sorted_clades[j].getAge())
-                {
-                    throw RbException("TopologyConstrainedTreeDistribution - cannot simulate tree: nested clade 2 constraint has larger Age");
-                }
-            }
-            else if ( sorted_clades[j].overlaps(sorted_clades[j+1]) == true )
-            {
-                throw RbException("Cannot simulate tree: conflicting monophyletic clade constraints. Check that all clade constraints are properly nested.");
-            }
-            else if (sorted_clades[j].getAge() > sorted_clades[j+1].getAge())
-            {
-                std::swap(sorted_clades[j], sorted_clades[j+1]);
-            }
-
-        }
-    }
+    std::sort(sorted_clades.begin(), sorted_clades.end(), clade_within_and_before);
 
     /*
      * Walk clade constraints from tips to root.

--- a/src/core/distributions/phylogenetics/tree/TopologyConstrainedTreeDistribution.cpp
+++ b/src/core/distributions/phylogenetics/tree/TopologyConstrainedTreeDistribution.cpp
@@ -222,7 +222,7 @@ void TopologyConstrainedTreeDistribution::initializeBitSets(void)
     for (size_t i = 0; i < monophyly_constraints.size(); i++)
     {
         // clade constraint has only one match
-        if (monophyly_constraints[i].isOptionalMatch() == false)
+        if (monophyly_constraints[i].isOptionalConstraint() == false)
         {
             RbBitSet b( value->getNumberOfTips() );
             for (size_t j = 0; j < monophyly_constraints[i].size(); j++)
@@ -384,7 +384,7 @@ bool TopologyConstrainedTreeDistribution::matchesConstraints( void )
     {
         
         std::vector<Clade> constraints;
-        if ( monophyly_constraints[i].isOptionalMatch() == true )
+        if ( monophyly_constraints[i].isOptionalConstraint() == true )
         {
             constraints = monophyly_constraints[i].getOptionalConstraints();
         }
@@ -702,7 +702,7 @@ Tree* TopologyConstrainedTreeDistribution::simulateRootedTree( void )
         // populate sorted clades vector
         if ( monophyly_constraint.size() > 1 && monophyly_constraint.size() < num_taxa )
         {
-            if ( monophyly_constraint.isOptionalMatch() == true )
+            if ( monophyly_constraint.isOptionalConstraint() == true )
             {
                 std::vector<Clade> optional_constraints = monophyly_constraint.getOptionalConstraints();
                 size_t idx = (size_t)( GLOBAL_RNG->uniform01() * optional_constraints.size() );
@@ -1019,7 +1019,7 @@ Tree* TopologyConstrainedTreeDistribution::simulateUnrootedTree( void )
         if ( monophyly_constraints[i].size() > 1 && monophyly_constraints[i].size() < num_taxa )
         {
         
-            if ( monophyly_constraints[i].isOptionalMatch() == true )
+            if ( monophyly_constraints[i].isOptionalConstraint() == true )
             {
                 std::vector<Clade> optional_constraints = monophyly_constraints[i].getOptionalConstraints();
                 size_t idx = (size_t)( GLOBAL_RNG->uniform01() * optional_constraints.size() );

--- a/src/core/utils/StartingTreeSimulator.cpp
+++ b/src/core/utils/StartingTreeSimulator.cpp
@@ -128,7 +128,7 @@ Tree* StartingTreeSimulator::simulateTree( const std::vector<Taxon> &taxa, const
     sorted_clades.push_back(all_species);
     
     // DO WE NEED TO SORT THE TAXA?
-    std::sort(sorted_clades.begin(), sorted_clades.end(), clade_before);
+    std::sort(sorted_clades.begin(), sorted_clades.end(), cladeBefore);
     
     std::vector<Clade> virtual_taxa;
     int i = -1;

--- a/src/core/utils/StartingTreeSimulator.cpp
+++ b/src/core/utils/StartingTreeSimulator.cpp
@@ -128,16 +128,7 @@ Tree* StartingTreeSimulator::simulateTree( const std::vector<Taxon> &taxa, const
     sorted_clades.push_back(all_species);
     
     // DO WE NEED TO SORT THE TAXA?
-    // try this crummy bubble sort
-    size_t num_clades = sorted_clades.size();
-    for (int i = 0; i < num_clades - 1; i++) {
-        for(int j = 0; j < num_clades - i - 1; j++){
-            if (sorted_clades[j].getAge() > sorted_clades[j+1].getAge()) {
-                std::swap(sorted_clades[j], sorted_clades[j+1]);
-            }
-        }
-    }
-    
+    std::sort(sorted_clades.begin(), sorted_clades.end(), clade_before);
     
     std::vector<Clade> virtual_taxa;
     int i = -1;

--- a/src/core/utils/StartingTreeSimulator.cpp
+++ b/src/core/utils/StartingTreeSimulator.cpp
@@ -107,7 +107,7 @@ Tree* StartingTreeSimulator::simulateTree( const std::vector<Taxon> &taxa, const
         if ( my_constraints[i].size() > 1 && my_constraints[i].size() < num_taxa )
         {
             
-            if ( my_constraints[i].isOptionalMatch() == true )
+            if ( my_constraints[i].isOptionalConstraint() == true )
             {
                 std::vector<Clade> optional_constraints = my_constraints[i].getOptionalConstraints();
                 size_t idx = (size_t)( GLOBAL_RNG->uniform01() * optional_constraints.size() );

--- a/src/core/utils/StringUtilities.cpp
+++ b/src/core/utils/StringUtilities.cpp
@@ -28,7 +28,8 @@
 #include "RbVector.h"
 
 
-
+using std::string;
+using std::vector;
 
 
 /** Convert the string s to a number */
@@ -476,6 +477,22 @@ void StringUtilities::replaceAllOccurrences(std::string& str, char old_ch, char 
     
 }
 
+void StringUtilities::join(std::ostream& o, const vector<string>& ss, const string& sep)
+{
+    for(int i=0;i<ss.size();i++)
+    {
+        o<<ss[i];
+        if (i+1 < ss.size())
+            o<<sep;
+    }
+}
+
+string StringUtilities::join(const vector<string>& ss, const string& sep)
+{
+    std::ostringstream o;
+    join(o, ss, sep);
+    return o.str();
+}
 
 /**
  * Utility function for dividing string into pieces

--- a/src/core/utils/StringUtilities.h
+++ b/src/core/utils/StringUtilities.h
@@ -42,6 +42,8 @@ namespace StringUtilities {
     void                        stringSplit(std::string str, std::string delim, std::vector<std::string>& results, bool trim = false); //!< Split a string into pieces
     void                        toLower(std::string& str);                                                          //!< Convert string's characters to lower case
     std::string                 toString(double x, int digits=6);                                                   //!< Convert string's characters to lower case
+    std::string                 join(const std::vector<std::string>& ss, const std::string& sep);
+    void                        join(std::ostream& o, const std::vector<std::string>& ss, const std::string& sep);
     
     /**
      * Generic to_string function

--- a/src/revlanguage/datatypes/phylogenetics/trees/RlClade.cpp
+++ b/src/revlanguage/datatypes/phylogenetics/trees/RlClade.cpp
@@ -182,10 +182,6 @@ void Clade::constructInternalObject( void )
         c->setOptionalConstraints( optional_constraints );
     }
 
-
-    // set optional match clade constraint
-    c->setOptionalMatch( match );
-
     // set negative clade constraint
     c->setNegativeConstraint( neg );
 


### PR DESCRIPTION
Before simulating the constrained tree, we first sort clade constraints so that tip-ward clades are first.  However, this doesn't make sense for negated constraints, so we need to avoid checking for overlapping taxa between negated constraints and other constraints.

Another issue was that we said that there were conflicting constraints, but didn't say which ones.  So, print out the supposedly-conflicting constraints.  When regular constraints conflict, its because their taxon sets overlap, so also print out the overlapping taxa.

Another issue was that we printed out negated or "optional" constraints as if they were regular clade constraints.  So, print out `NOT A` for negative constraints and `(A OR B OR C)` for optional constraints. 

The underlying issue may be that the code for simulating initial trees is just really fragile, and needs a thorough rework.

A deeper issue is that we are pretending that a constraint of the form (A OR B OR B) is a `Clade`.  It really is a Constraint, but not a Clade.  We should separate `Clade` from constraints -- perhaps by creating classes `CladeConstraint`, `OrConstraint`, and `NegativeConstraint` or something like that.