### PR TITLE
Make it impossible to create 0-length traces

### DIFF
--- a/src/revlanguage/functions/io/Func_readTreeTrace.cpp
+++ b/src/revlanguage/functions/io/Func_readTreeTrace.cpp
@@ -204,6 +204,11 @@ RevPtr<RevVariable> Func_readTreeTrace::execute( void )
 
         for(size_t i = 0; i < rv->getValue().size(); i++)
         {
+            if ( burnin >= rv->getValue()[i].getValue().size() )
+            {
+                throw RbException("Specified burnin equals or exceeds the total number of trees in the trace.");
+            }
+            
             (*rv)[i].getValue().setBurnin(burnin);
         }
     }
@@ -256,8 +261,8 @@ const ArgumentRules& Func_readTreeTrace::getArgumentRules( void ) const
         argumentRules.push_back( new Delimiter() );
 
         std::vector<TypeSpec> burninTypes;
-        burninTypes.push_back( Probability::getClassTypeSpec() );
         burninTypes.push_back( Integer::getClassTypeSpec() );
+        burninTypes.push_back( Probability::getClassTypeSpec() );
         argumentRules.push_back( new ArgumentRule( "burnin"   , burninTypes     , "The fraction/number of samples to discard as burnin.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new Probability(0.25) ) );
 
         argumentRules.push_back( new ArgumentRule( "thinning", Natural::getClassTypeSpec(), "The frequency of samples to read, i.e., we will only used every n-th sample where n is defined by this argument.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new Natural( 1l ) ) );


### PR DESCRIPTION
This is intended to fix issue #412 and supplant PR #227 with a (hopefully) somewhat more elegant solution. The basic idea is still to prevent the user from creating 0-length traces in the first place, rather than to make sure that the class methods of `TraceTree` or summary functions like `mapTree()` can handle them. This is mostly done for the sake of brevity, and because I can't think of any use for a 0-length trace anyway.

@bredelings's idea of switching the order of argument types, so that `1` (or `1.0`) will get preferentially interpreted as an integer rather than a probability, was almost enough to solve the problem. The only other way to create a 0-length trace is to specify a burnin length that exactly matches the total number of trees in the trace, so I added an extra check that throws an error if burnin >= length(trace). The current RB version already fails gracefully when the length of the burnin _exceeds_ the length of the trace, but with a somewhat enigmatic error message that we can probably improve on: `map::at:  key not found`.