### PR TITLE
Fixing compile errors because of missing cmath include

### DIFF
--- a/src/core/datatypes/trees/Clade.cpp
+++ b/src/core/datatypes/trees/Clade.cpp
@@ -1,6 +1,7 @@
 #include "Clade.h"
 
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 #include <string>
 #include <utility>

--- a/src/core/functions/phylogenetics/FeatureInformedRateFunction.cpp
+++ b/src/core/functions/phylogenetics/FeatureInformedRateFunction.cpp
@@ -1,11 +1,3 @@
-//
-//  FeatureInformedRateFunction.cpp
-//  revbayes-tensorphylo-proj
-//
-//  Created by Michael Landis on 7/12/22.
-//  Copyright © 2022 Michael Landis. All rights reserved.
-//
-
 #include "FeatureInformedRateFunction.h"
 #include "RbException.h"
 #include "Cloneable.h"
@@ -13,6 +5,7 @@
 #include "RbVectorImpl.h"
 #include "TypedDagNode.h"
 
+#include <cmath>
 #include <stddef.h>
 
 namespace RevBayesCore { class DagNode; }


### PR DESCRIPTION
This is a very minor fix which adds <cmath> to make RevBayes compile properly again.