### PR TITLE
fixing a problem with root-node probability calculations in CDBDP

### DIFF
--- a/src/core/distributions/phylogenetics/tree/birthdeath/StateDependentSpeciationExtinctionProcess.cpp
+++ b/src/core/distributions/phylogenetics/tree/birthdeath/StateDependentSpeciationExtinctionProcess.cpp
@@ -540,7 +540,7 @@ void StateDependentSpeciationExtinctionProcess::computeNodeProbability(const Rev
         }
         
     }
-    
+
 }
 
 
@@ -589,8 +589,7 @@ double StateDependentSpeciationExtinctionProcess::computeRootLikelihood( void ) 
         // cladogenetic events should be included at the root. right now,
         // I am just forcing the cladogenetic events at the root, but there
         // may be a better solution.
-        if ( use_cladogenetic_events == true || speciation_node == true )
-//		if ( use_cladogenetic_events == true && speciation_node == true )
+		if ( use_cladogenetic_events == true && speciation_node == true )
         {
 
             double like_sum = 0.0;


### PR DESCRIPTION
It seems like a bug was introduced to CDBDP in our recent merge of dev_mrm into development. Specifically, the root-node likelihood calculations is attempting to use cladogenetic state-change events even when the model does not include them. 

I think the correct behavior should be that: if the root node is a speciation event AND the model includes cladogenetic state-change events, then we use the cladogenetic eventMap to combine probabilities at the root; if the root node is a speciation event and the model does NOT include cladogenetic state changes, then we multiply by the speciation rate in state i; if the root node is actually a sampled ancestor, we multiply by 1.0 (no event, since the "tip" corresponding to the sampled ancestor is initialized with density equal to the state-dependent sampling rate).

I've resolved this issue and confirmed that the likelihoods under this model are equivalent to an independent implementation (tensorphylo).