### PR TITLE
Don't flatten arrays of stochastic variables in checkpoint files

### DIFF
--- a/src/core/analysis/mcmc/Mcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmc.cpp
@@ -202,7 +202,7 @@ void Mcmc::checkpoint( void ) const
 {
     // initialize variables
     std::string separator = "\t";
-    bool flatten = true;
+    bool flatten = false;
     
     createDirectoryForFile( checkpoint_file_name );
     


### PR DESCRIPTION
This is another trivial, single-line bug fix that we've never gotten around to implementing, this time for issue #339. @jsigao suggested this as a solution and implemented it on [his branch](https://github.com/revbayes/revbayes/commit/ec20e7875f3f572c7ad55b0767b40c7492538b4c); I verified that it's sufficient to get rid of the issue. While the plan was to make it just one part of a more extensive checkpointing fix, it's been more than a year, and it seems worth fixing the issue even without a more general solution to MPI and MC^3 checkpointing problems. However, precisely because the problem of getting checkpointing to work under MPI is still [unresolved](https://github.com/revbayes/revbayes/issues/184), I'm holding off from adding a full-blown checkpointing test.