### PR TITLE
switching submodules to use ssh instead of https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests"]
 	path = tests
-	url = https://github.com/revbayes/tests.git
+	url = git@github.com:revbayes/tests.git


### PR DESCRIPTION
[Github doesn't allow https anymore but requires ssh for authentication. This should also be the default for the submodules.](https://github.com/revbayes/revbayes/pull/300)