### PR TITLE
Use more up-to-date-version of openlibm package on mingw.

### DIFF
--- a/projects/meson/make_winroot.sh
+++ b/projects/meson/make_winroot.sh
@@ -97,7 +97,7 @@ cd ${SYSROOT}
 # We can use the libwinpthread-1 from the cross-compiler instead of download it.
 
 PKGS="boost-1.81.0-2
-openlibm-0.7.5-1
+openlibm-0.8.1-1
 dlfcn-1.3.1-1
 "
 


### PR DESCRIPTION
Update the version of openlibm to make the windows test pass.  The old version is no longer available.