### PR TITLE
Adding a member procedure to compute the joint probability of a set of clades

### DIFF
--- a/src/core/analysis/mcmc/output/TreeSummary.h
+++ b/src/core/analysis/mcmc/output/TreeSummary.h
@@ -85,6 +85,7 @@ namespace RevBayesCore {
         bool                                       isCoveredInInterval(const std::string &v, double size, bool verbose);
         bool                                       isCoveredInInterval(const Tree &t, double size, bool verbose);
         bool                                       isDirty(void) const;
+        double                                     jointCladeProbability(const RbVector<Clade> &c, bool verbose);
         double                                     maxdiff(bool verbose);
         Tree*                                      mapTree(AnnotationReport report, bool verbose);
         Tree*                                      mccTree(AnnotationReport report, bool verbose);
@@ -98,12 +99,13 @@ namespace RevBayesCore {
 
         Split                                      collectTreeSample(const TopologyNode&, RbBitSet&, std::string, std::map<Split, long>&);
         void                                       enforceNonnegativeBranchLengths(TopologyNode& tree) const;
-        long                                       splitCount(const Split &n) const;
-        double                                     splitFrequency(const Split &n) const;
         TopologyNode*                              findParentNode(TopologyNode&, const Split &, std::vector<TopologyNode*>&, RbBitSet& ) const;
+        double                                     jointSplitFrequency(const std::vector<Split>& s) const;
         void                                       mapContinuous(Tree &inputTree, const std::string &n, size_t paramIndex, double hpd, bool np, bool verbose ) const;
         void                                       mapDiscrete(Tree &inputTree, const std::string &n, size_t paramIndex, size_t num, bool np, bool verbose ) const;
         void                                       mapParameters(Tree &inputTree, bool verbose) const;
+        long                                       splitCount(const Split &n) const;
+        double                                     splitFrequency(const Split &n) const;
         void                                       summarize(bool verbose);
 
         std::vector<TraceTree* >                   traces;

--- a/src/core/datatypes/trees/TopologyNode.h
+++ b/src/core/datatypes/trees/TopologyNode.h
@@ -77,10 +77,10 @@ namespace RevBayesCore {
         void                                        addNodeParameter(const std::string &n, double p);
         void                                        addNodeParameter(const std::string &n, const std::string &p);
         void                                        addNodeParameters(const std::string &n, const std::vector<double> &p, bool io);
-	void                                        addNodeParameters(const std::string &n, const std::vector<std::string> &p, bool io);
+        void                                        addNodeParameters(const std::string &n, const std::vector<std::string> &p, bool io);
         void                                        clearParameters(void);                                                              //!< Clear the node and branch parameters
         void                                        clearBranchParameters(void);
-	void                                        clearNodeParameters(void);
+        void                                        clearNodeParameters(void);
         virtual std::string                         computeNewick(bool round = true);                                                   //!< Compute the newick string for this clade
         std::string                                 computePlainNewick(void) const;                                                     //!< Compute the newick string for this clade as a plain string without branch length
         std::string                                 computeSimmapNewick(bool round = true);                                             //!< Compute the newick string compatible with SIMMAP and phytools

--- a/src/revlanguage/analysis/mcmc/output/RlTraceTree.cpp
+++ b/src/revlanguage/analysis/mcmc/output/RlTraceTree.cpp
@@ -147,6 +147,18 @@ RevPtr<RevVariable> TraceTree::executeMethod(std::string const &name, const std:
         return new RevVariable( new Probability( p ) );
         
     }
+    else if ( name == "jointCladeProbability" )
+    {
+        found = true;
+        
+        const RevBayesCore::RbVector<RevBayesCore::Clade> &c    = static_cast<const ModelVector<Clade> &>( args[0].getVariable()->getRevObject() ).getValue();
+        bool verbose = static_cast<const RlBoolean &>( args[1].getVariable()->getRevObject() ).getValue();
+        
+        double p = this->value->jointCladeProbability( c, verbose );
+        
+        return new RevVariable( new Probability( p ) );
+        
+    }
     else if ( name == "computeEntropy" )
     {
         found = true;
@@ -461,6 +473,11 @@ void TraceTree::initMethods( void )
     cladeProbArgRules->push_back( new ArgumentRule("verbose", RlBoolean::getClassTypeSpec(), "Printing verbose output.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true)) );
     this->methods.addFunction( new MemberProcedure( "cladeProbability", Probability::getClassTypeSpec(), cladeProbArgRules) );
     
+    ArgumentRules* jointCladeProbArgRules = new ArgumentRules();
+    jointCladeProbArgRules->push_back( new ArgumentRule("clades", ModelVector<Clade>::getClassTypeSpec(), "The set of (monophyletic) clades.", ArgumentRule::BY_VALUE, ArgumentRule::ANY) );
+    jointCladeProbArgRules->push_back( new ArgumentRule("verbose", RlBoolean::getClassTypeSpec(), "Printing verbose output.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(true)) );
+    this->methods.addFunction( new MemberProcedure( "jointCladeProbability", Probability::getClassTypeSpec(), jointCladeProbArgRules) );
+   
     ArgumentRules* getNumberSamplesArgRules = new ArgumentRules();
     getNumberSamplesArgRules->push_back( new ArgumentRule("post", RlBoolean::getClassTypeSpec(), "Get the post-burnin number of samples?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false)) );
     this->methods.addFunction( new MemberProcedure( "getNumberSamples", Natural::getClassTypeSpec(), getNumberSamplesArgRules) );


### PR DESCRIPTION
This is a small addition to conveniently compute the posterior probability of a joint set of clades, i.e., the frequency in the tree sample how often all of the clades were found to be monophyletic. This helps to do some posthoc hypothesis testing.