### PR TITLE
Fix multi summary

### DIFF
--- a/src/core/analysis/mcmc/output/TreeSummary.cpp
+++ b/src/core/analysis/mcmc/output/TreeSummary.cpp
@@ -1149,15 +1149,12 @@ void TreeSummary::enforceNonnegativeBranchLengths(TopologyNode& node) const
 
 long TreeSummary::splitFrequency(const Split &n) const
 {
+    auto iter = clade_counts.find(n);
 
-    std::set<Sample<Split> >::const_iterator it = find_if (clade_samples.begin(), clade_samples.end(), n );
-
-    if ( it != clade_samples.end() )
-    {
-        return it->second;
-    }
-
-    throw RbException("Couldn't find split in set of samples");
+    if (iter == clade_counts.end())
+        throw RbException("Couldn't find split in set of samples");
+    else
+        return iter->second;
 }
 
 
@@ -1259,13 +1256,11 @@ int TreeSummary::getTopologyFrequency(const RevBayesCore::Tree &tree, bool verbo
 
     std::string newick = t.getPlainNewickRepresentation();
 
-    for (auto& [newick_sample, count]: tree_samples)
-    {
-        if ( newick == newick_sample )
-            return count;
-    }
-
-    return 0;
+    auto iter = tree_counts.find(newick);
+    if (iter == tree_counts.end())
+        return 0;
+    else
+        return iter->second;
 }
 
 
@@ -1902,9 +1897,8 @@ void TreeSummary::summarize( bool verbose )
     conditional_clade_ages.clear();
     tree_clade_ages.clear();
 
-    std::map<Split, long>       clade_counts;
-    std::map<std::string, long> tree_counts;
-
+    clade_counts.clear();
+    tree_counts.clear();
 
     ProgressBar progress = ProgressBar(sampleSize(true));
 

--- a/src/core/analysis/mcmc/output/TreeSummary.h
+++ b/src/core/analysis/mcmc/output/TreeSummary.h
@@ -109,8 +109,10 @@ namespace RevBayesCore {
         bool                                       clock;
         bool                                       rooted;
 
+        std::map<Split, long>                      clade_counts;
         std::set<Sample<Split> >                   clade_samples;
         std::map<Taxon, long >                     sampled_ancestor_counts;
+        std::map<std::string, long>                tree_counts;
         std::set<Sample<std::string> >             tree_samples;
 
         std::map<Split, std::vector<double> >                           clade_ages;

--- a/src/core/analysis/mcmc/output/TreeSummary.h
+++ b/src/core/analysis/mcmc/output/TreeSummary.h
@@ -109,6 +109,7 @@ namespace RevBayesCore {
         bool                                       clock;
         bool                                       rooted;
 
+        bool                                       computed = false;
         std::map<Split, long>                      clade_counts;
         std::set<Sample<Split> >                   clade_samples;
         std::map<Taxon, long >                     sampled_ancestor_counts;

--- a/src/core/analysis/mcmc/output/TreeSummary.h
+++ b/src/core/analysis/mcmc/output/TreeSummary.h
@@ -79,7 +79,8 @@ namespace RevBayesCore {
         std::vector<double>                        computeTreeLengths(void);
         std::vector<Clade>                         getUniqueClades(double ci=0.95, bool non_trivial_only=true, bool verbose=true);
         std::vector<Tree>                          getUniqueTrees(double ci=0.95, bool verbose=true);
-        int                                        getTopologyFrequency(const Tree &t, bool verbose);
+        long                                       getTopologyCount(const Tree &t, bool verbose);
+        double                                     getTopologyFrequency(const Tree &t, bool verbose);
         bool                                       isClock(void) const;
         bool                                       isCoveredInInterval(const std::string &v, double size, bool verbose);
         bool                                       isCoveredInInterval(const Tree &t, double size, bool verbose);
@@ -97,7 +98,8 @@ namespace RevBayesCore {
 
         Split                                      collectTreeSample(const TopologyNode&, RbBitSet&, std::string, std::map<Split, long>&);
         void                                       enforceNonnegativeBranchLengths(TopologyNode& tree) const;
-        long                                       splitFrequency(const Split &n) const;
+        long                                       splitCount(const Split &n) const;
+        double                                     splitFrequency(const Split &n) const;
         TopologyNode*                              findParentNode(TopologyNode&, const Split &, std::vector<TopologyNode*>&, RbBitSet& ) const;
         void                                       mapContinuous(Tree &inputTree, const std::string &n, size_t paramIndex, double hpd, bool np, bool verbose ) const;
         void                                       mapDiscrete(Tree &inputTree, const std::string &n, size_t paramIndex, size_t num, bool np, bool verbose ) const;


### PR DESCRIPTION
RevBayes was crashing whenever we annotated a tree trace multiple times.  This was because it marked the individual runs "clean" after the first annotation.  Then, during the second annotation, it skipped computing the summary statistics (i.e. split frequencies) because all the individual runs were clean.

Solved by separately recording whether the summary statistics are computed yet.

In addition, this patch
1. Improves readability for TreeSummary.cpp
2. Makes mccTree substantially faster.
3. Renames splitFrequency to splitCount since it is an integer, and creates a new function splitFrequency that is a fraction.  Similar for topologyCount/topologyFrequency.

You could review this patch as one big change, but I recommend reviewing each of the 4 parts separately.  The readability patch is the largest, and should make no functional changes.

--

BTW, for the "readability" part of the patch, I'm using 2 c++  features introduced in 2011, and one introduced in 2017.
(i) range-based for loops: `for(int i: v) { foo(i) }` to iterate over values inside v, where v is (say) a vector<int>. https://en.cppreference.com/w/cpp/language/range-for

(ii) the `auto` type: `auto iter = x.begin()` instead of `vector<TreeTrace*>::iterator iter = x.begin()`, where the type of `iter` can be deduced. https://en.cppreference.com/w/cpp/language/auto. 

(iii) decomposing pairs and tuples: You can now write `auto [x,y] = p` instead of `x=p.first; y=p.second`.  In for loops, you can write `for(auto& [tree,count]: tree_counts)` to iterate over a map. https://en.cppreference.com/w/cpp/language/auto