### PR TITLE
Avoid NaN when rescaling

### DIFF
--- a/src/core/distributions/phylogenetics/substitution/AbstractPhyloCTMCSiteHomogeneous.h
+++ b/src/core/distributions/phylogenetics/substitution/AbstractPhyloCTMCSiteHomogeneous.h
@@ -2732,6 +2732,9 @@ void RevBayesCore::AbstractPhyloCTMCSiteHomogeneous<charType>::scale( size_t nod
 
             }
 
+            // Don't divide by zero or NaN.
+            if (not (max > 0)) continue;
+
             this->perNodeSiteLogScalingFactors[this->activeLikelihood[node_index]][node_index][site] = -log(max);
 
             // compute the per site probabilities
@@ -2796,6 +2799,9 @@ void RevBayesCore::AbstractPhyloCTMCSiteHomogeneous<charType>::scale( size_t nod
                 }
 
             }
+
+            // Don't divide by zero or NaN.
+            if (not (max > 0)) continue;
 
             this->perNodeSiteLogScalingFactors[this->activeLikelihood[node_index]][node_index][site] = this->perNodeSiteLogScalingFactors[this->activeLikelihood[left]][left][site] + this->perNodeSiteLogScalingFactors[this->activeLikelihood[right]][right][site] - log(max);
 
@@ -2862,6 +2868,9 @@ void RevBayesCore::AbstractPhyloCTMCSiteHomogeneous<charType>::scale( size_t nod
                 }
 
             }
+
+            // Don't divide by zero or NaN.
+            if (not (max > 0)) continue;
 
             this->perNodeSiteLogScalingFactors[this->activeLikelihood[node_index]][node_index][site] = this->perNodeSiteLogScalingFactors[this->activeLikelihood[left]][left][site] + this->perNodeSiteLogScalingFactors[this->activeLikelihood[right]][right][site] + this->perNodeSiteLogScalingFactors[this->activeLikelihood[middle]][middle][site] - log(max);
 


### PR DESCRIPTION
Currently, during rescaling we divide by the largest conditional likelihood, and save its log for later use.  This prevents underflow of the conditional likelihoods.  But it doesn't help when the largest conditional likelihood is zero.

For example, if the conditional likelihoods for A, C, G, and T at a site are:
```
  [ 1.0e-300, 1.0e-200, 1.0e-270, 1.0e-210]
```
then we would divide the conditional likelihoods by max = 1.0e-200 to get
```
  [ 1.0e-100, 1.0, 1.0e-70, 1.0e-210]
```
Then we compute `log(max) = -460.517` and add it back in at the end of the likelihood calculation.

However, if we have 
```
   [ 0.0, 0.0, 0.0, 0.0]
```
then dividing by the maximum is dividing by zero.  So we get:

```
   [ NaN, NaN, NaN, NaN]
```
and we add in log(max) = NaN at the end :grimacing: .

So, just don't do this when the highest conditional likelihood is zero.