### PR TITLE
Improve speed and memory usage for DNA data by about 5x

### DIFF
--- a/src/core/datatypes/phylogenetics/character/DiscreteCharacterState.cpp
+++ b/src/core/datatypes/phylogenetics/character/DiscreteCharacterState.cpp
@@ -10,9 +10,7 @@ using namespace RevBayesCore;
 
 
 
-DiscreteCharacterState::DiscreteCharacterState(size_t n) : CharacterState(),
-    weighted(false),
-    weights(std::vector<double>(n,1.0/n))
+DiscreteCharacterState::DiscreteCharacterState(size_t n) : CharacterState()
 {}
 
 
@@ -291,13 +289,15 @@ bool DiscreteCharacterState::isStateSet(size_t index) const
 
 bool DiscreteCharacterState::isWeighted( void ) const
 {
-    return weighted;
+    return false;
 }
 
 
 void DiscreteCharacterState::setWeighted( bool tf )
 {
-    weighted = tf;
+    // PoMo has weights.
+    if (tf)
+        throw RbException()<<"This character class does not support weights";
 }
 
 
@@ -336,5 +336,6 @@ size_t DiscreteCharacterState::getNumberOfStates(void) const
 
 const std::vector<double>& DiscreteCharacterState::getWeights() const
 {
-    return weights;
+    // PoMo has weights.
+    throw RbException()<<"This character class does not support weights";
 }

