### PR TITLE
Fix GHA tests - remove obsolete gcc-7 and gcc-8 checks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,30 +12,17 @@ jobs:
   build:
     strategy:
       matrix:
-        name: [ubuntu-gcc-7,
-               ubuntu-gcc-8,
-               ubuntu-gcc-9,
+        name: [ubuntu-gcc-9,
                ubuntu-gcc-9-mpi,
                ubuntu-gcc-10,
                ubuntu-gcc-11,
-               ubuntu-clang-11,
+               ubuntu-gcc-12,
+               ubuntu-clang-13,
                macos-xcode-12.4,
                windows
                ]
 
         include:
-          - name: ubuntu-gcc-7
-            os: ubuntu-latest
-            compiler: gcc
-            version: "7"
-            mpi: false
-
-          - name: ubuntu-gcc-8
-            os: ubuntu-latest
-            compiler: gcc
-            version: "8"
-            install_boost: 1.74
-            mpi: false
 
           - name: ubuntu-gcc-9
             os: ubuntu-latest
@@ -63,10 +50,16 @@ jobs:
             install_boost: 1.74
             mpi: false
 
-          - name: ubuntu-clang-11
+          - name: ubuntu-gcc-12
+            os: ubuntu-22.04
+            compiler: gcc
+            version: "12"
+            mpi: false
+
+          - name: ubuntu-clang-13
             os: ubuntu-latest
             compiler: clang
-            version: "11"
+            version: "13"
             mpi: false
 
           - name: macos-xcode-12.4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,8 @@ jobs:
                ubuntu-gcc-11,
                ubuntu-gcc-12,
                ubuntu-clang-13,
-               macos-xcode-12.4,
+               macos-xcode-13,
+               macos-xcode-14,
                windows
                ]
 
@@ -60,10 +61,16 @@ jobs:
             version: "13"
             mpi: false
 
-          - name: macos-xcode-12.4
+          - name: macos-xcode-13
             os: macos-latest
             compiler: xcode
-            version: "12.4"
+            version: "13"
+            mpi: false
+
+          - name: macos-xcode-14
+            os: macos-12
+            compiler: xcode
+            version: "14"
             mpi: false
   
           - name: windows
@@ -98,14 +105,16 @@ jobs:
           sudo apt-get install libopenmpi-dev
         fi
 
+    - name: Select XCode version (macOS)
+      if: runner.os == 'macOS'
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: ${{ matrix.version }}
+
     - name: Install (macOS)
       if: runner.os == 'macOS'
       run: |
-          rm -rf /usr/local/bin/2to3 
-          
-          brew update
           brew install pkg-config pandoc boost ccache coreutils openlibm
-          sudo xcode-select -switch /Applications/Xcode_${{ matrix.version }}.app
           ccache --set-config=cache_dir=$HOME/.ccache
 
     - name: Install (Windows meson cross compile)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,14 +40,12 @@ jobs:
             os: ubuntu-latest
             compiler: gcc
             version: "10"
-            install_boost: 1.74
             mpi: false
 
           - name: ubuntu-gcc-11
             os: ubuntu-latest
             compiler: gcc
             version: "11"
-            install_boost: 1.74
             mpi: false
 
           - name: ubuntu-gcc-12

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       matrix:
         name: [ubuntu-gcc-9,
-               macos-xcode-12.5,
+               macos-xcode-13,
                windows
                ]
 
@@ -76,10 +76,10 @@ jobs:
             mpi: false
             arch: "linux64"
 
-          - name: macos-xcode-12.5
+          - name: macos-xcode-13
             os: macos-latest
             compiler: xcode
-            version: "12.5"
+            version: "13"
             mpi: false
             arch: "mac64"
   
@@ -116,14 +116,16 @@ jobs:
           sudo apt-get install libopenmpi-dev
         fi
 
+    - name: Select XCode version (macOS)
+      if: runner.os == 'macOS'
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: ${{ matrix.version }}
+
     - name: Install (macOS)
       if: runner.os == 'macOS'
       run: |
-          rm -rf /usr/local/bin/2to3 
-          
-          brew update
           brew install pkg-config pandoc boost ccache coreutils
-          sudo xcode-select -switch /Applications/Xcode_${{ matrix.version }}.app
           ccache --set-config=cache_dir=$HOME/.ccache
 
     - name: Install (Windows meson cross compile)


### PR DESCRIPTION
Tests are failing because the ubuntu-latest image doesn't have gcc-7 and gcc-8.

This branch removes those checks (for gcc from 2017/2018) and adds a check for gcc-11 (for 2021).