### PR TITLE
Constructors and destructors don't take template arguments.

### DIFF
--- a/src/core/datatypes/RbVectorImpl.h
+++ b/src/core/datatypes/RbVectorImpl.h
@@ -38,7 +38,7 @@ namespace RevBayesCore {
         RbVectorImpl(const vectorType &v) { size_t n=v.size(); for (size_t i = 0; i < n; ++i) this->push_back( v[i] ); }
         RbVectorImpl(const RbVectorImpl<valueType,indicator> &v):std::vector<valueType>() { size_t n=v.size(); for (size_t i = 0; i < n; ++i) this->push_back( v[i] ); }
         RbVectorImpl(RbVectorImpl<valueType,indicator> &&v) = default;
-        virtual                                            ~RbVectorImpl<valueType,indicator>(void) { }
+        virtual                                            ~RbVectorImpl(void) { }
         
         
         // public member functions

--- a/src/core/distributions/events/MarkovEventsDistribution.h
+++ b/src/core/distributions/events/MarkovEventsDistribution.h
@@ -109,7 +109,7 @@ RevBayesCore::MarkovEventsDistribution<valueType>::MarkovEventsDistribution(cons
 }
 
 template <class valueType>
-RevBayesCore::MarkovEventsDistribution<valueType>::~MarkovEventsDistribution<valueType>( void )
+RevBayesCore::MarkovEventsDistribution<valueType>::~MarkovEventsDistribution( void )
 {
 }
 

--- a/src/revlanguage/distributions/RlTypedDistribution.h
+++ b/src/revlanguage/distributions/RlTypedDistribution.h
@@ -11,7 +11,7 @@ namespace RevLanguage {
     class TypedDistribution : public Distribution {
         
     public:
-        TypedDistribution<rlType>(const TypedDistribution<rlType> &x);                                                                //!< Copy constuctor
+        TypedDistribution(const TypedDistribution<rlType> &x);                                                                              //!< Copy constuctor
         virtual                                         ~TypedDistribution(void);                                                                  //!< Destructor
         
         TypedDistribution<rlType>&                      operator=(const TypedDistribution<rlType> &d);
@@ -37,7 +37,7 @@ namespace RevLanguage {
         
         
     protected:
-        TypedDistribution<rlType>(void);                                                                                                 //!< Basic constructor
+        TypedDistribution(void);                                                                                                            //!< Basic constructor
         
         // this is the random variable is associated with the distribution
         // it should only be used for linking functions from the variable to the distribution

--- a/src/revlanguage/distributions/phylogenetics/RlFossilizedBirthDeathRangeProcess.h
+++ b/src/revlanguage/distributions/phylogenetics/RlFossilizedBirthDeathRangeProcess.h
@@ -34,7 +34,7 @@ namespace RevLanguage {
         static const TypeSpec&                              getClassTypeSpec(void);                                                             //!< Get class type spec
 
     protected:
-        FossilizedBirthDeathRangeProcess<rlType>( void );
+        FossilizedBirthDeathRangeProcess( void );
         
         void                                                setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var);   //!< Set member variable
     

--- a/src/revlanguage/functions/RlTypedFunction.h
+++ b/src/revlanguage/functions/RlTypedFunction.h
@@ -32,7 +32,7 @@ namespace RevLanguage {
         
     public:
         virtual                                         ~TypedFunction(void);                                                               //!< Destructor
-        TypedFunction<valueType>(const TypedFunction<valueType> &x);                                                                        //!< Copy constuctor
+        TypedFunction(const TypedFunction<valueType> &x);                                                                                   //!< Copy constuctor
         
         virtual RevPtr<RevVariable>                     execute(void);                                                                      //!< Create a random variable from this distribution
         virtual const TypeSpec&                         getReturnType(void) const;                                                          //!< Get type of return value
@@ -50,7 +50,7 @@ namespace RevLanguage {
         
         
     protected:
-        TypedFunction<valueType>(void);                                                                                                     //!< Basic constructor
+        TypedFunction(void);                                                                                                                //!< Basic constructor
     };
     
 }


### PR DESCRIPTION
This also makes revbayes compile under C++20.