### PR TITLE
Fixed memory leak in reversible jump mixtures

### DIFF
--- a/src/core/distributions/ReversibleJumpMixtureConstantDistribution.h
+++ b/src/core/distributions/ReversibleJumpMixtureConstantDistribution.h
@@ -329,7 +329,7 @@ template <class mixtureType>
 void RevBayesCore::ReversibleJumpMixtureConstantDistribution<mixtureType>::setValue(mixtureType *v, bool force)
 {
     
-    delete this->value;
+    if(v != this->value) delete this->value;
     
     if ( force == false )
     {


### PR DESCRIPTION
Issue led to segmentation faults e.g. #429 