### PR TITLE
Fix open-parenthesis in a string in interactive mode.

### DIFF
--- a/src/revlanguage/ui/RevClient.cpp
+++ b/src/revlanguage/ui/RevClient.cpp
@@ -349,7 +349,12 @@ void startInterpreter( void )
     }
     
     /* callback for printing function signatures on opening bracket*/
-    linenoiseSetCharacterCallback(printFunctionParameters, '(');
+
+    // Currently disabled because
+    // (i) it doesn't seem to do anything at the moment: pi.function_name is never set.
+    // (ii) it makes parsing go crazy if the '(' is inside a string.
+
+    // linenoiseSetCharacterCallback(printFunctionParameters, '(');
 
     int result = 0;
     std::string commandLine;


### PR DESCRIPTION
This fixes #292, where including `(` in a string resulting in a parse error if you were in interactive mode.

Apparently RevBayes registered a "character callback" in order to interrupt parsing and call 'printFunctionParameters' when it saw a '('.

I'm not quite sure why this broke parsing of `(` inside strings.  But this PR comments out the callback since
* the callback doesn't appear to actually do anything -- it doesn't print function parameters, for example
* removing the callback fixes the problem.

