### PR TITLE
fix probability constructor function

### DIFF
--- a/src/revlanguage/datatypes/basic/Probability.cpp
+++ b/src/revlanguage/datatypes/basic/Probability.cpp
@@ -127,7 +127,7 @@ const MemberRules& Probability::getParameterRules(void) const
     if ( !rules_set )
     {
 
-        argumentRules.push_back( new ArgumentRule( "x", Real::getClassTypeSpec(), "The value.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        argumentRules.push_back( new ArgumentRule( "x", Probability::getClassTypeSpec(), "The value.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
 
         rules_set = true;
     }


### PR DESCRIPTION
This should make a simple and RevBayes consistent fix to the discussion https://github.com/revbayes/revbayes/issues/391

It also fixes this issue: https://github.com/revbayes/revbayes/issues/348