### PR TITLE
More BLeSS efficiencies

### DIFF
--- a/src/core/math/distributions/DistributionExponentialError.cpp
+++ b/src/core/math/distributions/DistributionExponentialError.cpp
@@ -10,7 +10,6 @@
 
 #include <cmath>
 #include <numeric>
-#include <iostream>
 #include <algorithm>
 
 #include "DistributionDirichlet.h"
@@ -30,16 +29,16 @@ using namespace RevBayesCore;
  * vsoftco, https://stackoverflow.com/a/37732329
  *
  * \brief Index sorting.
- * \param v is a vector that we want to sort and return indices of.
- * \return Vector of sorted indices.
+ * \param v is a vector that we want to sort and return the indices of sorted elements.
+ * \return Vector of indices of the sorted elements of v.
  * \throws Does not throw an error.
  */
-std::vector<size_t> RbStatistics::ExponentialError::stringSortIndices(const std::vector<std::string>& v)
+std::vector<uint32_t> RbStatistics::ExponentialError::stringSortIndices(const std::vector<std::string>& v)
 {
-    std::vector<size_t> result( v.size() );
+    std::vector<uint32_t> result( v.size() );
     std::iota(result.begin(), result.end(), 0);
     std::sort(result.begin(), result.end(),
-              [&v](size_t i1, size_t i2) { return v[i1] < v[i2]; }
+              [&v](uint32_t i1, uint32_t i2) { return v[i1] < v[i2]; }
              );
     return result;
 }
@@ -97,18 +96,22 @@ double RbStatistics::ExponentialError::lnPdf(const AverageDistanceMatrix &avgDis
         zNames[i] = z.getTaxa()[i].getName();
     }
     
-    std::vector<size_t> ix0 = stringSortIndices(zNames);
-    std::vector<size_t> ix1 = stringSortIndices(admNames);
+    std::vector<uint32_t> ix0 = stringSortIndices(zNames);
+    std::vector<uint32_t> ix1 = stringSortIndices(admNames);
 
     double dist = 0;
 
