### PR TITLE
fix missing check if optional constraints exist

### DIFF
--- a/src/core/datatypes/trees/Clade.cpp
+++ b/src/core/datatypes/trees/Clade.cpp
@@ -355,7 +355,7 @@ size_t Clade::getNumberOfTaxa( void ) const
  * \return       The optional clade constraints
  */
 
-std::vector<Clade> Clade::getOptionalConstraints(void) const
+const std::vector<Clade>& Clade::getOptionalConstraints(void) const
 {
     assert(optional_constraints.has_value());
     return *optional_constraints;
@@ -411,6 +411,18 @@ const std::string& Clade::getTaxonName(size_t i) const
 
 
 /**
+ * Is this clade an optional constraint (used with e.g. dnConstrainedTopology).
+ * An "optional" constraint means that at least one of the referenced clades must be true.
+ *
+ * \return       The true/false value of whether the clade is an optional constraint.
+ */
+bool Clade::hasOptionalConstraints(void) const
+{
+    return optional_constraints.has_value();
+}
+
+
+/**
  * Is this clade a negative clade constraint (used with e.g. dnConstrainedTopology).
  *
  * \return       The true/false value of whether the clade is a negative constraint.
@@ -461,18 +473,6 @@ bool Clade::isNestedWithin(const Clade& c) const
     }
 
     return nested;
-}
-
-
-/**
- * Is this clade an optional constraint (used with e.g. dnConstrainedTopology).
- * An "optional" constraint means that at least one of the referenced clades must be true.
- *
- * \return       The true/false value of whether the clade is an optional constraint.
- */
-bool Clade::isOptionalConstraint(void) const
-{
-    return optional_constraints.has_value();
 }
 
 
@@ -675,7 +675,7 @@ std::string Clade::toString( void ) const
 {
     std::string s;
 
-    if (isOptionalConstraint())
+    if ( hasOptionalConstraints() == true )
     {
         vector<string> cstrings;
         for(auto& c: getOptionalConstraints())
@@ -762,9 +762,9 @@ bool cladeBefore(const Clade& c1, const Clade& c2)
         return false;
 
     // Negative constraints and Optional constraints are ordered after all regular constraints.
-    else if (not (c1.isNegativeConstraint() or c1.isOptionalConstraint()) and (c2.isNegativeConstraint() or c2.isOptionalConstraint()))
+    else if (not (c1.isNegativeConstraint() or c1.hasOptionalConstraints()) and (c2.isNegativeConstraint() or c2.hasOptionalConstraints()))
         return true;
-    else if (c1.isNegativeConstraint() or c1.isOptionalConstraint() or c2.isNegativeConstraint() or c2.isOptionalConstraint())
+    else if (c1.isNegativeConstraint() or c1.hasOptionalConstraints() or c2.isNegativeConstraint() or c2.hasOptionalConstraints())
         return false;
 
     else
@@ -787,9 +787,9 @@ bool cladeSmaller(const Clade& c1, const Clade& c2)
         return false;
 
     // Negative constraints and Optional constraints are ordered after all regular constraints.
-    else if (not (c1.isNegativeConstraint() or c1.isOptionalConstraint()) and (c2.isNegativeConstraint() or c2.isOptionalConstraint()))
+    else if (not (c1.isNegativeConstraint() or c1.hasOptionalConstraints()) and (c2.isNegativeConstraint() or c2.hasOptionalConstraints()))
         return true;
-    else if (c1.isNegativeConstraint() or c1.isOptionalConstraint() or c2.isNegativeConstraint() or c2.isOptionalConstraint())
+    else if (c1.isNegativeConstraint() or c1.hasOptionalConstraints() or c2.hasOptionalConstraints() or c2.hasOptionalConstraints())
         return false;
 
     else
@@ -803,9 +803,9 @@ bool cladeWithin(const Clade& c1, const Clade& c2)
         return false;
 
     // Negative constraints and Optional constraints are ordered after all regular constraints.
-    else if (not (c1.isNegativeConstraint() or c1.isOptionalConstraint()) and (c2.isNegativeConstraint() or c2.isOptionalConstraint()))
+    else if (not (c1.isNegativeConstraint() or c1.hasOptionalConstraints()) and (c2.isNegativeConstraint() or c2.hasOptionalConstraints()))
         return true;
-    else if (c1.isNegativeConstraint() or c1.isOptionalConstraint() or c2.isNegativeConstraint() or c2.isOptionalConstraint())
+    else if (c1.isNegativeConstraint() or c1.hasOptionalConstraints() or c2.isNegativeConstraint() or c2.hasOptionalConstraints())
         return false;
 
     // c2 is nested with c1

--- a/src/core/datatypes/trees/Clade.h
+++ b/src/core/datatypes/trees/Clade.h
@@ -60,13 +60,13 @@ namespace RevBayesCore {
         const std::set<Taxon>&                      getMrca(void) const;                                        //!< Get the mrca taxon.
         int                                         getNumberMissingTaxa(void) const;                           //!< Get the number of missing taxa.
         size_t                                      getNumberOfTaxa(void) const;                                //!< Get the number of taxa.
-        std::vector<Clade>                          getOptionalConstraints(void) const;                         //!< Get optional clade constraints
+        const std::vector<Clade>&                   getOptionalConstraints(void) const;                         //!< Get optional clade constraints
         std::vector<Taxon>&                         getTaxa(void);                                              //!< Get the taxon names.
         const std::vector<Taxon>&                   getTaxa(void) const;                                        //!< Get the taxon names.
         const Taxon&                                getTaxon(size_t i) const;                                   //!< Get a single taxon name.
         const std::string&                          getTaxonName(size_t i) const;                               //!< Get a single taxon name.
+        bool                                        hasOptionalConstraints(void) const;                         //!< Has optional clade constraints
         bool                                        isNegativeConstraint(void) const;                           //!< Get negative constraint flag.
-        bool                                        isOptionalConstraint(void) const;                           //!< Get negative constraint flag.
         bool                                        isNestedWithin(const Clade& c) const;                       //!< Is the provided clade nested within me?
         bool                                        overlaps(const Clade& c) const;                             //!< Does the provided clade overlap with me?
         std::set<Taxon>                             intersection(const Clade&) const;                           //!< Get the taxa that both clades have in common.

--- a/src/core/distributions/phylogenetics/tree/TopologyConstrainedTreeDistribution.cpp
+++ b/src/core/distributions/phylogenetics/tree/TopologyConstrainedTreeDistribution.cpp
@@ -222,7 +222,7 @@ void TopologyConstrainedTreeDistribution::initializeBitSets(void)
     for (size_t i = 0; i < monophyly_constraints.size(); i++)
     {
         // clade constraint has only one match
-        if (monophyly_constraints[i].isOptionalConstraint() == false)
+        if (monophyly_constraints[i].hasOptionalConstraints() == false)
         {
             RbBitSet b( value->getNumberOfTips() );
             for (size_t j = 0; j < monophyly_constraints[i].size(); j++)
@@ -384,7 +384,7 @@ bool TopologyConstrainedTreeDistribution::matchesConstraints( void )
     {
         
         std::vector<Clade> constraints;
-        if ( monophyly_constraints[i].isOptionalConstraint() == true )
+        if ( monophyly_constraints[i].hasOptionalConstraints() == true )
         {
             constraints = monophyly_constraints[i].getOptionalConstraints();
         }
@@ -747,7 +747,7 @@ Tree* TopologyConstrainedTreeDistribution::simulateRootedTree( void )
         // populate sorted clades vector
         if ( monophyly_constraint.size() > 1 && monophyly_constraint.size() < num_taxa )
         {
-            if ( monophyly_constraint.isOptionalConstraint() == true )
+            if ( monophyly_constraint.hasOptionalConstraints() == true )
             {
                 std::vector<Clade> optional_constraints = monophyly_constraint.getOptionalConstraints();
                 size_t idx = (size_t)( GLOBAL_RNG->uniform01() * optional_constraints.size() );
@@ -1036,13 +1036,16 @@ Tree* TopologyConstrainedTreeDistribution::simulateUnrootedTree( void )
     {
         
         // set ages for optional constraints
-        std::vector<Clade> optional_constraints = monophyly_constraints[i].getOptionalConstraints();
-        monophyly_constraints[i].setOptionalConstraints( optional_constraints );
+        if ( monophyly_constraints[i].hasOptionalConstraints() == true )
+        {
+            std::vector<Clade> optional_constraints = monophyly_constraints[i].getOptionalConstraints();
+            monophyly_constraints[i].setOptionalConstraints( optional_constraints );
+        }
         // populate sorted clades vector
         if ( monophyly_constraints[i].size() > 1 && monophyly_constraints[i].size() < num_taxa )
         {
         
-            if ( monophyly_constraints[i].isOptionalConstraint() == true )
+            if ( monophyly_constraints[i].hasOptionalConstraints() == true )
             {
                 std::vector<Clade> optional_constraints = monophyly_constraints[i].getOptionalConstraints();
                 size_t idx = (size_t)( GLOBAL_RNG->uniform01() * optional_constraints.size() );

--- a/src/core/utils/StartingTreeSimulator.cpp
+++ b/src/core/utils/StartingTreeSimulator.cpp
@@ -84,30 +84,34 @@ Tree* StartingTreeSimulator::simulateTree( const std::vector<Taxon> &taxa, const
         }
         
         // set ages for optional constraints
-        std::vector<Clade> optional_constraints = my_constraints[i].getOptionalConstraints();
-        for (size_t k = 0; k < optional_constraints.size(); k++)
+        if ( my_constraints[i].hasOptionalConstraints() == true )
         {
-            for (size_t opt_taxon_idx = 0; opt_taxon_idx < optional_constraints[k].size(); opt_taxon_idx++)
+            std::vector<Clade> optional_constraints = my_constraints[i].getOptionalConstraints();
+            for (size_t k = 0; k < optional_constraints.size(); k++)
             {
-                for (size_t full_taxon_idx = 0; full_taxon_idx < num_taxa; full_taxon_idx++)
+                for (size_t opt_taxon_idx = 0; opt_taxon_idx < optional_constraints[k].size(); opt_taxon_idx++)
                 {
-                    if ( taxa[full_taxon_idx].getName() == optional_constraints[k].getTaxonName(opt_taxon_idx) )
+                    for (size_t full_taxon_idx = 0; full_taxon_idx < num_taxa; full_taxon_idx++)
                     {
+                        if ( taxa[full_taxon_idx].getName() == optional_constraints[k].getTaxonName(opt_taxon_idx) )
+                        {
                         
-                        optional_constraints[k].setTaxonAge(opt_taxon_idx, taxa[full_taxon_idx].getAge());
-                        break;
+                            optional_constraints[k].setTaxonAge(opt_taxon_idx, taxa[full_taxon_idx].getAge());
+                            break;
+                        }
                     }
                 }
-            }
             
-        }
+            }
         
-        my_constraints[i].setOptionalConstraints( optional_constraints );
+            my_constraints[i].setOptionalConstraints( optional_constraints );
+        } // finished with the optional constrains, if they exist
+        
         // populate sorted clades vector
         if ( my_constraints[i].size() > 1 && my_constraints[i].size() < num_taxa )
         {
             
-            if ( my_constraints[i].isOptionalConstraint() == true )
+            if ( my_constraints[i].hasOptionalConstraints() == true )
             {
                 std::vector<Clade> optional_constraints = my_constraints[i].getOptionalConstraints();
                 size_t idx = (size_t)( GLOBAL_RNG->uniform01() * optional_constraints.size() );


### PR DESCRIPTION
The following code crashed before:
> taxa <- simTree(8).taxa()
> simStartingTree(taxa, [ clade(taxa[1],taxa[2]) ])

The issue was that in the starting tree simulator we didn't check if optional constraints exist and used them either way. This should be fixed now.