### PR TITLE
BLeSS efficiencies

### DIFF
--- a/src/core/math/distributions/DistributionExponentialError.cpp
+++ b/src/core/math/distributions/DistributionExponentialError.cpp
@@ -66,17 +66,22 @@ double RbStatistics::ExponentialError::lnPdf(const AverageDistanceMatrix &avgDis
         txNames[i] = avgDistMat.getTaxa()[i].getName();
     }
     
+    std::vector<size_t> ADMind( avgDistMat.getSize() );
+    for(size_t i = 0; i < txNames.size(); i++)
+    {
+        ADMind[i] = std::distance(txNames.begin(), std::find( txNames.begin(), txNames.end(), z.getTaxa()[i].getName() ));
+    }
+
     double dist = 0;
-    
+
     for (size_t i=0; i<avgDistMat.getSize(); i++)
     {
-        size_t rowInd = std::distance(txNames.begin(), std::find( txNames.begin(), txNames.end(), z.getTaxa()[i].getName() ));
         for (size_t j=0; j<i; j++)
         {
-            size_t colInd = std::distance(txNames.begin(), std::find( txNames.begin(), txNames.end(), z.getTaxa()[j].getName() ));
             if (z.getMask()[i][j])
             {
-                dist += pow(z.getDistanceMatrix()[i][j] - avgDistMat.getDistanceMatrix()[rowInd][colInd], 2.0);
+                double difference = z.getDistanceMatrix()[i][j] - avgDistMat.getDistanceMatrix()[ ADMind[i] ][ ADMind[j] ];
+                dist += difference * difference;
             }
         }
     }
@@ -201,17 +206,22 @@ double RbStatistics::ExponentialError::lnPdf(const DistanceMatrix &distMat, doub
         txNames[i] = distMat.getTaxa()[i].getName();
     }
     
+    std::vector<size_t> DMind( distMat.getSize() );
+    for(size_t i = 0; i < txNames.size(); i++)
+    {
+        DMind[i] = std::distance(txNames.begin(), std::find( txNames.begin(), txNames.end(), z.getTaxa()[i].getName() ));
+    }
+    
     double dist = 0;
     
     for (size_t i=0; i<distMat.getSize(); i++)
     {
-        size_t rowInd = std::distance(txNames.begin(), std::find( txNames.begin(), txNames.end(), z.getTaxa()[i].getName() ));
         for (size_t j=0; j<i; j++)
         {
-            size_t colInd = std::distance(txNames.begin(), std::find( txNames.begin(), txNames.end(), z.getTaxa()[j].getName() ));
             if (z.getMask()[i][j])
             {
-                dist += pow(z.getDistanceMatrix()[i][j] - distMat[rowInd][colInd], 2.0);
+                double difference = z.getDistanceMatrix()[i][j] - distMat[ DMind[i] ][ DMind[j] ];
+                dist += difference * difference;
             }
         }
     }


### PR DESCRIPTION
This branch provides a more efficient ln(pdf) calculation for the exponential error distribution, which is defined over distance matrices and underlies the (hopefully soon to be published) Bayesian Least-Squares Supertrees (BLeSS) method. Following Claudio Kozický's (@qak) suggestion, the new implementation reduces the number of `std::find` calls (from _n_(_n_ − 1)/2 to just _n_), yielding a roughly 36-fold speed-up for 5000-by-5000 matrices. 