### PR TITLE
Fix constraints for real this time.

### DIFF
--- a/src/core/datatypes/trees/Clade.h
+++ b/src/core/datatypes/trees/Clade.h
@@ -101,10 +101,11 @@ namespace RevBayesCore {
     // Global functions using the class
     std::ostream&                       operator<<(std::ostream& o, const Clade& x);                             //!< Overloaded output operator
 
-    bool cladeWithinAndBefore(const Clade& c1, const Clade& c2);
-
+    // Partial order
     bool cladeWithin(const Clade& c1, const Clade& c2);
 
+    // Strict weak order
+    bool cladeSmaller(const Clade& c1, const Clade& c2);
     bool cladeBefore(const Clade& c1, const Clade& c2);
 }
 

--- a/src/core/distributions/phylogenetics/tree/TopologyConstrainedTreeDistribution.cpp
+++ b/src/core/distributions/phylogenetics/tree/TopologyConstrainedTreeDistribution.cpp
@@ -648,6 +648,52 @@ void TopologyConstrainedTreeDistribution::setBackbone(const TypedDagNode<Tree> *
     }
 }
 
+void checkCladesConsistent(const std::vector<Clade>& clades)
+{
+    // complain if we have conflicts
+    for(int i=0;i<clades.size();i++)
+    {
+        auto& c1 = clades[i];
+        if ( c1.isNegativeConstraint() ) continue;
+
+        for(int j=0;j<clades.size();j++)
+        {
+            if (i == j) continue;
+
+            auto& c2 = clades[j];
+            if ( c2.isNegativeConstraint() ) continue;
+
+            // c1 conflicts with c2 then say which clades conflict
+            if (c1.conflicts(c2))
+            {
+                RbException e;
+                e<<"Clades conflict:\n"
+                 <<"  Clade1 = "<<c1<<"\n"
+                 <<"  Clade2 = "<<c2<<"\n";
+
+                // Here we print the intersection.
+                // But we should probably print the smallest of:
+                // (c1 AND c2), (c1 - c2), (c2 - c1).
+                e<<"  Overlap = ";
+                auto both = c1.intersection(c2);
+                for(auto& taxon: both)
+                    e<<taxon.getName()<<" ";
+
+                throw e;
+            }
+
+            // If c2 is within c1 then it shouldn't be older
+            if (c1.isNestedWithin(c2))
+            {
+                if (c2.getAge() > c1.getAge())
+                    throw RbException()<<"Clade ages conflict:\n"
+                                       <<"Clade 1 = "<<c1<<" Age = "<<c1.getAge()<<"\n"
+                                       <<"Clade 2 = "<<c2<<" Age = "<<c2.getAge();
+            }
+        }
+    }
+}
+
 /**
  *
  */
@@ -720,8 +766,11 @@ Tree* TopologyConstrainedTreeDistribution::simulateRootedTree( void )
     all_species.setAge( ra );
     sorted_clades.push_back(all_species);
 
+    // complain if we have conflicts
+    checkCladesConsistent(sorted_clades);
+
     size_t num_clades = sorted_clades.size();
-    std::sort(sorted_clades.begin(), sorted_clades.end(), cladeWithinAndBefore);
+    std::sort(sorted_clades.begin(), sorted_clades.end(), cladeSmaller);
 
     /*
      * Walk clade constraints from tips to root.
@@ -731,19 +780,29 @@ Tree* TopologyConstrainedTreeDistribution::simulateRootedTree( void )
      *   Remove its tip taxa from the unclaimed_taxa set to avoid adding grandchildren as children.
      */
 