-    for (size_t i=0; i<avgDistMat.getSize(); i++)
+    for (size_t i = 0; i < avgDistMat.getSize(); i++)
     {
-        for (size_t j=0; j<i; j++)
+        uint32_t k = ix0[i];
+        uint32_t m = ix1[i];
+        for (size_t j = 0; j < i; j++)
         {
-            if (z.getMask()[ ix0[i] ][ ix0[j] ])
+            uint32_t l = ix0[j];
+            uint32_t n = ix1[j];
+            if (z.getMask()[k][l])
             {
-                double difference = z.getDistanceMatrix()[ ix0[i] ][ ix0[j] ] - avgDistMat.getDistanceMatrix()[ ix1[i] ][ ix1[j] ];
+                double difference = z.getDistanceMatrix()[k][l] - avgDistMat.getDistanceMatrix()[m][n];
                 dist += difference * difference;
             }
         }
@@ -227,31 +230,35 @@ double RbStatistics::ExponentialError::lnPdf(const DistanceMatrix &distMat, doub
     {
         return RbConstants::Double::neginf;
     }
-    
+
     std::vector<std::string> dmNames( distMat.getSize() );
     for(size_t i = 0; i < dmNames.size(); i++)
     {
         dmNames[i] = distMat.getTaxa()[i].getName();
     }
-    
+
     std::vector<std::string> zNames( z.getSize() );
     for(size_t i = 0; i < zNames.size(); i++)
     {
         zNames[i] = z.getTaxa()[i].getName();
     }
     
-    std::vector<size_t> ix0 = stringSortIndices(zNames);
-    std::vector<size_t> ix1 = stringSortIndices(dmNames);
+    std::vector<uint32_t> ix0 = stringSortIndices(zNames);
+    std::vector<uint32_t> ix1 = stringSortIndices(dmNames);
     
     double dist = 0;
     
-    for (size_t i=0; i<distMat.getSize(); i++)
+    for (size_t i = 0; i < distMat.getSize(); i++)
     {
-        for (size_t j=0; j<i; j++)
+        uint32_t k = ix0[i];
+        uint32_t m = ix1[i];
+        for (size_t j = 0; j < i; j++)
         {
-            if (z.getMask()[ ix0[i] ][ ix0[j] ])
+            uint32_t l = ix0[j];
+            uint32_t n = ix1[j];
+            if (z.getMask()[k][l])
             {
-                double difference = z.getDistanceMatrix()[ ix0[i] ][ ix0[j] ] - distMat[ ix1[i] ][ ix1[j] ];
+                double difference = z.getDistanceMatrix()[k][l] - distMat[m][n];
                 dist += difference * difference;
             }
         }

--- a/src/core/math/distributions/DistributionExponentialError.cpp
+++ b/src/core/math/distributions/DistributionExponentialError.cpp
@@ -18,30 +18,11 @@
 #include "Cloneable.h"
 #include "RbVector.h"
 #include "RbVectorImpl.h"
+#include "StringUtilities.h"
 #include "AverageDistanceMatrix.h"
 #include "DistanceMatrix.h"
 
 using namespace RevBayesCore;
-
-/*!
- * Helper function for index sorting, inspired by the following Stack Overflow posts:
- * Lukasz Wiklendt, https://stackoverflow.com/a/12399290 and
- * vsoftco, https://stackoverflow.com/a/37732329
- *
- * \brief Index sorting.
- * \param v is a vector that we want to sort and return the indices of sorted elements.
- * \return Vector of indices of the sorted elements of v.
- * \throws Does not throw an error.
- */
-std::vector<uint32_t> RbStatistics::ExponentialError::stringSortIndices(const std::vector<std::string>& v)
-{
-    std::vector<uint32_t> result( v.size() );
-    std::iota(result.begin(), result.end(), 0);
-    std::sort(result.begin(), result.end(),
-              [&v](uint32_t i1, uint32_t i2) { return v[i1] < v[i2]; }
-             );
-    return result;
-}
 
 
 
@@ -96,8 +77,8 @@ double RbStatistics::ExponentialError::lnPdf(const AverageDistanceMatrix &avgDis
         zNames[i] = z.getTaxa()[i].getName();
     }
     
-    std::vector<uint32_t> ix0 = stringSortIndices(zNames);
-    std::vector<uint32_t> ix1 = stringSortIndices(admNames);
+    std::vector<uint32_t> ix0 = StringUtilities::stringSortIndices(zNames);
+    std::vector<uint32_t> ix1 = StringUtilities::stringSortIndices(admNames);
 
     double dist = 0;
 
@@ -243,8 +224,8 @@ double RbStatistics::ExponentialError::lnPdf(const DistanceMatrix &distMat, doub
         zNames[i] = z.getTaxa()[i].getName();
     }
     
-    std::vector<uint32_t> ix0 = stringSortIndices(zNames);
-    std::vector<uint32_t> ix1 = stringSortIndices(dmNames);
+    std::vector<uint32_t> ix0 = StringUtilities::stringSortIndices(zNames);
+    std::vector<uint32_t> ix1 = StringUtilities::stringSortIndices(dmNames);
     
     double dist = 0;
     

--- a/src/core/math/distributions/DistributionExponentialError.cpp
+++ b/src/core/math/distributions/DistributionExponentialError.cpp
@@ -10,6 +10,7 @@
 
 #include <cmath>
 #include <numeric>
+#include <iostream>
 #include <algorithm>
 
 #include "DistributionDirichlet.h"
@@ -96,8 +97,8 @@ double RbStatistics::ExponentialError::lnPdf(const AverageDistanceMatrix &avgDis
         zNames[i] = z.getTaxa()[i].getName();
     }
     
-    std::vector<size_t> ix0 = stringSortIndices(admNames);
-    std::vector<size_t> ix1 = stringSortIndices(zNames);
+    std::vector<size_t> ix0 = stringSortIndices(zNames);
+    std::vector<size_t> ix1 = stringSortIndices(admNames);
 
     double dist = 0;
 
@@ -105,7 +106,7 @@ double RbStatistics::ExponentialError::lnPdf(const AverageDistanceMatrix &avgDis
     {
         for (size_t j=0; j<i; j++)
         {
-            if (z.getMask()[i][j])
+            if (z.getMask()[ ix0[i] ][ ix0[j] ])
             {
                 double difference = z.getDistanceMatrix()[ ix0[i] ][ ix0[j] ] - avgDistMat.getDistanceMatrix()[ ix1[i] ][ ix1[j] ];
                 dist += difference * difference;
@@ -248,7 +249,7 @@ double RbStatistics::ExponentialError::lnPdf(const DistanceMatrix &distMat, doub
     {
         for (size_t j=0; j<i; j++)
         {
-            if (z.getMask()[i][j])
+            if (z.getMask()[ ix0[i] ][ ix0[j] ])
             {
                 double difference = z.getDistanceMatrix()[ ix0[i] ][ ix0[j] ] - distMat[ ix1[i] ][ ix1[j] ];
                 dist += difference * difference;

--- a/src/core/math/distributions/DistributionExponentialError.cpp
+++ b/src/core/math/distributions/DistributionExponentialError.cpp
@@ -33,7 +33,7 @@ using namespace RevBayesCore;
  * \return Vector of sorted indices.
  * \throws Does not throw an error.
  */
-std::vector<size_t> stringSortIndices(const std::vector<std::string>& v)
+std::vector<size_t> RbStatistics::ExponentialError::stringSortIndices(const std::vector<std::string>& v)
 {
     std::vector<size_t> result( v.size() );
     std::iota(result.begin(), result.end(), 0);

--- a/src/core/math/distributions/DistributionExponentialError.h
+++ b/src/core/math/distributions/DistributionExponentialError.h
@@ -25,8 +25,6 @@ namespace RevBayesCore {
         
         namespace ExponentialError {
         
-            std::vector<uint32_t>       stringSortIndices(const std::vector<std::string>& v);                                          /*!< Get the indices of the sorted elements of a vector of strings */
-        
             // exponential error of parameters avgDistMat and lambda
             double                      pdf(const AverageDistanceMatrix& avgDistMat, double lambda, const AverageDistanceMatrix& z);   /*!< Exponential error probability density */
             double                      lnPdf(const AverageDistanceMatrix& avgDistMat, double lambda, const AverageDistanceMatrix& z); /*!< Exponential error log_e probability density */

--- a/src/core/math/distributions/DistributionExponentialError.h
+++ b/src/core/math/distributions/DistributionExponentialError.h
@@ -25,7 +25,7 @@ namespace RevBayesCore {
         
         namespace ExponentialError {
         
-            std::vector<size_t>         stringSortIndices(const std::vector<std::string>& v);                                          /*!< Get sorted indices of a vector of strings */
+            std::vector<uint32_t>       stringSortIndices(const std::vector<std::string>& v);                                          /*!< Get the indices of the sorted elements of a vector of strings */
         
             // exponential error of parameters avgDistMat and lambda
             double                      pdf(const AverageDistanceMatrix& avgDistMat, double lambda, const AverageDistanceMatrix& z);   /*!< Exponential error probability density */

--- a/src/core/math/distributions/DistributionExponentialError.h
+++ b/src/core/math/distributions/DistributionExponentialError.h
@@ -25,6 +25,8 @@ namespace RevBayesCore {
         
         namespace ExponentialError {
         
+            std::vector<size_t>         stringSortIndices(const std::vector<std::string>& v);                                          /*!< Get sorted indices of a vector of strings */
+        
             // exponential error of parameters avgDistMat and lambda
             double                      pdf(const AverageDistanceMatrix& avgDistMat, double lambda, const AverageDistanceMatrix& z);   /*!< Exponential error probability density */
             double                      lnPdf(const AverageDistanceMatrix& avgDistMat, double lambda, const AverageDistanceMatrix& z); /*!< Exponential error log_e probability density */

--- a/src/core/utils/StringUtilities.cpp
+++ b/src/core/utils/StringUtilities.cpp
@@ -18,6 +18,7 @@
 #include "StringUtilities.h"
 
 #include <cstdio>
+#include <cstdint>
 #include <iomanip>
 
 #include <algorithm>

--- a/src/core/utils/StringUtilities.cpp
+++ b/src/core/utils/StringUtilities.cpp
@@ -494,6 +494,26 @@ string StringUtilities::join(const vector<string>& ss, const string& sep)
     return o.str();
 }
 
+/*!
+ * Utility function for index sorting, inspired by the following Stack Overflow posts:
+ * Lukasz Wiklendt, https://stackoverflow.com/a/12399290 and
+ * vsoftco, https://stackoverflow.com/a/37732329
+ *
+ * \brief Index sorting.
+ * \param v is a vector that we want to sort and return the indices of sorted elements.
+ * \return Vector of indices of the sorted elements of v. We use uint32_t rather than size_t to speed up memory access.
+ * \throws Does not throw an error.
+ */
+std::vector<uint32_t> StringUtilities::stringSortIndices(const std::vector<std::string>& v)
+{
+    std::vector<uint32_t> result( v.size() );
+    std::iota(result.begin(), result.end(), 0);
+    std::sort(result.begin(), result.end(),
+              [&v](uint32_t i1, uint32_t i2) { return v[i1] < v[i2]; }
+             );
+    return result;
+}
+
 /**
  * Utility function for dividing string into pieces
  * If no delimiter is specified, then the string is split on whitespace.

--- a/src/core/utils/StringUtilities.h
+++ b/src/core/utils/StringUtilities.h
@@ -15,6 +15,7 @@
 #define RlStringUtilities_H
 
 #include <cstddef>
+#include <cstdint>
 #include <sstream> // IWYU pragma: keep
 #include <vector>
 

--- a/src/core/utils/StringUtilities.h
+++ b/src/core/utils/StringUtilities.h
@@ -39,6 +39,7 @@ namespace StringUtilities {
     std::string                 oneLiner(const std::string& input, size_t maxLen);                                  //!< Get a one-liner of specified length
     void                        replaceSubstring(std::string& str, const std::string& oldStr, const std::string& newStr);
     void                        replaceAllOccurrences(std::string& str, char old_ch, char new_ch);
+    std::vector<uint32_t>       stringSortIndices(const std::vector<std::string>& v);                               //!< Get the indices of the sorted elements of a vector of strings
     void                        stringSplit(std::string str, std::string delim, std::vector<std::string>& results, bool trim = false); //!< Split a string into pieces
     void                        toLower(std::string& str);                                                          //!< Convert string's characters to lower case
     std::string                 toString(double x, int digits=6);                                                   //!< Convert string's characters to lower case


### PR DESCRIPTION
Some additional improvements to the performance of ln(pdf), again following very helpful suggestions by Claudio Kozický ([@qak](https://github.com/qak)). The main changes are as follows:

(1) The "alignment" of the average distance matrix and the distance matrix of a proposed tree (i.e., the step of ensuring that we are subtracting distances corresponding to the same pair of taxa) is done using `std::sort` rather than `std::find`, which is up to two orders of magnitude faster for 10,000-by-10,000 matrices;

(2) Indexing is done using `uint32_t` rather than `size_t`, which speeds up memory access (and consequently, the matrix subtraction step).

In practice, the performance improvement gained by these changes can be difficult to observe, because the total amount of time spent on evaluating the (log) probability density of a proposed tree is now dominated by the time it takes to convert the tree to a distance matrix. However, some experimentation with `std::chrono::steady_clock` will show that the ln(pdf) calculation implemented in this branch is about 12% faster for 10,000-by-10,000 matrices (~0.63 vs. ~0.55 s).