### PR TITLE
Fix problem reconstructing ancestral state with missing data.

### DIFF
--- a/src/core/distributions/phylogenetics/substitution/AbstractPhyloCTMCSiteHomogeneous.h
+++ b/src/core/distributions/phylogenetics/substitution/AbstractPhyloCTMCSiteHomogeneous.h
@@ -2101,11 +2101,11 @@ void RevBayesCore::AbstractPhyloCTMCSiteHomogeneous<charType>::tipDrawJointCondi
             }
 
             // get the ambiguous character's bitset for the tip taxon
-            RbBitSet bs = RbBitSet(this->num_chars, true);
-            if ( c.isMissingState() == false )
-            {
+            RbBitSet bs = RbBitSet(this->num_chars);
+            if ( c.isMissingState() )
+                bs.set(); // set to all 1s.
+            else
                 bs = c.getState();
-            }
 
             // iterate over possible end states for each site given start state
             for (size_t j = 0; j < this->num_chars; j++)

--- a/src/core/distributions/phylogenetics/tree/TopologyConstrainedTreeDistribution.cpp
+++ b/src/core/distributions/phylogenetics/tree/TopologyConstrainedTreeDistribution.cpp
@@ -499,7 +499,7 @@ RbBitSet TopologyConstrainedTreeDistribution::recursivelyUpdateClades( const Top
             dirty_nodes[node.getIndex()] = false;
         }
         
-        return RbBitSet( value->getNumberOfTips(), true );
+        return RbBitSet( value->getNumberOfTips() ).set();
     }
     else
     {

--- a/src/core/distributions/phylogenetics/tree/birthdeath/ConstantRateOutgroupBirthDeathProcess.cpp
+++ b/src/core/distributions/phylogenetics/tree/birthdeath/ConstantRateOutgroupBirthDeathProcess.cpp
@@ -542,7 +542,7 @@ RbBitSet ConstantRateOutgroupBirthDeathProcess::recursivelyUpdateClades( const T
             dirty_nodes[node.getIndex()] = false;
         }
         
-        return RbBitSet( value->getNumberOfTips(), true );
+        return RbBitSet( value->getNumberOfTips() ).set();
     }
     else
     {

--- a/src/core/distributions/phylogenetics/tree/birthdeath/StateDependentSpeciationExtinctionProcess.cpp
+++ b/src/core/distributions/phylogenetics/tree/birthdeath/StateDependentSpeciationExtinctionProcess.cpp
@@ -363,7 +363,8 @@ void StateDependentSpeciationExtinctionProcess::computeNodeProbability(const Rev
                 extinction = pExtinction(0.0, node.getAge());
             }
             
-            RbBitSet obs_state(num_states, true);
+            RbBitSet obs_state(num_states);
+            obs_state.set();
             bool gap = true;
 
             if ( tree->hasCharacterData() == true )

--- a/src/core/distributions/phylogenetics/tree/birthdeath/TimeVaryingStateDependentSpeciationExtinctionProcess.cpp
+++ b/src/core/distributions/phylogenetics/tree/birthdeath/TimeVaryingStateDependentSpeciationExtinctionProcess.cpp
@@ -377,7 +377,8 @@ void TimeVaryingStateDependentSpeciationExtinctionProcess::computeNodeProbabilit
                 extinction = pExtinction(0.0, node.getAge());
             }
             
-            RbBitSet obs_state(num_states, true);
+            RbBitSet obs_state(num_states);
+            obs_state.set();
             bool gap = true;
             
             if ( tree->hasCharacterData() == true )


### PR DESCRIPTION
This problem was caused by a change I made in the RbBitSet implementation a while back.

RbBitSet is now an alias to `boost::dynamic_bitset<>`.  So, RbBitSet(n, true) doesn't construct an all-1s bitset anymore.  Instead, the second argument is a `long int` that represents a bitmask.  So, passing in `true` initializes the bitset to `0000..001` 😬.

While fixing this problem, I noticed a few other cases where RbBitSet(n, true) occurred and fixed them too.