+    /*
+     * An alternative idea would be to make a tree with all leaves as children of the root.
+     * Then for each clade we try find the MRCA, and see if we can create a new child that
+     * contains some of the children of the MCRA.  It should contain all the clade taxa and
+     * no others.  If we cannot do that, then the clade is not consistent with the tree.
+     *
+     * For constraints with rooted splits that separate TAXA1 from TAXA2+root, we can use the
+     * BUILD algorithm to find a consistent tree or report failure.
+     *
+     * However, perhaps a better idea would be to use MCMC to find a solution to the constraints.
+     * There isn't a general algorithm for determining if tree constraints are consistent,
+     * especially when we include NOT constraints and OR constraints.
+     */
+    
     std::vector<Clade> virtual_taxa;
     int i = -1;
     for (std::vector<Clade>::iterator it = sorted_clades.begin(); it != sorted_clades.end(); it++)
     {
-        // ignore negative clade constraints during simulation
-        if ( it->isNegativeConstraint() == true )
-        {
-            continue;
-        }
-
-
         ++i;
         const Clade &c = *it;
+
+        // ignore negative clade constraints during simulation
+        if ( c.isNegativeConstraint() ) continue;
 
         std::vector<Taxon> unclaimed_taxa = c.getTaxa();
         std::vector<Clade> children;
@@ -752,21 +811,18 @@ Tree* TopologyConstrainedTreeDistribution::simulateRootedTree( void )
         std::vector<Clade>::reverse_iterator jt(it);
         for (; jt != sorted_clades.rend(); jt++)
         {
-            // ignore negative clade constraints during simulation
-            if ( jt->isNegativeConstraint() == true )
-            {
-                continue;
-            }
-
             j--;
             const Clade &c_nested = *jt;
+
+            // ignore negative clade constraints during simulation
+            if ( c_nested.isNegativeConstraint() ) continue;
+
             const std::vector<Taxon>& taxa_nested = c_nested.getTaxa();
 
             bool found_all = true;
             bool found_some = false;
-            for (size_t k=0; k<taxa_nested.size(); ++k)
+            for (auto& taxon_nested: taxa_nested)
             {
-                const Taxon& taxon_nested = taxa_nested[k];
                 std::vector<Taxon>::iterator kt = std::find(unclaimed_taxa.begin(), unclaimed_taxa.end(), taxon_nested);
                 if ( kt != unclaimed_taxa.end() )
                 {
@@ -786,7 +842,7 @@ Tree* TopologyConstrainedTreeDistribution::simulateRootedTree( void )
                 children.push_back( virtual_taxa[j] );
             }
 
-            // We check for conflicts when comparing clades during the sort.
+            // We check for conflicts before we try to construct the tree.
             // So any overlapping clades should be nested.
             assert(found_all == found_some);
         }


### PR DESCRIPTION
This is fixes problems reported in #162 and #250.  It is a followup to a previous PR #288 that partially fixed this problem, but not completely.

PR #288 used a partial order to sort the clades, which std::sort cannot handle.

Instead just sort the clades by the number of taxa they contain.  This should ensure that each clade comes before any other clade that includes it.  We still need to sort negative and optional constraints after real clades for this to work.

Since we aren't using cladeWithin anymore, we need to check for conflicting constraints separately.  Factor this out into a new function `checkConstraints(clades)`.  Also check that nested clades aren't older than clades that contain them.  Make sure to print out clades that supposedly conflict, so the user can tell why there are errors.

The order `cladeBefore` is still used in a few places.  Just comparing numbers with NaNs doesn't provide an order that you can sort on.  We need to place all clades without ages either before or after clades with ages, so place them before.  So fix that.

Finally, remove cladeWithinAndBefore -- this is no longer used, and in retrospect wasn't really a good idea anyway.  I don't think we should have two identical clades with different ages, so we don't need ages in order to sort the clades.  We can still have conflicts in clade ages, but sorting by age didn't do a good job finding them.  We now check for those conflicts in the new `checkConstraints( )` function.

LONG TERM, we should probably solve the constraints in a different way -- see note in `TopologyConstrainedTreeDistribution.cpp`.  We can construct a star tree and impose clades on it without sorting the clades.  Also, we don't have a method to solve general constraints, so an alternative approach would be to let the MCMC search solve the constraints.