--- a/src/core/datatypes/phylogenetics/character/DiscreteCharacterState.cpp
+++ b/src/core/datatypes/phylogenetics/character/DiscreteCharacterState.cpp
@@ -37,7 +37,7 @@ bool DiscreteCharacterState::operator!=(const CharacterState& x) const
 bool DiscreteCharacterState::operator<(const CharacterState &x) const
 {
 
-    const DiscreteCharacterState* derivedX = static_cast<const DiscreteCharacterState*>(&x);
+    const DiscreteCharacterState* derivedX = dynamic_cast<const DiscreteCharacterState*>(&x);
     if ( derivedX != NULL )
     {
         const RbBitSet& myState = getState();

--- a/src/core/datatypes/phylogenetics/character/DiscreteCharacterState.cpp
+++ b/src/core/datatypes/phylogenetics/character/DiscreteCharacterState.cpp
@@ -53,46 +53,14 @@ bool DiscreteCharacterState::operator<(const CharacterState &x) const
 /** Prefix increment current state (if non ambiguous) by 1 */
 void DiscreteCharacterState::operator++( void )
 {
-
-    if ( isAmbiguous() == true )
-    {
-        throw RbException("Cannot increment an ambiguous character.");
-    }
-
-    size_t index = getStateIndex();
-    ++index;
-
-    if ( index >= getNumberOfStates() )
-    {
-        throw RbException("Cannot increment character state any further; we are already at the last state.");
-    }
-
-    // unset the current state
-    setStateByIndex( index );
+    operator+=(1);
 }
 
 
 /** Postfix increment current state (if non ambiguous) by 1 */
 void DiscreteCharacterState::operator++( int i )
 {
-
-    if ( isAmbiguous() == true )
-    {
-        throw RbException("Cannot increment an ambiguous character.");
-    }
-
-    size_t index = getStateIndex();
-    ++index;
-
-    if ( index >= getNumberOfStates() )
-    {
-        throw RbException("Cannot increment character state any further; we are already at the last state.");
-    }
-
-
-    // unset the current state
-    setStateByIndex( index );
-
+    operator+=(1);
 }
 
 
@@ -101,7 +69,6 @@ void DiscreteCharacterState::operator++( int i )
  */
 void DiscreteCharacterState::operator+=( int i )
 {
-
     if ( isAmbiguous() == true )
     {
         throw RbException("Cannot increment an ambiguous character.");
@@ -118,57 +85,20 @@ void DiscreteCharacterState::operator+=( int i )
 
     // unset the current state
     setStateByIndex( index );
-
 }
 
 
 /** Prefix decrement current state (if non ambiguous) by 1 */
 void DiscreteCharacterState::operator--( void )
 {
-
-    if ( isAmbiguous() == true )
-    {
-        throw RbException("Cannot decrement an ambiguous character.");
-    }
-
-
-    size_t index = getStateIndex();
-
-    if ( index == 0 )
-    {
-        throw RbException("Cannot decrement character state any further; we are already at the first state.");
-    }
-
-    --index;
-
-    // unset the current state
-    setStateByIndex( index );
-
+    operator-=(1);
 }
 
 
 /** Postfix decrement current state (if non ambiguous) by 1 */
 void DiscreteCharacterState::operator--( int i )
 {
-
-    if ( isAmbiguous() == true )
-    {
-        throw RbException("Cannot decrement an ambiguous character.");
-    }
-
-
-    size_t index = getStateIndex();
-
-    if ( index == 0 )
-    {
-        throw RbException("Cannot decrement character state any further; we are already at the first state.");
-    }
-
-    --index;
-
-    // unset the current state
-    setStateByIndex( index );
-
+    operator-=(1);
 }
 
 
@@ -177,7 +107,6 @@ void DiscreteCharacterState::operator--( int i )
  */
 void DiscreteCharacterState::operator-=( int i )
 {
-
     if ( isAmbiguous() == true )
     {
         throw RbException("Cannot decrement an ambiguous character.");

--- a/src/core/datatypes/phylogenetics/character/DiscreteCharacterState.h
+++ b/src/core/datatypes/phylogenetics/character/DiscreteCharacterState.h
@@ -31,7 +31,7 @@ namespace RevBayesCore {
         void                                    operator--(int i);  //!< Decrement
         virtual void                            operator-=(int i);  //!< Decrement
 
-        bool                                    isAmbiguous(void) const;
+        virtual bool                            isAmbiguous(void) const;
         virtual std::string                     getStringValue(void) const;
         virtual std::string                     getStateDescription(void) const;  //!< Get a description of the current state
         virtual std::vector<std::string>        getStateDescriptions(void) const;  //!< Get all possible state labels as a vector

--- a/src/core/datatypes/phylogenetics/character/DiscreteCharacterState.h
+++ b/src/core/datatypes/phylogenetics/character/DiscreteCharacterState.h
@@ -21,15 +21,15 @@ namespace RevBayesCore {
     public:
         virtual                                ~DiscreteCharacterState(void) {}
 
-        bool                                    operator==(const CharacterState& x) const;
+        virtual bool                            operator==(const CharacterState& x) const;
         bool                                    operator!=(const CharacterState& x) const;
-        bool                                    operator<(const CharacterState& x) const;
+        virtual bool                            operator<(const CharacterState& x) const;
         void                                    operator++();  //!< Increment
         void                                    operator++(int i);  //!< Increment
-        void                                    operator+=(int i);  //!< Increment
+        virtual void                            operator+=(int i);  //!< Increment
         void                                    operator--();  //!< Decrement
         void                                    operator--(int i);  //!< Decrement
-        void                                    operator-=(int i);  //!< Decrement
+        virtual void                            operator-=(int i);  //!< Decrement
 
         bool                                    isAmbiguous(void) const;
         virtual std::string                     getStringValue(void) const;
@@ -40,9 +40,7 @@ namespace RevBayesCore {
         virtual size_t                          getStateIndex(void) const;  //!< Get the index of the current state
         virtual bool                            isStateSet(size_t index) const;  //!< Is this state part of the current set?
 
-
         virtual DiscreteCharacterState*         clone(void) const = 0;
-
 
         virtual void                            addState(const std::string &symbol) = 0;  //!< Add a state to the set of current states
         virtual RbBitSet                        getState(void) const = 0;  //!< Get the current state (as a bitset)

--- a/src/core/datatypes/phylogenetics/character/DiscreteCharacterState.h
+++ b/src/core/datatypes/phylogenetics/character/DiscreteCharacterState.h
@@ -58,9 +58,6 @@ namespace RevBayesCore {
 
     protected:
                                                 DiscreteCharacterState(size_t n);   //!< Constructor
-        
-        bool                                    weighted;  //!< whether the current state is weighted
-        std::vector<double>                     weights;  //!< vector of weights for each state
     };
 
 }

--- a/src/core/datatypes/phylogenetics/character/DnaState.cpp
+++ b/src/core/datatypes/phylogenetics/character/DnaState.cpp
@@ -43,6 +43,34 @@ DnaState* DnaState::clone( void ) const
 }
 
 
+bool DnaState::operator==(const CharacterState& x) const
+{
+    if (auto d = dynamic_cast<const DnaState*>(&x))
+        return operator==(*d);
+    else
+        return false;
+}
+
+bool DnaState::operator==(const DnaState& x) const
+{
+    return state == x.state;
+}
+
+void DnaState::operator+=(int i)
+{
+    setStateByIndex(getStateIndex()+i);
+}
+
+void DnaState::operator-=(int i)
+{
+    setStateByIndex(getStateIndex()-i);
+}
+
+bool DnaState::isAmbiguous(void) const
+{
+    return not (state == 'A' or state == 'G' or state == 'C' or state == 'T');
+}
+
 void DnaState::setState(const std::string &symbol)
 {
     char s = char( toupper( symbol[0] ) );
@@ -393,11 +421,23 @@ void DnaState::addState(const std::string &symbol)
 }
 
 
-//size_t DnaState::getNumberOfStates(void) const
-//{
-//    return 4;
-//}
+size_t DnaState::getNumberOfStates(void) const
+{
+    return 4;
+}
 
+size_t DnaState::getStateIndex(void) const
+{
+    switch ( state )
+    {
+    case 'A': return 0;
+    case 'C': return 1;
+    case 'G': return 2;
+    case 'T': return 3;
+    }
+
+    throw RbException("Cannot get the index of an ambiguous state.");
+}
 
 RbBitSet DnaState::getState(void) const
 {

--- a/src/core/datatypes/phylogenetics/character/DnaState.h
+++ b/src/core/datatypes/phylogenetics/character/DnaState.h
@@ -31,12 +31,21 @@ namespace RevBayesCore {
                                         DnaState(const std::string &s);                     //!< Constructor with nucleotide observation
                                         DnaState(const RbBitSet& bs);                       //!< Constructor with which letters are observed.
 
+        bool                            operator==(const CharacterState& x) const override;
+        bool                            operator==(const DnaState& x) const;
+//        bool                            operator<(const DnaState& x) const override;
+        void                            operator+=(int) override;
+        void                            operator-=(int) override;
+
+        bool                            isAmbiguous(void) const override;
+        size_t                          getStateIndex(void) const override;                 //!< Get the index of the current state
+
         DnaState*                       clone(void) const;                                  //!< Get a copy of this object
 
         // Discrete character observation functions
 
         void                            addState(const std::string &symbol);                //!< Add a character state to the set of character states
-//        size_t                          getNumberOfStates(void) const;                      //!< Get the number of discrete states for the character
+        size_t                          getNumberOfStates(void) const;                      //!< Get the number of discrete states for the character
         RbBitSet                        getState(void) const;                               //!< Get the state (as the bitset)
         void                            setToFirstState(void);                              //!< Set this character state to the first (lowest) possible state
         void                            setStateByIndex(size_t index);                      //!< Set the discrete observation

--- a/src/core/datatypes/phylogenetics/character/PoMoState.cpp
+++ b/src/core/datatypes/phylogenetics/character/PoMoState.cpp
@@ -421,3 +421,18 @@ void PoMoState::setStateByIndex(size_t index)
     state.reset();
     state.set( index );
 }
+
+const std::vector<double>& PoMoState::getWeights( void ) const
+{
+    return weights;
+}
+
+bool PoMoState::isWeighted( void ) const
+{
+    return weighted;
+}
+
+void PoMoState::setWeighted( bool tf )
+{
+    weighted = tf;
+}

--- a/src/core/datatypes/phylogenetics/character/PoMoState.h
+++ b/src/core/datatypes/phylogenetics/character/PoMoState.h
@@ -56,14 +56,13 @@ namespace RevBayesCore {
         const std::string&              getChromosome( void ) const;                              //!< Get the chromosome for the state
         size_t                          getPosition( void ) const;                                //!< Get the position for the state
         
-        const std::vector<double>       getWeights( void ) const;                            //!< Get the weight of the state
-        // bool                            isWeighted( void ) const;
-        // void                            setWeighted( bool tf );
+        const std::vector<double>&      getWeights( void ) const;                            //!< Get the weight of the state
+        bool                            isWeighted( void ) const;
+        void                            setWeighted( bool tf );
         bool                            isGapState(void) const;                             //!< Get whether this is a gapped character state
         bool                            isMissingState(void) const;                         //!< Get whether this is a missing character state
         void                            setGapState(bool tf);                               //!< set whether this is a gapped character
         void                            setMissingState(bool tf);                           //!< set whether this is a missing character
-        
         
     private:
         void                            populateWeightedStatesForMonoallelicState(size_t id1, int sum); //!< Sets the weights of all the states compatible with a monoallelic state
@@ -79,8 +78,8 @@ namespace RevBayesCore {
         
         std::string                     chromosome;                                         //!< The chromosome on which the state lies
         size_t                          position;                                           //!< The position of the state in the chromosome
-        //std::vector<double>             weights_;                                           //!< Weights are used when the "average" option is used
-        //bool                                    weighted_;
+        std::vector<double>             weights;                                            //!< Weights are used when the "average" option is used
+        bool                            weighted;
         std::string                     string_value;                           //!< The string description of the state.
     };
     

--- a/src/core/datatypes/phylogenetics/character/PoMoState4.cpp
+++ b/src/core/datatypes/phylogenetics/character/PoMoState4.cpp
@@ -575,3 +575,18 @@ void PoMoState4::setStateByIndex(size_t index)
     state.reset();
     state.set( index );
 }
+
+const std::vector<double>& PoMoState4::getWeights( void ) const
+{
+    return weights;
+}
+
+bool PoMoState4::isWeighted( void ) const
+{
+    return weighted;
+}
+
+void PoMoState4::setWeighted( bool tf )
+{
+    weighted = tf;
+}

--- a/src/core/datatypes/phylogenetics/character/PoMoState4.h
+++ b/src/core/datatypes/phylogenetics/character/PoMoState4.h
@@ -57,9 +57,9 @@ namespace RevBayesCore {
         const std::string               getChromosome( void );                              //!< Get the chromosome for the state
         const size_t                    getPosition( void );                                //!< Get the position for the state
 
-        const std::vector<double>       getWeights( void ) const;                            //!< Get the weight of the state
-        // bool                            isWeighted( void ) const;
-        // void                            setWeighted( bool tf );
+        const std::vector<double>&      getWeights( void ) const;                            //!< Get the weight of the state
+        bool                            isWeighted( void ) const;
+        void                            setWeighted( bool tf );
         bool                            isGapState(void) const;                             //!< Get whether this is a gapped character state
         bool                            isMissingState(void) const;                         //!< Get whether this is a missing character state
         void                            setGapState(bool tf);                               //!< set whether this is a gapped character
@@ -78,8 +78,8 @@ namespace RevBayesCore {
         std::string                     chromosome_;                                        //!< The chromosome on which the state lies
         size_t                          position_;                                          //!< The position of the state in the chromosome
         size_t                          virtualPopulationSize_;                             //!< The virtual population size of the PoMo model (by default, 10)
-        //std::vector<double>             weights_;                                           //!< Weights are used when the "average" option is used
-        //bool                                    weighted_;
+        std::vector<double>             weights;                                           //!< Weights are used when the "average" option is used
+        bool                            weighted;
         std::string stringValue_;                           //!< The string description of the state.
     };
 

--- a/src/core/datatypes/phylogenetics/characterdata/DiscreteTaxonData.h
+++ b/src/core/datatypes/phylogenetics/characterdata/DiscreteTaxonData.h
@@ -50,7 +50,7 @@ namespace RevBayesCore {
     private:
 
         std::vector<charType>                           sequence;
-        std::vector<bool>                               is_resolved;
+        RbBitSet                                        is_resolved;
 
     };
 


### PR DESCRIPTION
While looking for a problem in a someone's data set, I noticed that RevBayes was spending a lot of time copying and creating DNA characters in `readDiscreteCharacterData( )`.

One big culprit is that a `vector<double> weights` field was added to DiscreteCharacterState.  This is slow to copy because it requires a memory allocation for each character.  It also expands the memory footprint.  This field seems to have originally been part of PoMoState and PoMoState4, so I moved the field back to those classes.  Probably the idea needs a better design.

I did some testing, and this reduces the time to read a large DNA matrix from 6.2s to 1.4s -- about 4.5x faster.

It reduces the memory usages for that matrix from 3100M to 610M, about 5x smaller.