### PR TITLE
added bounds on tuning parameter for mvScale

### DIFF
--- a/src/core/moves/proposal/scalar/ScaleProposal.cpp
+++ b/src/core/moves/proposal/scalar/ScaleProposal.cpp
@@ -183,5 +183,7 @@ void ScaleProposal::tune( double rate )
         lambda /= (2.0 - rate/p);
     }
     
+    if(lambda > 1) lambda = fmin(1000, lambda);
+    else lambda = fmax(0.001, lambda);
 }
 


### PR DESCRIPTION
This is a partial fix for the issue #272 where a bad interaction between tuning and mixture variable leads to overflow on the scaling factor used in mvScale
similar bounds are implemented in e.g. mvSlideBactrian
