### PR TITLE
Don't return (2^64) when a rooted tree has 1 node.

### DIFF
--- a/src/core/datatypes/trees/Tree.cpp
+++ b/src/core/datatypes/trees/Tree.cpp
@@ -799,7 +799,10 @@ size_t Tree::getNumberOfInteriorNodes( void ) const
 
     if ( isRooted() )
     {
-        return preliminaryNumIntNodes - 1;
+	if (preliminaryNumIntNodes > 1)
+	    return preliminaryNumIntNodes - 1;
+	else
+	    return 0;
     }
     else
     {

--- a/src/core/datatypes/trees/Tree.h
+++ b/src/core/datatypes/trees/Tree.h
@@ -90,7 +90,7 @@ namespace RevBayesCore {
         const std::vector<TopologyNode*>&                   getNodes(void) const;                                                                               //!< Get a pointer to the nodes in the Tree
         std::vector<RbBitSet>*                              getNodesAsBitset(void) const;                                                                       //!< Get a vector of bitset representations of nodes
         std::vector<long>                                   getNodeIndices(void) const;                                                                         //!< Get a vector of node indices
-        size_t                                              getNumberOfInteriorNodes(void) const;                                                               //!< Get the number of nodes in the Tree
+        size_t                                              getNumberOfInteriorNodes(void) const;                                                               //!< Get the number of non-root internal nodes in the Tree
         size_t                                              getNumberOfNodes(void) const;                                                                       //!< Get the number of nodes in the Tree
         size_t                                              getNumberOfExtantTips(void) const;                                                                  //!< Get the number of extant tip nodes in the Tree
         size_t                                              getNumberOfExtinctTips(void) const;                                                                 //!< Get the number of extinct tip nodes in the Tree


### PR DESCRIPTION
Currently `Tree::getNumberOfInteriorNodes()` returns `-1` when a rooted tree has only 1 node.  When the `-1` gets converted to `size_t`, it turns into `2^64`.

Avoid this by not subtracting 1 when the root is also a tip (which occurs when the rooted tree has 1 node).