### PR TITLE
Print clearer error message.

### DIFF
--- a/src/core/analysis/mcmc/Mcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmc.cpp
@@ -603,7 +603,7 @@ void Mcmc::initializeSampler( bool prior_only )
             if ( RbMath::isAComputableNumber(ln_prob) == false )
             {
                 std::stringstream ss;
-                ss << "Could not compute lnProb for node " << the_node->getName() << "." << std::endl;
+                ss << "Could not compute lnProb for node '" << the_node->getName() << "': lnProb = "<< ln_prob << std::endl;
                 std::ostringstream o1;
                 the_node->printValue( o1, "," );
                 ss << StringUtilities::oneLiner( o1.str(), 54 ) << std::endl;


### PR DESCRIPTION
Quote the node name and print the bad probability.  It helps to know if its zero or NaN.