### PR TITLE
minor fix to the homeolog monitor

### DIFF
--- a/src/revlanguage/monitors/Mntr_HomeologPhase.cpp
+++ b/src/revlanguage/monitors/Mntr_HomeologPhase.cpp
@@ -152,7 +152,7 @@ void Mntr_HomeologPhase::setConstParameter(const std::string& name, const RevPtr
     }
     else
     {
-        Monitor::setConstParameter(name, var);
+    	FileMonitor::setConstParameter(name, var);
     }
     
 }


### PR DESCRIPTION
A very minor fix for the homeolog phase monitor, which was breaking when trying to use the append argument.