### PR TITLE
Add and change AbstractHomologousDiscreteCharacterData methods

### DIFF
--- a/src/core/datatypes/phylogenetics/characterdata/AbstractHomologousDiscreteCharacterData.cpp
+++ b/src/core/datatypes/phylogenetics/characterdata/AbstractHomologousDiscreteCharacterData.cpp
@@ -77,7 +77,7 @@ void AbstractHomologousDiscreteCharacterData::fillMissingSitesMask(std::vector<s
 }
 
 
-void AbstractHomologousDiscreteCharacterData::removeMissingSites( void )
+void AbstractHomologousDiscreteCharacterData::excludeMissingSites( void )
 {
 
     size_t num_taxa  = getNumberOfTaxa();
@@ -119,7 +119,7 @@ void AbstractHomologousDiscreteCharacterData::removeMissingSites( void )
 }
 
 
-void AbstractHomologousDiscreteCharacterData::removeRandomSites( double p )
+void AbstractHomologousDiscreteCharacterData::replaceRandomSitesByMissingData( double p )
 {
 
     size_t num_taxa  = getNumberOfTaxa();

--- a/src/core/datatypes/phylogenetics/characterdata/AbstractHomologousDiscreteCharacterData.h
+++ b/src/core/datatypes/phylogenetics/characterdata/AbstractHomologousDiscreteCharacterData.h
@@ -91,8 +91,8 @@ class DiscreteCharacterState;
         virtual double                                          varGcContent(bool excl) const = 0;                                                          //!< Mean GC-content of all sequence
         virtual double                                          varGcContentByCodon(size_t n, bool excl) const = 0;                                         //!< Mean GC-content of all sequences by codon position
         
-        void                                                    removeMissingSites( void );
-        void                                                    removeRandomSites( double p );
+        void                                                    excludeMissingSites( void );
+        void                                                    replaceRandomSitesByMissingData( double p );
         virtual void                                            removeExcludedCharacters(void) = 0;                                                         //!< Remove all the excluded characters
         virtual void                                            restoreCharacter(size_t i) = 0;                                                             //!< Restore character
         

--- a/src/core/datatypes/phylogenetics/characterdata/AbstractHomologousDiscreteCharacterData.h
+++ b/src/core/datatypes/phylogenetics/characterdata/AbstractHomologousDiscreteCharacterData.h
@@ -62,6 +62,7 @@ class DiscreteCharacterState;
         virtual std::string                                     getDataType(void) const = 0;                                                                //!< Return the data type of this character data matrix
         virtual std::vector<double>                             getEmpiricalBaseFrequencies(void) const = 0;                                                //!< Compute the empirical base frequencies
         virtual std::vector<size_t>                             getIncludedSiteIndices(void) const = 0;
+        virtual std::vector<size_t>                             getInvariantSiteIndices(bool excl) const = 0;                                               //!< Get the indices of invariant characters in this matrix
         virtual size_t                                          getNumberOfCharacters(void) const = 0;                                                      //!< Number of characters
         virtual size_t                                          getMaxObservedStateIndex(void) const = 0;                                                   //!< Get the number of observed states for the characters in this matrix
         virtual size_t                                          getNumberOfSegregatingSites(bool excl) const = 0;                                           //!< Compute the number of segregating sites

--- a/src/core/datatypes/phylogenetics/characterdata/HomologousDiscreteCharacterData.h
+++ b/src/core/datatypes/phylogenetics/characterdata/HomologousDiscreteCharacterData.h
@@ -57,6 +57,7 @@ namespace RevBayesCore {
         std::vector<double>                                 getEmpiricalBaseFrequencies(void) const;                                    //!< Compute the empirical base frequencies
         const std::set<size_t>&                             getExcludedCharacters(void) const;                                          //!< Returns the name of the file the data came from
         std::vector<size_t>                                 getIncludedSiteIndices(void) const;
+        std::vector<size_t>                                 getInvariantSiteIndices(bool excl) const;                                   //!< Get the indices of invariant characters in this matrix
         size_t                                              getMaxObservedStateIndex(void) const;                                       //!< Get the number of observed states for the characters in this matrix
         size_t                                              getNumberOfCharacters(void) const;                                          //!< Number of characters
         size_t                                              getNumberOfIncludedCharacters(void) const;                                  //!< Number of characters
@@ -938,6 +939,57 @@ std::vector<size_t> RevBayesCore::HomologousDiscreteCharacterData<charType>::get
 
 
 
+/**
+ * Get the indices of invariant characters in taxon data object.
+ * This is regardless of whether the character are included or excluded.
+ *
+ * \return    The total number of characters
+ */
+template<class charType>
+std::vector<size_t> RevBayesCore::HomologousDiscreteCharacterData<charType>::getInvariantSiteIndices(bool exclude_missing) const
+{
+    // create a vector with the correct site indices
+    // some of the sites may have been excluded
+    std::vector<size_t> inv_site_indices;
+    size_t nt = this->getNumberOfTaxa();
+
+    const AbstractDiscreteTaxonData& firstTaxonData = this->getTaxonData(0);
+    size_t nc = firstTaxonData.getNumberOfCharacters();
+    for (size_t j=0; j<nc; j++)
+    {
+        const DiscreteCharacterState* a = &firstTaxonData[j];
+        size_t k = 1;
+        while ( exclude_missing == true && a->isAmbiguous() && k<nt)
+        {
+            const AbstractDiscreteTaxonData& td = this->getTaxonData(k);
+            a = &td[j];
+            ++k;
+        }
+        
+        bool invariant = true;
+        for (size_t i=1; i<nt; i++)
+        {
+            const AbstractDiscreteTaxonData& secondTaxonData = this->getTaxonData(i);
+            const DiscreteCharacterState& b = secondTaxonData[j];
+            
+            if ( exclude_missing == false || (b.isAmbiguous() == false && a->isAmbiguous() == false) )
+            {
+                invariant &= (*a == b);
+            }
+
+        }
+        
+        if ( invariant == true )
+        {
+            inv_site_indices.push_back( j + 1 );
+        }
+
+    }
+    
+    return inv_site_indices;
+}
+
+
 
 /** 
  * Get the number of characters in taxon data object. 
@@ -1053,9 +1105,9 @@ size_t RevBayesCore::HomologousDiscreteCharacterData<charType>::getNumberOfState
 
 
 /**
- * Get the set of excluded character indices.
+ * Get the number of invariant characters.
  *
- * \return    The excluded character indices.
+ * \return    The number of invariant sites.
  */
 template<class charType>
 size_t RevBayesCore::HomologousDiscreteCharacterData<charType>::getNumberOfInvariantSites(bool exclude_missing) const

--- a/src/core/datatypes/phylogenetics/characterdata/HomologousDiscreteCharacterData.h
+++ b/src/core/datatypes/phylogenetics/characterdata/HomologousDiscreteCharacterData.h
@@ -1112,42 +1112,8 @@ size_t RevBayesCore::HomologousDiscreteCharacterData<charType>::getNumberOfState
 template<class charType>
 size_t RevBayesCore::HomologousDiscreteCharacterData<charType>::getNumberOfInvariantSites(bool exclude_missing) const
 {
-    size_t invSites = 0;
-    size_t nt = this->getNumberOfTaxa();
-
-    const AbstractDiscreteTaxonData& firstTaxonData = this->getTaxonData(0);
-    size_t nc = firstTaxonData.getNumberOfCharacters();
-    for (size_t j=0; j<nc; j++)
-    {
-        const DiscreteCharacterState* a = &firstTaxonData[j];
-        size_t k = 1;
-        while ( exclude_missing == true && a->isAmbiguous() && k<nt)
-        {
-            const AbstractDiscreteTaxonData& td = this->getTaxonData(k);
-            a = &td[j];
-            ++k;
-        }
-        
-        bool invariant = true;
-        for (size_t i=1; i<nt; i++)
-        {
-            const AbstractDiscreteTaxonData& secondTaxonData = this->getTaxonData(i);
-            const DiscreteCharacterState& b = secondTaxonData[j];
-            
-            if ( exclude_missing == false || (b.isAmbiguous() == false && a->isAmbiguous() == false) )
-            {
-                invariant &= (*a == b);
-            }
-
-        }
-        
-        if ( invariant == true )
-        {
-            ++invSites;
-        }
-
-    }
-    
+    std::vector<size_t> inv_site_indices = this->getInvariantSiteIndices(exclude_missing);
+    size_t invSites = inv_site_indices.size();
     return invSites;
 }
 

--- a/src/revlanguage/datatypes/phylogenetics/characterdata/RlAbstractHomologousDiscreteCharacterData.cpp
+++ b/src/revlanguage/datatypes/phylogenetics/characterdata/RlAbstractHomologousDiscreteCharacterData.cpp
@@ -446,21 +446,21 @@ RevPtr<RevVariable> AbstractHomologousDiscreteCharacterData::executeMethod(std::
         
         return NULL;
     }
-    else if (name == "removeMissingSites")
+    else if (name == "excludeMissingSites")
     {
         found = true;
         
-        this->dag_node->getValue().removeMissingSites();
+        this->dag_node->getValue().excludeMissingSites();
         
         return NULL;
     }
-    else if (name == "removeRandomSites")
+    else if (name == "replaceRandomSitesByMissingData")
     {
         found = true;
         
         double missing = static_cast<const Probability&>( args[0].getVariable()->getRevObject() ).getValue();
 
-        this->dag_node->getValue().removeRandomSites(missing);
+        this->dag_node->getValue().replaceRandomSitesByMissingData(missing);
 
         
         return NULL;
@@ -817,8 +817,8 @@ void AbstractHomologousDiscreteCharacterData::initMethods( void )
     ArgumentRules* numInvariableBlocksArgRules              = new ArgumentRules();
     ArgumentRules* num_taxaMissingSequenceArgRules          = new ArgumentRules();
     ArgumentRules* remove_excluded_characters_arg_rules     = new ArgumentRules();
-    ArgumentRules* remove_random_sites_arg_rules            = new ArgumentRules();
-    ArgumentRules* remove_missing_sites_arg_rules           = new ArgumentRules();
+    ArgumentRules* replace_random_sites_arg_rules            = new ArgumentRules();
+    ArgumentRules* exclude_missing_sites_arg_rules           = new ArgumentRules();
     ArgumentRules* setCodonPartitionArgRules                = new ArgumentRules();
     ArgumentRules* setCodonPartitionArgRules2               = new ArgumentRules();
     ArgumentRules* setNumStatesPartitionArgRules            = new ArgumentRules();
@@ -861,7 +861,7 @@ void AbstractHomologousDiscreteCharacterData::initMethods( void )
     meanGcContentByCodonPositionArgRules->push_back(    new ArgumentRule( "excludeAmbiguous" , RlBoolean::getClassTypeSpec()          , "Should we exclude ambiguous and missing characters?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean( false )  ) );
     numInvariableBlocksArgRules->push_back(             new ArgumentRule( "excludeAmbiguous" , RlBoolean::getClassTypeSpec()          , "Should we exclude ambiguous and missing characters?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean( false )  ) );
     num_taxaMissingSequenceArgRules->push_back(         new ArgumentRule( "x" ,     Probability::getClassTypeSpec()          , "The percentage/threshold for the missing sequence.", ArgumentRule::BY_VALUE, ArgumentRule::ANY  ) );
-    remove_random_sites_arg_rules->push_back(       new ArgumentRule("fraction",        Probability::getClassTypeSpec(), "The fraction of sites to remove.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
+    replace_random_sites_arg_rules->push_back(       new ArgumentRule("fraction",        Probability::getClassTypeSpec(), "The fraction of sites to remove.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
     translateCharactersArgRules->push_back(             new ArgumentRule( "type" ,     RlString::getClassTypeSpec()          , "The character type into which we want to translate.", ArgumentRule::BY_VALUE, ArgumentRule::ANY  ) );
     varGcContentArgRules->push_back(                    new ArgumentRule( "excludeAmbiguous" , RlBoolean::getClassTypeSpec()          , "Should we exclude ambiguous and missing characters?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean( false )  ) );
     varGcContentByCodonPositionArgRules->push_back(     new ArgumentRule( "index" , Natural::getClassTypeSpec()          , "The index of the codon position.", ArgumentRule::BY_VALUE, ArgumentRule::ANY  ) );
@@ -873,6 +873,7 @@ void AbstractHomologousDiscreteCharacterData::initMethods( void )
     methods.addFunction( new MemberProcedure( "computeSiteFrequencySpectrum",           ModelVector<Natural>::getClassTypeSpec(), comp_site_freq_spec_arg_rules     ) );
     methods.addFunction( new MemberProcedure( "computeStateFrequencies",                MatrixReal::getClassTypeSpec(),     compStateFreqArgRules           ) );
     methods.addFunction( new MemberProcedure( "computeMultinomialProfileLikelihood",    Real::getClassTypeSpec(),           compMultiLikeArgRules           ) );
+    methods.addFunction( new MemberProcedure( "excludeMissingSites",                     RlUtils::Void,                      exclude_missing_sites_arg_rules  ) );
     methods.addFunction( new MemberProcedure( "expandCharacters",                       AbstractHomologousDiscreteCharacterData::getClassTypeSpec(),        expandCharactersArgRules         ) );
     methods.addFunction( new MemberProcedure( "getNumStatesVector"  ,                   ModelVector<AbstractHomologousDiscreteCharacterData>::getClassTypeSpec(), getNumStatesVectorArgRules      ) );
     methods.addFunction( new MemberProcedure( "getEmpiricalBaseFrequencies",            Simplex::getClassTypeSpec(),        empiricalBaseArgRules           ) );
@@ -893,8 +894,7 @@ void AbstractHomologousDiscreteCharacterData::initMethods( void )
     methods.addFunction( new MemberProcedure( "numInvariableBlocks",                    Natural::getClassTypeSpec(),        numInvariableBlocksArgRules     ) );
     methods.addFunction( new MemberProcedure( "numTaxaMissingSequence",                 Natural::getClassTypeSpec(),        num_taxaMissingSequenceArgRules ) );
     methods.addFunction( new MemberProcedure( "removeExcludedCharacters",               RlUtils::Void,                    remove_excluded_characters_arg_rules ) );
-    methods.addFunction( new MemberProcedure( "removeMissingSites",                     RlUtils::Void,                      remove_missing_sites_arg_rules  ) );
-    methods.addFunction( new MemberProcedure( "removeRandomSites",                      RlUtils::Void,                      remove_random_sites_arg_rules   ) );
+    methods.addFunction( new MemberProcedure( "replaceRandomSitesByMissingData",        RlUtils::Void,                      replace_random_sites_arg_rules   ) );
     methods.addFunction( new MemberProcedure( "setCodonPartition",                      RlUtils::Void,                      setCodonPartitionArgRules       ) );
     methods.addFunction( new MemberProcedure( "setCodonPartition",                      RlUtils::Void,                      setCodonPartitionArgRules2      ) );
     methods.addFunction( new MemberProcedure( "setNumStatesPartition",                  RlUtils::Void,                      setNumStatesPartitionArgRules   ) );

--- a/src/revlanguage/datatypes/phylogenetics/characterdata/RlAbstractHomologousDiscreteCharacterData.cpp
+++ b/src/revlanguage/datatypes/phylogenetics/characterdata/RlAbstractHomologousDiscreteCharacterData.cpp
@@ -18,6 +18,7 @@
 #include "RlUserInterface.h"
 #include "RbBitSet.h"
 #include "AbstractDiscreteTaxonData.h"
+#include "HomologousDiscreteCharacterData.h"
 #include "Argument.h"
 #include "ArgumentRules.h"
 #include "DiscreteCharacterState.h"
@@ -245,6 +246,17 @@ RevPtr<RevVariable> AbstractHomologousDiscreteCharacterData::executeMethod(std::
 
         return new RevVariable( new Natural(n) );
     }
+    else if (name == "getNumInvariantSites")
+    {
+        found = true;
+
+        const RevObject& argument = args[0].getVariable()->getRevObject();
+        bool excl = static_cast<const RlBoolean&>( argument ).getValue();
+
+        size_t n = this->dag_node->getValue().getNumberOfInvariantSites( excl );
+
+        return new RevVariable( new Natural(n) );
+    }
     else if ( name == "getStateDescriptions" )
     {
         found = true;
@@ -424,6 +436,14 @@ RevPtr<RevVariable> AbstractHomologousDiscreteCharacterData::executeMethod(std::
         size_t num_taxa = this->dag_node->getValue().numberTaxaMissingSequence( percentage );
 
         return new RevVariable( new Natural(num_taxa) );
+    }
+    else if (name == "removeExcludedCharacters")
+    {
+        found = true;
+        
+        this->dag_node->getValue().removeExcludedCharacters();
+        
+        return NULL;
     }
     else if (name == "removeMissingSites")
     {
@@ -794,6 +814,7 @@ void AbstractHomologousDiscreteCharacterData::initMethods( void )
     ArgumentRules* minPairwiseDifferenceArgRules            = new ArgumentRules();
     ArgumentRules* numInvariableBlocksArgRules              = new ArgumentRules();
     ArgumentRules* num_taxaMissingSequenceArgRules          = new ArgumentRules();
+    ArgumentRules* remove_excluded_characters_arg_rules     = new ArgumentRules();
     ArgumentRules* remove_random_sites_arg_rules            = new ArgumentRules();
     ArgumentRules* remove_missing_sites_arg_rules           = new ArgumentRules();
     ArgumentRules* setCodonPartitionArgRules                = new ArgumentRules();
@@ -867,6 +888,7 @@ void AbstractHomologousDiscreteCharacterData::initMethods( void )
     methods.addFunction( new MemberProcedure( "meanGcContentByCodonPosition",           Probability::getClassTypeSpec(),    meanGcContentByCodonPositionArgRules                ) );
     methods.addFunction( new MemberProcedure( "numInvariableBlocks",                    Natural::getClassTypeSpec(),        numInvariableBlocksArgRules     ) );
     methods.addFunction( new MemberProcedure( "numTaxaMissingSequence",                 Natural::getClassTypeSpec(),        num_taxaMissingSequenceArgRules ) );
+    methods.addFunction( new MemberProcedure( "removeExcludedCharacters",               RlUtils::Void,                    remove_excluded_characters_arg_rules ) );
     methods.addFunction( new MemberProcedure( "removeMissingSites",                     RlUtils::Void,                      remove_missing_sites_arg_rules  ) );
     methods.addFunction( new MemberProcedure( "removeRandomSites",                      RlUtils::Void,                      remove_random_sites_arg_rules   ) );
     methods.addFunction( new MemberProcedure( "setCodonPartition",                      RlUtils::Void,                      setCodonPartitionArgRules       ) );

--- a/src/revlanguage/datatypes/phylogenetics/characterdata/RlAbstractHomologousDiscreteCharacterData.cpp
+++ b/src/revlanguage/datatypes/phylogenetics/characterdata/RlAbstractHomologousDiscreteCharacterData.cpp
@@ -235,16 +235,17 @@ RevPtr<RevVariable> AbstractHomologousDiscreteCharacterData::executeMethod(std::
 
         return new RevVariable( new Simplex(ebf) );
     }
-    else if (name == "getNumInvariantSites")
+    else if (name == "getInvariantSiteIndices")
     {
         found = true;
 
         const RevObject& argument = args[0].getVariable()->getRevObject();
         bool excl = static_cast<const RlBoolean&>( argument ).getValue();
 
-        size_t n = this->dag_node->getValue().getNumberOfInvariantSites( excl );
+        std::vector<size_t> tmp = this->dag_node->getValue().getInvariantSiteIndices( excl );
+        std::vector<long> inv_vect(begin(tmp), end(tmp));
 
-        return new RevVariable( new Natural(n) );
+        return new RevVariable( new ModelVector<Natural>(inv_vect) );
     }
     else if (name == "getNumInvariantSites")
     {
@@ -802,6 +803,7 @@ void AbstractHomologousDiscreteCharacterData::initMethods( void )
     ArgumentRules* getStateDescriptionsArgRules             = new ArgumentRules();
     ArgumentRules* ishomologousArgRules                     = new ArgumentRules();
     ArgumentRules* invSitesArgRules                         = new ArgumentRules();
+    ArgumentRules* invSiteIndicesArgRules                   = new ArgumentRules();
     ArgumentRules* mask_missing_arg_rules                   = new ArgumentRules();
     ArgumentRules* maxGcContentArgRules                     = new ArgumentRules();
     ArgumentRules* maxInvariableBlockLengthArgRules         = new ArgumentRules();
@@ -845,6 +847,7 @@ void AbstractHomologousDiscreteCharacterData::initMethods( void )
 //    comp_site_freq_spec_arg_rules->push_back(           new ArgumentRule( "ambigAreDerived"  , RlBoolean::getClassTypeSpec()          , "Should we treat ambiguous characters as derived?",    ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean( false )  ) );
     expandCharactersArgRules->push_back(                new ArgumentRule( "factor"           , Natural::getClassTypeSpec()            , "The factor by which the state space is expanded.",    ArgumentRule::BY_VALUE, ArgumentRule::ANY  ) );
     invSitesArgRules->push_back(                        new ArgumentRule( "excludeAmbiguous" , RlBoolean::getClassTypeSpec()          , "Should we exclude ambiguous and missing characters?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean( false )  ) );
+    invSiteIndicesArgRules->push_back(                  new ArgumentRule( "excludeAmbiguous" , RlBoolean::getClassTypeSpec()          , "Should we exclude ambiguous and missing characters?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean( false )  ) );
     mask_missing_arg_rules->push_back(       new ArgumentRule("ref",        AbstractHomologousDiscreteCharacterData::getClassTypeSpec(), "The reference dataset/alignment which we use for applying the mask of missing sites.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
     maxGcContentArgRules->push_back(                    new ArgumentRule( "excludeAmbiguous" , RlBoolean::getClassTypeSpec()          , "Should we exclude ambiguous and missing characters?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean( false )  ) );
     maxInvariableBlockLengthArgRules->push_back(        new ArgumentRule( "excludeAmbiguous" , RlBoolean::getClassTypeSpec()          , "Should we exclude ambiguous and missing characters?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean( false )  ) );
@@ -873,6 +876,7 @@ void AbstractHomologousDiscreteCharacterData::initMethods( void )
     methods.addFunction( new MemberProcedure( "expandCharacters",                       AbstractHomologousDiscreteCharacterData::getClassTypeSpec(),        expandCharactersArgRules         ) );
     methods.addFunction( new MemberProcedure( "getNumStatesVector"  ,                   ModelVector<AbstractHomologousDiscreteCharacterData>::getClassTypeSpec(), getNumStatesVectorArgRules      ) );
     methods.addFunction( new MemberProcedure( "getEmpiricalBaseFrequencies",            Simplex::getClassTypeSpec(),        empiricalBaseArgRules           ) );
+    methods.addFunction( new MemberProcedure( "getInvariantSiteIndices",                ModelVector<Natural>::getClassTypeSpec(), invSiteIndicesArgRules           ) );
     methods.addFunction( new MemberProcedure( "getNumInvariantSites",                   Natural::getClassTypeSpec(),        invSitesArgRules                ) );
     methods.addFunction( new MemberProcedure( "getPairwiseDifference",                  DistanceMatrix::getClassTypeSpec(), getPairwiseDifferenceArgRules       ) );
     methods.addFunction( new MemberProcedure( "getStateDescriptions",                   ModelVector<RlString>::getClassTypeSpec(), getStateDescriptionsArgRules ) );

--- a/tests/data/petromyzontiformes.nex
+++ b/tests/data/petromyzontiformes.nex
@@ -1,0 +1,27 @@
+#NEXUS
+BEGIN DATA;
+	DIMENSIONS  NTAX=18 NCHAR=31;
+	FORMAT datatype=standard SYMBOLS= "012345" MISSING=? GAP=-;
+
+MATRIX
+Mordacia_mordax_0.0            12343315211112212233{12}3123122232
+Mordacia_lapicidia_0.0         123433152111122132?3133?3?????2
+Geotria_australis_0.0          3231433412214312112323321322322
+Ichthyomyzon_bdellium_0.0      122213111111111111?11122212???2
+Ichthyomyzon_castaneus_0.0     122213211111111111?111222122??2
+Ichthyomyzon_unicuspis_0.0     1221131111111111111111222122??2
+Petromyzon_marinus_0.0         1222131121111111111213222222112
+Caspiomyzon_wagneri_0.0        222112211212121111?212222112??2
+Tetrapleurodon_spadiceus_0.0   12222322122232111??212?2211???2
+Entosphenus_macrostomus_0.0    13232222122232111???12?2212???2
+Entosphenus_minimus_0.0        132322221121221111?21222211???2
+Entosphenus_similis_0.0        13232222122222111???1212212???2
+Entosphenus_tridentatus_0.0    1323222212223211111212222122?12
+Lethenteron_camtschaticum_0.0  1212233312222211111213122112??2
+Eudontomyzon_danfordi_0.0      121223333222321111?21212211???2
+Eudontomyzon_morii_0.0         12122333322222111???13?2211???2
+Lampetra_ayresii_0.0           131323333212121111?21212211???2
+Lampetra_fluviatilis_0.0       1313233332122211111212122122112
+;
+END;
+

--- a/tests/test_discCharMethods/output_expected/Test_discCharMethods.txt
+++ b/tests/test_discCharMethods/output_expected/Test_discCharMethods.txt
@@ -1,0 +1,51 @@
+Invariant character indices:
+[ 31 ]
+
+Number of invariant characters according to getNumInvariantSites():
+1
+
+Size of the vector of indices created above:
+1
+
+Are the two values identical?
+TRUE
+
+Invariant character indices with excludeAmbiguous = TRUE:
+[ 24, 28, 31 ]
+
+Number of invariant characters according to getNumInvariantSites()
+(excludeAmbiguous = TRUE):
+3
+
+Size of the vector of indices created above:
+3
+
+Are the two values identical?
+TRUE
+
+Total number of characters:
+31
+
+Number of included characters:
+31
+
+Are the two values identical?
+TRUE
+
+Total number of characters after excluding invariant characters:
+31
+
+Number of included characters after excluding invariant characters:
+28
+
+Do the two numbers differ by the size of the invariant character vector?
+TRUE
+
+Total number of characters after removing excluded characters:
+28
+
+Number of included characters after removing excluded characters:
+28
+
+Are the two values identical?
+TRUE

--- a/tests/test_discCharMethods/scripts/Test_discCharMethods.Rev
+++ b/tests/test_discCharMethods/scripts/Test_discCharMethods.Rev
@@ -1,0 +1,144 @@
+################################################################################
+#
+# RevBayes Test-Script: Manipulating character matrices
+#
+#
+# authors: David Cerny
+#
+################################################################################
+
+seed(12345)
+
+
+# testing the newly added getInvariantSiteIndices() and removeExcludedCharacters() methods
+
+# first read in a version of the lamprey morphological matrix from Brownstein & Near (2023),
+# Curr. Biol. 33(2): 397-404, modified to exclude the fossils
+
+morpho <- readDiscreteCharacterData("data/petromyzontiformes.nex")
+
+# get the indices of all sites that are invariant
+# for now, we will only count a character as invariant if *all* of its states are identical
+
+inv_ix_one = morpho.getInvariantSiteIndices()
+
+print(filename = "output/Test_discCharMethods.txt", append = FALSE, "Invariant character indices:")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, inv_ix_one)
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n\n")
+
+# check that the size of this vector is identical to the output of a pre-existing method
+# that gets the number of invariant characters but not their indices:
+
+num_inv_one = morpho.getNumInvariantSites()
+
+print(filename = "output/Test_discCharMethods.txt", append = TRUE,
+      "Number of invariant characters according to getNumInvariantSites():")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, num_inv_one)
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "Size of the vector of indices created above:")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, inv_ix_one.size() )
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "Are the two values identical?")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, inv_ix_one.size() == num_inv_one)
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n\n")
+
+# get the indices of all sites that are invariant
+# this time, we count a character as invariant if all of its *unambiguous* states are identical
+
+inv_ix_two = morpho.getInvariantSiteIndices(excludeAmbiguous = TRUE)
+
+print(filename = "output/Test_discCharMethods.txt", append = TRUE,
+      "Invariant character indices with excludeAmbiguous = TRUE:")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, inv_ix_two)
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n\n")
+
+num_inv_two = morpho.getNumInvariantSites(excludeAmbiguous = TRUE)
+
+print(filename = "output/Test_discCharMethods.txt", append = TRUE,
+      "Number of invariant characters according to getNumInvariantSites()")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "(excludeAmbiguous = TRUE):")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, num_inv_two)
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "Size of the vector of indices created above:")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, inv_ix_two.size() )
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "Are the two values identical?")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, inv_ix_two.size() == num_inv_two)
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n\n")
+
+# check that the number of included characters is the same as the total number of characters
+# the easiest way to get the total number of characters is to run nchar() on the first taxon
+
+all_chars_one = morpho[1].nchar()
+incl_chars_one = morpho.getIncludedCharacterIndices().size()
+
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "Total number of characters:")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, all_chars_one)
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "Number of included characters:")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, incl_chars_one)
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "Are the two values identical?")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, all_chars_one == incl_chars_one)
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n\n")
+
+# exclude all characters that are invariant according to the second criterion
+
+morpho.excludeCharacter( inv_ix_two )
+
+# check that the new number of included characters decreased but the total number did not change
+
+all_chars_two = morpho[1].nchar()
+incl_chars_two = morpho.getIncludedCharacterIndices().size()
+
+print(filename = "output/Test_discCharMethods.txt", append = TRUE,
+      "Total number of characters after excluding invariant characters:")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, all_chars_two)
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE,
+      "Number of included characters after excluding invariant characters:")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, incl_chars_two)
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE,
+      "Do the two numbers differ by the size of the invariant character vector?")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE,
+      incl_chars_two == all_chars_two - inv_ix_two.size() )
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n\n")
+
+# remove excluded characters, make sure the total number of characters now decreased as well
+
+morpho.removeExcludedCharacters()
+all_chars_three = morpho[1].nchar()
+incl_chars_three = morpho.getIncludedCharacterIndices().size()
+
+print(filename = "output/Test_discCharMethods.txt", append = TRUE,
+      "Total number of characters after removing excluded characters:")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, all_chars_three)
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE,
+      "Number of included characters after removing excluded characters:")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, incl_chars_three)
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "Are the two values identical?")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, "\n")
+print(filename = "output/Test_discCharMethods.txt", append = TRUE, all_chars_three == incl_chars_three)
+clear()
+
+q()


### PR DESCRIPTION
This branch makes the following changes to the class `AbstractHomologousDiscreteCharacterData`, originally suggested by Alessio Capobianco:

(1) Add a `.getInvariantSiteIndices()` method, which returns the indices of all characters that are invariant, either with or without accounting for ambiguities. The code is based on the pre-existing `.getNumInvariantSites()` method, which has been refactored to remove redundancies.

(2) Add a `.removeExcludedCharacters()` method, which entirely removes excluded characters from the matrix. The idea behind this method is to do for characters what we already do for taxa, where we have both an `.excludeTaxa()` method (which marks one or more taxa as excluded but keeps them in the matrix) and a `.removeTaxa()` method (which removes them entirely).

(3) Add a test to check these methods work as intended.

(4) Use the words "exclude" and "remove" in a consistent manner by renaming the existing method `.removeMissingSites()` to `.excludeMissingSites()` (since it marks sites consisting entirely of missing data as excluded but keeps them in the matrix) and `.removeRandomSites()` to `.replaceRandomSitesByMissingData()`. This latter method neither excludes nor removes any sites; instead, it irreversibly changes their coding.