### PR TITLE
Begin cleaning up tree summaries and fix computePairwiseRFDistance()

### DIFF
--- a/src/core/analysis/mcmc/output/Trace.cpp
+++ b/src/core/analysis/mcmc/output/Trace.cpp
@@ -13,14 +13,12 @@ using namespace RevBayesCore;
 template <>
 int Trace<double>::isCoveredInInterval(const std::string &v, double alpha, bool verbose)
 {
-
     double sample = atof( v.c_str() );
 
     double smaller_values_count = 0;
     double equal_values_count   = 0;
     for (size_t j=0; j<values.size(); ++j)
     {
-
         if ( values[j] < sample )
         {
             ++smaller_values_count;
@@ -29,9 +27,8 @@ int Trace<double>::isCoveredInInterval(const std::string &v, double alpha, bool 
         {
             ++equal_values_count;
         }
-
     }
-    
+
     RandomNumberGenerator *rng = GLOBAL_RNG;
 
     double u = rng->uniform01();

--- a/src/core/analysis/mcmc/output/Trace.h
+++ b/src/core/analysis/mcmc/output/Trace.h
@@ -22,7 +22,7 @@ namespace RevBayesCore {
         
     public:
         
-        Trace(void);
+        Trace(void)                     = default;
         
         virtual                         ~Trace(void) {}
 
@@ -37,7 +37,8 @@ namespace RevBayesCore {
         const valueType&                objectAt(size_t index, bool post = false) const { return post ? values.at(index + burnin) : values.at(index); }
         long                            size(bool post = false) const                   { return post ? values.size() - burnin : values.size(); }
 
-        virtual void                    addObject(valueType d);
+        virtual void                    addObject(const valueType& d);
+        virtual void                    addObject(valueType&& d);
         virtual void                    addObject(valueType* d);
         virtual int                     isCoveredInInterval(const std::string &v, double i, bool verbose);
         bool                            isDirty(void) const                             { return dirty; };
@@ -62,12 +63,12 @@ namespace RevBayesCore {
         
     protected:
         
-        size_t                          burnin;
+        size_t                          burnin = 0;
         path                            fileName;
         std::string                     parmName;
         std::vector<valueType>          values;                                     //!< the values of this trace
 
-        mutable bool                    dirty;
+        mutable bool                    dirty = true;
 
     };
 
@@ -110,22 +111,18 @@ namespace RevBayesCore {
 
 }
 
-/**
- * Default constructor.
- */
 template <class valueType>
-RevBayesCore::Trace<valueType>::Trace() :
-    burnin( 0 ),
-    parmName( "" ),
-    dirty( true )
+void RevBayesCore::Trace<valueType>::addObject(const valueType& t)
 {
+    values.push_back(t);
+    dirty = true;
 }
 
 
 template <class valueType>
-void RevBayesCore::Trace<valueType>::addObject(valueType t)
+void RevBayesCore::Trace<valueType>::addObject(valueType&& t)
 {
-    values.push_back(t);
+    values.push_back( std::move(t) );
     dirty = true;
 }
 

--- a/src/core/analysis/mcmc/output/TreeSummary.cpp
+++ b/src/core/analysis/mcmc/output/TreeSummary.cpp
@@ -1177,7 +1177,7 @@ TopologyNode* TreeSummary::findParentNode(TopologyNode& n, const Split& split, s
     // check if the flipped unrooted split is compatible
     if ( !rooted && !compatible && !ischild)
     {
-        RbBitSet clade_flip = clade; ~clade_flip;
+        RbBitSet clade_flip = ~clade;
         mask  = node | clade_flip;
 
         compatible = (mask == node);

--- a/src/core/analysis/mcmc/output/TreeSummary.cpp
+++ b/src/core/analysis/mcmc/output/TreeSummary.cpp
@@ -1076,26 +1076,30 @@ std::vector<double> TreeSummary::computePairwiseRFDistance( double credible_inte
     std::vector<double> rf_distances;
     for (size_t i=0; i<unique_trees.size(); ++i)
     {
+        // The unique tree occurs sample_count[i] times.
+        // Here we are treating them as coming in one continuous block, which is annoying.
 
-        // first we need to compare the tree to 'itself'
-        for (size_t k=0; k<(sample_count[i]*(sample_count[i]-1)); ++k )
+        for(int rep = 0;rep<sample_count[i];rep++)
         {
-            rf_distances.push_back( 0.0 );
-        }
-
-        for (size_t j=i+1; j<unique_trees.size(); ++j)
-        {
-            
-            std::vector<RbBitSet>* a = unique_trees_bs[i];
-            std::vector<RbBitSet>* b = unique_trees_bs[j];
-            double rf = TreeUtilities::computeRobinsonFouldDistance(*a, *b, true);
-
-            for (size_t k=0; k<(sample_count[i]*sample_count[j]); ++k )
+            // first we need to compare the tree to subsequent copies of itself
+            for (size_t k=rep+1; k<sample_count[i]; ++k )
             {
-                rf_distances.push_back( rf );
+                rf_distances.push_back( 0.0 );
+            }
+
+            // then we compare it to copies of other trees
+            for (size_t j=i+1; j<unique_trees.size(); ++j)
+            {
+                std::vector<RbBitSet>* a = unique_trees_bs[i];
+                std::vector<RbBitSet>* b = unique_trees_bs[j];
+                double rf = TreeUtilities::computeRobinsonFouldDistance(*a, *b, true);
+
+                for (size_t k=0; k<sample_count[j]; ++k )
+                    rf_distances.push_back( rf );
             }
         }
     }
+
     for (size_t i=0; i<unique_trees.size(); ++i)
     {
         Tree* tmp = unique_trees[i];

--- a/src/core/analysis/mcmc/output/TreeSummary.cpp
+++ b/src/core/analysis/mcmc/output/TreeSummary.cpp
@@ -37,24 +37,6 @@ using namespace RevBayesCore;
 
 
 /*
- * Default AnnotationReport constructor
- */
-TreeSummary::AnnotationReport::AnnotationReport() :
-    clade_probs                   (true),
-    conditional_clade_ages        (false),
-    conditional_clade_probs       (false),
-    conditional_tree_ages         (false),
-    MAP_parameters                (false),
-    node_ages                     (true),
-    mean_node_ages                (true),
-    node_ages_HPD                 (0.95),
-    sampled_ancestor_probs        (true),
-    force_positive_branch_lengths (false),
-    use_outgroup(false)
-{}
-
-
-/*
  * TreeSummary constructor
  */
 TreeSummary::TreeSummary( TraceTree* t, bool c ) :

--- a/src/core/analysis/mcmc/output/TreeSummary.cpp
+++ b/src/core/analysis/mcmc/output/TreeSummary.cpp
@@ -41,8 +41,7 @@ using namespace RevBayesCore;
  */
 TreeSummary::TreeSummary( TraceTree* t, bool c ) :
     clock( c ),
-    rooted( c ),
-    use_outgroup(false)
+    rooted( c )
 {
     traces.push_back(t);
 }
@@ -54,8 +53,7 @@ TreeSummary::TreeSummary( TraceTree* t, bool c ) :
 TreeSummary::TreeSummary( std::vector<TraceTree* > t, bool c ) :
     traces(t),
     clock( c ),
-    rooted( c ),
-    use_outgroup(false)
+    rooted( c )
 {
     if( traces.empty() )
     {
@@ -666,9 +664,9 @@ void TreeSummary::annotateTree( Tree &tree, AnnotationReport report, bool verbos
 
         if ( tmp_tree->isRooted() == false && rooted == false )
         {
-            if ( use_outgroup == true )
+            if ( outgroup )
             {
-                tmp_tree->reroot( outgroup, false, true );
+                tmp_tree->reroot( *outgroup, false, true );
             }
             else
             {
@@ -1244,9 +1242,9 @@ int TreeSummary::getTopologyFrequency(const RevBayesCore::Tree &tree, bool verbo
 
     if ( t.isRooted() == false && rooted == false )
     {
-        if( use_outgroup )
+        if( outgroup )
         {
-            t.reroot( outgroup, false, true );
+            t.reroot( *outgroup, false, true );
         }
         else
         {
@@ -1350,9 +1348,9 @@ bool TreeSummary::isCoveredInInterval(const std::string &v, double ci_size, bool
 
     if ( tree.isRooted() == false && rooted == false )
     {
-        if ( use_outgroup == true )
+        if ( outgroup )
         {
-            tree.reroot( outgroup, false, true );
+            tree.reroot( *outgroup, false, true );
         }
         else
         {
@@ -1880,7 +1878,6 @@ void TreeSummary::printTreeSummary(std::ostream &o, double credibleIntervalSize,
 
 void TreeSummary::setOutgroup(const RevBayesCore::Clade &c)
 {
-    use_outgroup = true;
     outgroup = c;
 }
 
@@ -1944,9 +1941,9 @@ void TreeSummary::summarize( bool verbose )
 
             if ( rooted == false )
             {
-                if ( use_outgroup == true )
+                if ( outgroup )
                 {
-                    tree.reroot( outgroup, false, true );
+                    tree.reroot( *outgroup, false, true );
                 }
                 else
                 {

--- a/src/core/analysis/mcmc/output/TreeSummary.h
+++ b/src/core/analysis/mcmc/output/TreeSummary.h
@@ -49,19 +49,17 @@ namespace RevBayesCore {
          */
         struct AnnotationReport
         {
-            bool clade_probs;
-            bool conditional_clade_ages;
-            bool conditional_clade_probs;
-            bool conditional_tree_ages;
-            bool MAP_parameters;
-            bool node_ages;
-            bool mean_node_ages;
-            double node_ages_HPD;
-            bool sampled_ancestor_probs;
-            bool force_positive_branch_lengths;
-            bool use_outgroup;
-            
-            AnnotationReport();
+            bool clade_probs = true;
+            bool conditional_clade_ages = false;
+            bool conditional_clade_probs = false;
+            bool conditional_tree_ages = false;
+            bool MAP_parameters = false;
+            bool node_ages = true;
+            bool mean_node_ages = true;
+            double node_ages_HPD = 0.95;
+            bool sampled_ancestor_probs = true;
+            bool force_positive_branch_lengths = false;
+            bool use_outgroup = false;  // Is this unused?
         };
 
 

--- a/src/core/analysis/mcmc/output/TreeSummary.h
+++ b/src/core/analysis/mcmc/output/TreeSummary.h
@@ -117,8 +117,7 @@ namespace RevBayesCore {
         std::map<Split, std::map<Split, std::vector<double> > >         conditional_clade_ages;
         std::map<std::string, std::map<Split, std::vector<double> > >   tree_clade_ages;
 
-        bool                                       use_outgroup;
-        Clade                                      outgroup;
+        boost::optional<Clade>                     outgroup;
     };
 
 }

--- a/src/core/dag/DagNode.h
+++ b/src/core/dag/DagNode.h
@@ -9,7 +9,7 @@
 
 #include "MemberObject.h"
 #include "Parallelizable.h"
-#include "RbVector.h"
+#include "RbOrderedSet.h"
 #include "SimulationConditions.h"
 #include "RbFileManager.h"
 

--- a/src/core/dag/TypedDagNode.cpp
+++ b/src/core/dag/TypedDagNode.cpp
@@ -1,0 +1,160 @@
+#include "TypedDagNode.h"
+
+#include "NexusWriter.h"
+#include "RbSettings.h"
+#include "RbUtil.h"
+#include "Simplex.h"
+#include "StringUtilities.h"
+#include "TraceNumeric.h"
+#include "TraceTree.h"
+
+#include <ostream>
+#include <string>
+#include <limits>
+
+///////////////////////
+// createTraceObject //
+///////////////////////
+
+using namespace RevBayesCore;
+
+template<>
+AbstractTrace*  TypedDagNode<long>::createTraceObject(void) const
+{
+    return new TraceNumericInteger();
+}
+
+template<>
+AbstractTrace*  TypedDagNode<double>::createTraceObject(void) const
+{
+    return new TraceNumeric();
+}
+
+template<>
+AbstractTrace*  TypedDagNode<RbVector<double> >::createTraceObject(void) const
+{
+    return new TraceNumericVector();
+}
+    
+template<>
+AbstractTrace*  TypedDagNode<Simplex>::createTraceObject(void) const
+{
+    return new TraceSimplex();
+}
+    
+template<>
+AbstractTrace*  TypedDagNode<Tree>::createTraceObject(void) const
+{
+    return new TraceTree( getValue().isRooted() );
+}
+
+    
+/////////////////////
+// isSimpleNumeric //
+/////////////////////
+template<>
+bool TypedDagNode<long>::isSimpleNumeric(void) const
+{
+    return true;
+} 
+    
+template<>
+bool TypedDagNode<double>::isSimpleNumeric(void) const
+{
+    return true;
+}
+
+template<>
+bool TypedDagNode<RbVector<long> >::isSimpleNumeric(void) const
+{
+    return true;
+}
+    
+template<>
+bool TypedDagNode<RbVector<double> >::isSimpleNumeric(void) const
+{
+    return true;
+}
+    
+template<>
+bool TypedDagNode<Simplex>::isSimpleNumeric(void) const
+{
+    return true;
+}
+    
+////////////////
+// printValue //
+////////////////
+template<>
+void TypedDagNode<double>::printValue(std::ostream &o, const std::string & /*sep*/, int l, bool left, bool /*user*/, bool simple, bool flatten) const
+{
+    std::stringstream ss;
+
+    // if simple == FALSE, print with maximum precision allowed
+    if (!simple)
+    {
+        ss.precision(std::numeric_limits<double>::digits10);
+    }
+
+    // otherwise, use standard RB precision
+    else
+    {
+        ss.precision(RbSettings::userSettings().getOutputPrecision());
+    }
+    ss << getValue();
+    std::string s = ss.str();
+    if ( l > 0 )
+    {
+        StringUtilities::fillWithSpaces(s, l, left);
+    }
+    o << s;
+}
+
+    
+template<>
+void TypedDagNode<long>::printValue(std::ostream &o, const std::string & /*sep*/, int l, bool left, bool /*user*/, bool /*simple*/, bool /*flatten*/) const
+{
+        
+    std::stringstream ss;
+    ss << getValue();
+    std::string s = ss.str();
+    if ( l > 0 )
+    {
+        StringUtilities::fillWithSpaces(s, l, left);
+    }
+    o << s;
+}
+    
+    
+template<>
+void TypedDagNode<unsigned int>::printValue(std::ostream &o, const std::string & /*sep*/, int l, bool left, bool /*user*/, bool /*simple*/, bool /*flatten*/) const
+{
+        
+    std::stringstream ss;
+    ss << getValue();
+    std::string s = ss.str();
+    if ( l > 0 )
+    {
+        StringUtilities::fillWithSpaces(s, l, left);
+    }
+    o << s;
+}
+    
+    
+template<>
+void TypedDagNode<std::string>::printValue(std::ostream &o, const std::string & /*sep*/, int l, bool left, bool /*user*/, bool /*simple*/, bool /*flatten*/) const
+{
+        
+    std::stringstream ss;
+//        ss << "\"" << getValue() << "\"";
+    ss << getValue();
+    std::string s = ss.str();
+    if ( l > 0 )
+    {
+        StringUtilities::fillWithSpaces(s, l, left);
+    }
+    o << s;
+}
+    
+    
+    

--- a/src/core/dag/TypedDagNode.h
+++ b/src/core/dag/TypedDagNode.h
@@ -2,13 +2,8 @@
 #define TypedDagNode_H
 
 #include "DagNode.h"
-#include "NexusWriter.h"
-#include "RbSettings.h"
 #include "RbUtil.h"
-#include "Simplex.h"
 #include "StringUtilities.h"
-#include "TraceNumeric.h"
-#include "TraceTree.h"
 
 #include <ostream>
 #include <string>
@@ -44,42 +39,46 @@ namespace RevBayesCore {
     };
     
 
+    class Tree;
+    class Simplex;
+    template <typename T> class RbVector;
+
     ///////////////////////
     // createTraceObject //
     ///////////////////////
     template<>
-    inline AbstractTrace*                                TypedDagNode<long>::createTraceObject(void) const { return new TraceNumericInteger(); }
+    AbstractTrace*                                          TypedDagNode<long>::createTraceObject(void) const;
 
     template<>
-    inline AbstractTrace*                                TypedDagNode<double>::createTraceObject(void) const { return new TraceNumeric(); }
+    AbstractTrace*                                          TypedDagNode<double>::createTraceObject(void) const;
 
     template<>
-    inline AbstractTrace*                                TypedDagNode<RbVector<double> >::createTraceObject(void) const { return new TraceNumericVector(); }
+    AbstractTrace*                                          TypedDagNode<RbVector<double> >::createTraceObject(void) const;
     
     template<>
-    inline AbstractTrace*                                TypedDagNode<Simplex>::createTraceObject(void) const { return new TraceSimplex(); }
+    AbstractTrace*                                          TypedDagNode<Simplex>::createTraceObject(void) const;
     
     template<>
-    inline AbstractTrace*                                TypedDagNode<Tree>::createTraceObject(void) const { return new TraceTree( getValue().isRooted() ); }
+    AbstractTrace*                                          TypedDagNode<Tree>::createTraceObject(void) const;
 
     
     /////////////////////
     // isSimpleNumeric //
     /////////////////////
     template<>
-    inline bool                                  TypedDagNode<long>::isSimpleNumeric(void) const { return true; } 
+    bool                                                    TypedDagNode<long>::isSimpleNumeric(void) const;
     
     template<>
-    inline bool                                  TypedDagNode<double>::isSimpleNumeric(void) const { return true; }
+    bool                                                    TypedDagNode<double>::isSimpleNumeric(void) const;
 
     template<>
-    inline bool                                  TypedDagNode<RbVector<long> >::isSimpleNumeric(void) const { return true; }
+    bool                                                    TypedDagNode<RbVector<long> >::isSimpleNumeric(void) const;
     
     template<>
-    inline bool                                  TypedDagNode<RbVector<double> >::isSimpleNumeric(void) const { return true; }
+    bool                                                    TypedDagNode<RbVector<double> >::isSimpleNumeric(void) const;
     
     template<>
-    inline bool                                  TypedDagNode<Simplex>::isSimpleNumeric(void) const { return true; }
+    bool                                                    TypedDagNode<Simplex>::isSimpleNumeric(void) const;
     
     
     
@@ -87,76 +86,16 @@ namespace RevBayesCore {
     // printValue //
     ////////////////
     template<>
-    inline void TypedDagNode<double>::printValue(std::ostream &o, const std::string & /*sep*/, int l, bool left, bool /*user*/, bool simple, bool flatten) const
-    {
-        std::stringstream ss;
+    void TypedDagNode<double>::printValue(std::ostream &o, const std::string & /*sep*/, int l, bool left, bool /*user*/, bool simple, bool flatten) const;
 
-        // if simple == FALSE, print with maximum precision allowed
-        if (!simple)
-        {
-            ss.precision(std::numeric_limits<double>::digits10);
-        }
-
-        // otherwise, use standard RB precision
-        else
-        {
-            ss.precision(RbSettings::userSettings().getOutputPrecision());
-        }
-        ss << getValue();
-        std::string s = ss.str();
-        if ( l > 0 )
-        {
-            StringUtilities::fillWithSpaces(s, l, left);
-        }
-        o << s;
-    }
-
+    template<>
+    void TypedDagNode<long>::printValue(std::ostream &o, const std::string & /*sep*/, int l, bool left, bool /*user*/, bool /*simple*/, bool /*flatten*/) const;
     
     template<>
-    inline void TypedDagNode<long>::printValue(std::ostream &o, const std::string & /*sep*/, int l, bool left, bool /*user*/, bool /*simple*/, bool /*flatten*/) const
-    {
-        
-        std::stringstream ss;
-        ss << getValue();
-        std::string s = ss.str();
-        if ( l > 0 )
-        {
-            StringUtilities::fillWithSpaces(s, l, left);
-        }
-        o << s;
-    }
-    
+    void TypedDagNode<unsigned int>::printValue(std::ostream &o, const std::string & /*sep*/, int l, bool left, bool /*user*/, bool /*simple*/, bool /*flatten*/) const;
     
     template<>
-    inline void TypedDagNode<unsigned int>::printValue(std::ostream &o, const std::string & /*sep*/, int l, bool left, bool /*user*/, bool /*simple*/, bool /*flatten*/) const
-    {
-        
-        std::stringstream ss;
-        ss << getValue();
-        std::string s = ss.str();
-        if ( l > 0 )
-        {
-            StringUtilities::fillWithSpaces(s, l, left);
-        }
-        o << s;
-    }
-    
-    
-    template<>
-    inline void TypedDagNode<std::string>::printValue(std::ostream &o, const std::string & /*sep*/, int l, bool left, bool /*user*/, bool /*simple*/, bool /*flatten*/) const
-    {
-        
-        std::stringstream ss;
-//        ss << "\"" << getValue() << "\"";
-        ss << getValue();
-        std::string s = ss.str();
-        if ( l > 0 )
-        {
-            StringUtilities::fillWithSpaces(s, l, left);
-        }
-        o << s;
-    }
-    
+    void TypedDagNode<std::string>::printValue(std::ostream &o, const std::string & /*sep*/, int l, bool left, bool /*user*/, bool /*simple*/, bool /*flatten*/) const;
 }
 
 #include "Printable.h"

--- a/src/core/datatypes/phylogenetics/TaxonMap.cpp
+++ b/src/core/datatypes/phylogenetics/TaxonMap.cpp
@@ -1,10 +1,13 @@
 #include "TaxonMap.h"
 
+#include <sstream>
 #include <cstddef>
 #include <utility>
 
+#include "RbException.h"
 #include "Tree.h"
 #include "TimeInterval.h"
+
 
 using namespace RevBayesCore;
 
@@ -41,7 +44,10 @@ TaxonMap::TaxonMap( const Tree &t ) :
  */
 void TaxonMap::addTaxon( const Taxon &t )
 {
-    taxa_map.insert( std::pair<Taxon, size_t>( t, taxa.size() ) );
+    if (taxa_map.count(t))
+        throw RbException()<<"TaxonMap: adding duplicate taxon "<<t;
+
+    taxa_map.insert( { t, taxa.size() } );
     taxa.push_back( t );
 }
 
@@ -57,8 +63,39 @@ const Taxon& TaxonMap::getTaxon(size_t i) const
 }
 
 
+bool TaxonMap::hasTaxon(const Taxon &t) const
+{
+    return (taxa_map.count(t) > 0);
+}
+
 size_t TaxonMap::getTaxonIndex(const Taxon &t) const
 {
-    const std::map< Taxon, size_t >::const_iterator& entry = taxa_map.find(t);
+    auto entry = taxa_map.find(t);
+    if (entry == taxa_map.end())
+        throw RbException()<<"TaxonMap: can't find taxon "<<t;
     return entry->second;
 }
+
+
+int TaxonMap::size() const
+{
+    return taxa.size();
+}
+
+std::string TaxonMap::print() const
+{
+    std::ostringstream ss;
+    ss<<(*this);
+    return ss.str();
+}
+
+// Global functions using the class
+std::ostream& RevBayesCore::operator<<(std::ostream& o, const TaxonMap& tm)
+{
+    for(int i=0; i<tm.size();i++)
+    {
+        o<<i+1<<": "<<tm.getTaxon(i)<<"\n";
+    }
+    return o;
+}
+//!< Overloaded output operator

--- a/src/core/datatypes/phylogenetics/TaxonMap.h
+++ b/src/core/datatypes/phylogenetics/TaxonMap.h
@@ -40,9 +40,15 @@ namespace RevBayesCore {
         
         // public methods
         void                                addTaxon(const Taxon &t);                       //!< Get the age for this TaxonMap.
-        const Taxon&                        getTaxon(size_t i) const;                       //!< Get the i-th Taxon
+        bool                                hasTaxon(const Taxon &t) const;                 //!< Get the i-th Taxon
         size_t                              getTaxonIndex(const Taxon &t) const;            //!< Get the i-th Taxon
+
+        const Taxon&                        getTaxon(size_t i) const;                       //!< Get the i-th Taxon
+
+        int                                 size() const;                                   //!< How many taxa in the map?
         
+        std::string                         print() const;
+
     private:
         
         std::vector<Taxon>                  taxa;

--- a/src/core/datatypes/phylogenetics/ratemap/HostSwitchRateModifier.cpp
+++ b/src/core/datatypes/phylogenetics/ratemap/HostSwitchRateModifier.cpp
@@ -11,7 +11,6 @@
 #include "Assignable.h"
 #include "CharacterHistoryRateModifier.h"
 #include "Cloneable.h"
-#include "DistanceMatrix.h"
 #include "RbException.h"
 #include "RbVector.h"
 #include "RbVectorImpl.h"

--- a/src/core/datatypes/phylogenetics/ratemap/HostSwitchRateModifier.h
+++ b/src/core/datatypes/phylogenetics/ratemap/HostSwitchRateModifier.h
@@ -11,8 +11,10 @@
 
 
 #include "CharacterHistoryRateModifier.h"
+#include "DistanceMatrix.h"
 #include "StochasticNode.h"
 #include "TopologyNode.h"
+#include "Tree.h"
 
 #include <set>
 #include <string>

--- a/src/core/datatypes/trees/TopologyNode.cpp
+++ b/src/core/datatypes/trees/TopologyNode.cpp
@@ -1991,27 +1991,6 @@ void TopologyNode::setTaxon(Taxon const &t)
 }
 
 
-//!< Set the indices of the taxa from the taxon map
-void TopologyNode::setTaxonIndices(const TaxonMap &tm)
-{
-
-    if ( isTip() == true )
-    {
-        size_t idx = tm.getTaxonIndex( taxon );
-        index = idx;
-    }
-    else
-    {
-        for ( std::vector<TopologyNode* >::const_iterator i=children.begin(); i!=children.end(); i++ )
-        {
-            (*i)->setTaxonIndices( tm );
-        }
-    }
-
-
-}
-
-
 void TopologyNode::setTimeInStates(std::vector<double> t)
 {
     time_in_states = t;

--- a/src/core/datatypes/trees/TopologyNode.h
+++ b/src/core/datatypes/trees/TopologyNode.h
@@ -51,7 +51,6 @@
 namespace RevBayesCore {
     
     class Tree;
-    class TaxonMap;
     
     class TopologyNode  {
         
@@ -158,7 +157,6 @@ namespace RevBayesCore {
         void                                        setSampledAncestor(bool tf);                                                        //!< Set if the node is a sampled ancestor
         void                                        setSpeciesName(std::string const &n);                                               //!< Set the species name of this node
         void                                        setTaxon(Taxon const &t);                                                           //!< Set the taxon of this node
-        void                                        setTaxonIndices(const TaxonMap &tm);                                                //!< Set the indices of the taxa from the taxon map
         void                                        setTimeInStates(std::vector<double> t);
         void                                        setTree(Tree *t);                                                                   //!< Sets the tree pointer
         void                                        setUseAges(bool tf, bool recursive);

--- a/src/core/datatypes/trees/TopologyNode.h
+++ b/src/core/datatypes/trees/TopologyNode.h
@@ -42,7 +42,6 @@
 
 #include "TreeChangeEventMessage.h"
 #include "Taxon.h"
-#include "TaxonMap.h"
 
 #include <vector>
 #include <map>
@@ -52,6 +51,7 @@
 namespace RevBayesCore {
     
     class Tree;
+    class TaxonMap;
     
     class TopologyNode  {
         

--- a/src/core/datatypes/trees/Tree.cpp
+++ b/src/core/datatypes/trees/Tree.cpp
@@ -908,13 +908,14 @@ std::vector<std::string> Tree::getSpeciesNames() const
 std::vector<Taxon> Tree::getTaxa() const
 {
     std::vector< Taxon > taxa;
-    for (size_t i = 0; i < getNumberOfTips(); ++i)
+    for (auto& node: nodes)
     {
-        const TopologyNode& n = getTipNode( i );
-        Taxon taxon = n.getTaxon();
-        taxon.setAge(n.getAge());
-        taxa.push_back( taxon );
-
+        if (node->isTip() or node->isSampledAncestor())
+        {
+            Taxon taxon = node->getTaxon();
+            taxon.setAge(node->getAge());
+            taxa.push_back( taxon );
+        }
     }
 
     return taxa;

--- a/src/core/datatypes/trees/Tree.h
+++ b/src/core/datatypes/trees/Tree.h
@@ -26,7 +26,6 @@
 #include "Cloneable.h"
 #include "MemberObject.h"
 #include "Serializable.h"
-#include "TaxonMap.h"
 #include "TreeChangeEventHandler.h"
 #include "Printable.h"
 
@@ -36,6 +35,7 @@
 namespace RevBayesCore {
 
     class TopologyNode;
+    class TaxonMap;
 
     class Tree : public Cloneable, public MemberObject<double>, public MemberObject<long>, public MemberObject<Boolean>, public Serializable, public Printable {
 

--- a/src/core/datatypes/trees/Tree.h
+++ b/src/core/datatypes/trees/Tree.h
@@ -40,12 +40,14 @@ namespace RevBayesCore {
     class Tree : public Cloneable, public MemberObject<double>, public MemberObject<long>, public MemberObject<Boolean>, public Serializable, public Printable {
 
     public:
-        Tree(void);                                                                                                                                             //!< Default constructor
+        Tree(void) = default;                                                                                                                                   //!< Default constructor
         Tree(const Tree& t);                                                                                                                                    //!< Copy constructor
+        Tree(Tree&& t);                                                                                                                                         //!< Move constructor
 
         virtual                                            ~Tree(void);                                                                                         //!< Destructor
 
         Tree&                                               operator=(const Tree& t);
+        Tree&                                               operator=(Tree&& t);
 
         // overloaded operators
         bool                                                operator==(const Tree &t) const;
@@ -161,12 +163,12 @@ namespace RevBayesCore {
         void                                                reindexNodes();
 
         // private members
-        TopologyNode*                                       root;
+        TopologyNode*                                       root = nullptr;
         std::vector<TopologyNode*>                          nodes;                                                                  //!< Vector of pointers to all nodes
-        bool                                                rooted;
-        bool                                                is_negative_constraint;
-        size_t                                              num_tips;
-        size_t                                              num_nodes;
+        bool                                                rooted = false;
+        bool                                                is_negative_constraint = false;
+        size_t                                              num_tips = 0;
+        size_t                                              num_nodes = 0;
         mutable std::map<std::string, size_t>               taxon_bitset_map;
 
     };

--- a/src/core/distributions/EmpiricalSampleDistribution.h
+++ b/src/core/distributions/EmpiricalSampleDistribution.h
@@ -4,6 +4,7 @@
 #include "MemberObject.h"
 #include "Parallelizable.h"
 #include "RbVector.h"
+#include "Trace.h"
 #include "TypedDagNode.h"
 #include "TypedDistribution.h"
 

--- a/src/core/distributions/TypedDistribution.h
+++ b/src/core/distributions/TypedDistribution.h
@@ -33,6 +33,7 @@
 
 #include "Distribution.h"
 #include "Function.h"
+#include "RbVector.h"
 
 #include <iostream>
 

--- a/src/core/distributions/phylogenetics/AbstractFossilizedBirthDeathRangeProcess.h
+++ b/src/core/distributions/phylogenetics/AbstractFossilizedBirthDeathRangeProcess.h
@@ -2,7 +2,9 @@
 #define AbstractFossilizedBirthDeathRangeProcess_H
 
 #include "RbVector.h"
+#include "Taxon.h"
 #include "TypedDagNode.h"
+
 
 namespace RevBayesCore {
 

--- a/src/core/distributions/phylogenetics/characterhistory/TreeHistoryCtmc.h
+++ b/src/core/distributions/phylogenetics/characterhistory/TreeHistoryCtmc.h
@@ -5,6 +5,8 @@
 #include "BranchHistoryDiscrete.h"
 #include "CharacterEventDiscrete.h"
 #include "ConstantNode.h"
+#include "ContinuousTaxonData.h"
+#include "ContinuousCharacterData.h"
 #include "DiscreteTaxonData.h"
 #include "HomologousDiscreteCharacterData.h"
 #include "DiscreteCharacterState.h"

--- a/src/core/distributions/phylogenetics/tree/UltrametricTreeDistribution.h
+++ b/src/core/distributions/phylogenetics/tree/UltrametricTreeDistribution.h
@@ -1,6 +1,7 @@
 #ifndef UltrametricTreeDistribution_H
 #define UltrametricTreeDistribution_H
 
+#include "TraceTree.h"
 #include "Tree.h"
 #include "TypedDagNode.h"
 #include "TypedDistribution.h"

--- a/src/core/distributions/phylogenetics/tree/birthdeath/BirthDeathSamplingTreatmentProcess.cpp
+++ b/src/core/distributions/phylogenetics/tree/birthdeath/BirthDeathSamplingTreatmentProcess.cpp
@@ -9,6 +9,7 @@
 #include "AbstractBirthDeathProcess.h"
 #include "BirthDeathForwardSimulator.h"
 #include "BirthDeathSamplingTreatmentProcess.h"
+#include "Clade.h"
 #include "DagNode.h"
 #include "DistributionExponential.h"
 #include "RandomNumberFactory.h"

--- a/src/core/distributions/phylogenetics/tree/birthdeath/BirthDeathSamplingTreatmentProcess.cpp
+++ b/src/core/distributions/phylogenetics/tree/birthdeath/BirthDeathSamplingTreatmentProcess.cpp
@@ -6,17 +6,18 @@
 #include <string>
 #include <vector>
 
+#include "AbstractBirthDeathProcess.h"
 #include "BirthDeathForwardSimulator.h"
-#include "DistributionExponential.h"
 #include "BirthDeathSamplingTreatmentProcess.h"
+#include "DagNode.h"
+#include "DistributionExponential.h"
 #include "RandomNumberFactory.h"
 #include "RandomNumberGenerator.h"
 #include "RbConstants.h"
 #include "RbMathCombinatorialFunctions.h"
 #include "RbMathLogic.h"
-#include "AbstractBirthDeathProcess.h"
-#include "DagNode.h"
 #include "RbException.h"
+#include "RbSettings.h"
 #include "RbVector.h"
 #include "StartingTreeSimulator.h"
 #include "TopologyNode.h"

--- a/src/core/distributions/phylogenetics/tree/birthdeath/ConstantRateBirthDeathProcess.cpp
+++ b/src/core/distributions/phylogenetics/tree/birthdeath/ConstantRateBirthDeathProcess.cpp
@@ -2,6 +2,7 @@
 #include <iosfwd>
 #include <vector>
 
+#include "Clade.h"
 #include "ConstantRateBirthDeathProcess.h"
 #include "BirthDeathForwardSimulator.h"
 #include "BirthDeathProcess.h"

--- a/src/core/distributions/phylogenetics/tree/birthdeath/EpisodicBirthDeathProcess.cpp
+++ b/src/core/distributions/phylogenetics/tree/birthdeath/EpisodicBirthDeathProcess.cpp
@@ -7,6 +7,7 @@
 #include <utility>
 #include <vector>
 
+#include "Clade.h"
 #include "DivergenceTimeCDF.h"
 #include "EpisodicBirthDeathProcess.h"
 #include "RandomNumberFactory.h"

--- a/src/core/functions/phylogenetics/ComputeLikelihoodsLtMt.cpp
+++ b/src/core/functions/phylogenetics/ComputeLikelihoodsLtMt.cpp
@@ -5,9 +5,11 @@
 #include <iomanip>
 #include <cmath>
 
+#include "MatrixReal.h"
 #include "RbConstants.h"
 #include "RbMathMatrix.h"
-#include "MatrixReal.h"
+#include "RbUtil.h"
+#include "Simplex.h"
 #include "TypedDagNode.h"
 #include "Tree.h"
 #include "TopologyNode.h"

--- a/src/core/monitors/characterhistory/TreeCharacterHistoryNhxMonitor.h
+++ b/src/core/monitors/characterhistory/TreeCharacterHistoryNhxMonitor.h
@@ -9,6 +9,7 @@
 #include "TimeAtlas.h"
 #include "Tree.h"
 #include "GeographicArea.h"
+#include "AbstractHomologousDiscreteCharacterData.h"
 
 #include <fstream>
 #include <iostream>

--- a/src/core/moves/MetropolisHastingsMove.cpp
+++ b/src/core/moves/MetropolisHastingsMove.cpp
@@ -13,6 +13,7 @@
 #include "RbMathLogic.h"
 #include "AbstractMove.h"
 #include "RbOrderedSet.h"
+#include "RbException.h"
 
 using namespace RevBayesCore;
 

--- a/src/core/moves/compound/RateAgeBetaShift.cpp
+++ b/src/core/moves/compound/RateAgeBetaShift.cpp
@@ -4,16 +4,17 @@
 #include <ostream>
 #include <vector>
 
+#include "AbstractHomologousDiscreteCharacterData.h"
+#include "AbstractMove.h"
+#include "DagNode.h"
 #include "DistributionBeta.h"
 #include "RandomNumberFactory.h"
 #include "RandomNumberGenerator.h"
 #include "RateAgeBetaShift.h"
-#include "TopologyNode.h"
-#include "AbstractMove.h"
-#include "DagNode.h"
 #include "RbException.h"
 #include "RbOrderedSet.h"
 #include "StochasticNode.h"
+#include "TopologyNode.h"
 #include "Tree.h"
 
 using namespace RevBayesCore;

--- a/src/core/moves/proposal/tree/EmpiricalTreeTopologyProposal.h
+++ b/src/core/moves/proposal/tree/EmpiricalTreeTopologyProposal.h
@@ -9,6 +9,8 @@
 
 namespace RevBayesCore {
     
+    class TraceTree;
+
     /**
      * The narrow-exchange operator.
      *
@@ -25,6 +27,7 @@ namespace RevBayesCore {
     class EmpiricalTreeTopologyProposal : public Proposal {
         
     public:
+
         EmpiricalTreeTopologyProposal( StochasticNode<Tree> *t, const TraceTree &tt, double a );                                               //!<  constructor
         
         // Basic utility functions

--- a/src/core/moves/proposal/tree/NodeTimeSlideUniformAgeConstrainedProposal.h
+++ b/src/core/moves/proposal/tree/NodeTimeSlideUniformAgeConstrainedProposal.h
@@ -6,6 +6,7 @@
 #include "Proposal.h"
 #include "StochasticNode.h"
 #include "Tree.h"
+#include "Clade.h"
 
 namespace RevBayesCore {
     

--- a/src/core/utils/StringUtilities.cpp
+++ b/src/core/utils/StringUtilities.cpp
@@ -262,35 +262,6 @@ std::string StringUtilities::formatStringForScreen(const std::string &s, const s
 }
 
 
-/** Return file contents as string with '\n' line breaks */
-std::string StringUtilities::getFileContentsAsString(const RevBayesCore::path& p)
-{
-    
-    // open file
-    std::ifstream fStrm( p.string() );
-    if ( !fStrm.is_open() )
-        return "";
-        
-    // read the file
-    int ch;
-    std::string retStr = "";
-    while ( (ch = fStrm.get()) != EOF)
-    {
-        char c = (char)ch;
-        
-        if (ch == '\n' || ch == '\r' || ch == EOF)
-            retStr += '\n';
-        else
-            retStr += c;
-        } 
-
-    // close file
-    fStrm.close();
-
-    return retStr;
-}
-
-
 /**
  * Indicates if a char is affecting text formatting
  * @param c

--- a/src/core/utils/StringUtilities.h
+++ b/src/core/utils/StringUtilities.h
@@ -17,7 +17,6 @@
 #include <stddef.h>
 #include <sstream> // IWYU pragma: keep
 #include <vector>
-#include "RbFileManager.h"
 
 namespace StringUtilities {
     
@@ -34,7 +33,6 @@ namespace StringUtilities {
                                                         const std::string  &hangingPad,
                                                         size_t              screenWidth);                           //!< Format string for output to screen
     std::string                 formatTabWrap(std::string s, size_t tabs, size_t width, bool removeFormat=true);    //!< Wraps texts.
-    std::string                 getFileContentsAsString(const RevBayesCore::path& p);                                      //!< Convert the file contents to a string
     bool                        isFormattingChar(char c) ;
     bool                        isIntegerNumber(const std::string& s);                                              //!< Checks if a string is an integer number
     bool                        isNumber(const std::string& s);                                                     //!< Checks if a string is a number

--- a/src/revlanguage/analysis/mcmc/output/RlBurninEstimationConvergenceAssessment.h
+++ b/src/revlanguage/analysis/mcmc/output/RlBurninEstimationConvergenceAssessment.h
@@ -4,6 +4,7 @@
 #include "TypedDagNode.h"
 #include "RevObject.h"
 #include "WorkspaceObject.h"
+#include "TraceNumeric.h"
 
 #include <ostream>
 #include <string>


### PR DESCRIPTION
This PR is a start on cleaning up tree summaries.

It does a few different things:
1. Minimize the number of times that we copy trees to insert them into a tree trace.  Creating and destroying nodes for trees is quite slow.
2. Check that trees in the same trace have the same set of taxa -- the same TaxonMap.
3. Give understandable error messages when trees have different taxa.  Previously we were saying something like `Two nodes had same index of '144'`.  That doesn't help identify the source of the problem.
4. Include tip taxa AND sampled ancestors in the taxon set.
5. Avoid recompiling most of RevBayes when the TraceTree.h and TreeSummary.h files change.
6. Fix computePairwiseRFDistance

The PR is preparatory for further changes in TreeSummary.  Eventually, we should check that all the trees in the trace have the same set of (tips + sampled ancestors), and assign those taxa the same index in every tree.