### PR TITLE
Improvements to MatrixBoolean and AverageDistanceMatrix

### DIFF
--- a/src/core/datatypes/math/MatrixBoolean.cpp
+++ b/src/core/datatypes/math/MatrixBoolean.cpp
@@ -150,7 +150,7 @@ void MatrixBoolean::executeMethod(const std::string &n, const std::vector<const 
         size_t index = (size_t)static_cast<const TypedDagNode<long> *>( args[0] )->getValue() - 1;
         boost::dynamic_bitset<> tmp = elements[index];
         
-        RbVector<Boolean> rv;
+        RbVector<Boolean> rv( tmp.size() );
         for (size_t i = 0; i < tmp.size(); i++)
         {
             rv[i] = (Boolean)tmp[i];
@@ -161,7 +161,7 @@ void MatrixBoolean::executeMethod(const std::string &n, const std::vector<const 
     {
         boost::dynamic_bitset<> tmp = this->getUpperTriangle();
         
-        RbVector<Boolean> rv;
+        RbVector<Boolean> rv( tmp.size() );
         for (size_t i = 0; i < tmp.size(); i++)
         {
             rv[i] = (Boolean)tmp[i];

--- a/src/core/datatypes/math/MatrixBoolean.cpp
+++ b/src/core/datatypes/math/MatrixBoolean.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 
 #include "MatrixBoolean.h"
+#include "RbBoolean.h"
 #include "RbException.h"
 #include "RbVector.h"
 #include "RbConstants.h"
@@ -141,17 +142,30 @@ MatrixBoolean* MatrixBoolean::clone(void) const
 }
 
 
-void MatrixBoolean::executeMethod(const std::string &n, const std::vector<const DagNode *> &args, boost::dynamic_bitset<> &rv) const
+void MatrixBoolean::executeMethod(const std::string &n, const std::vector<const DagNode *> &args, RbVector<Boolean> &rv) const
 {
     
     if ( n == "[]" )
     {
-        int index = (int)static_cast<const TypedDagNode<long> *>( args[0] )->getValue()-1;
-        rv = elements[index];
+        size_t index = (size_t)static_cast<const TypedDagNode<long> *>( args[0] )->getValue() - 1;
+        boost::dynamic_bitset<> tmp = elements[index];
+        
+        RbVector<Boolean> rv;
+        for (size_t i = 0; i < tmp.size(); i++)
+        {
+            rv[i] = (Boolean)tmp[i];
+        }
+        
     }
     else if ( n == "upperTriangle" )
     {
-        rv = this->getUpperTriangle();
+        boost::dynamic_bitset<> tmp = this->getUpperTriangle();
+        
+        RbVector<Boolean> rv;
+        for (size_t i = 0; i < tmp.size(); i++)
+        {
+            rv[i] = (Boolean)tmp[i];
+        }
     }
     else
     {
@@ -181,7 +195,7 @@ void MatrixBoolean::executeMethod(const std::string &n, const std::vector<const 
  * @throw RbException if columnIndex is out of bounds
  * @return Vector of Booleans corresponding to the given column of the matrix
  */
-boost::dynamic_bitset<> MatrixBoolean::getColumn( size_t columnIndex ) const
+RbVector<Boolean> MatrixBoolean::getColumn( size_t columnIndex ) const
 {
     
     if ( columnIndex >= nCols )
@@ -191,7 +205,7 @@ boost::dynamic_bitset<> MatrixBoolean::getColumn( size_t columnIndex ) const
         throw RbException( o.str() );
     }
     
-    boost::dynamic_bitset<> col( nRows );
+    RbVector<Boolean> col( nRows );
 
     for (size_t i = 0; i < nRows; ++i)
     {

--- a/src/core/datatypes/math/MatrixBoolean.cpp
+++ b/src/core/datatypes/math/MatrixBoolean.cpp
@@ -150,10 +150,9 @@ void MatrixBoolean::executeMethod(const std::string &n, const std::vector<const 
         size_t index = (size_t)static_cast<const TypedDagNode<long> *>( args[0] )->getValue() - 1;
         boost::dynamic_bitset<> tmp = elements[index];
         
-        RbVector<Boolean> rv( tmp.size() );
         for (size_t i = 0; i < tmp.size(); i++)
         {
-            rv[i] = Boolean( tmp[i] );
+            rv.push_back( Boolean( tmp[i] ) );
         }
         
     }
@@ -161,10 +160,9 @@ void MatrixBoolean::executeMethod(const std::string &n, const std::vector<const 
     {
         boost::dynamic_bitset<> tmp = this->getUpperTriangle();
         
-        RbVector<Boolean> rv( tmp.size() );
         for (size_t i = 0; i < tmp.size(); i++)
         {
-            rv[i] = Boolean( tmp[i] );
+            rv.push_back( Boolean( tmp[i] ) );
         }
     }
     else

--- a/src/core/datatypes/math/MatrixBoolean.cpp
+++ b/src/core/datatypes/math/MatrixBoolean.cpp
@@ -153,7 +153,7 @@ void MatrixBoolean::executeMethod(const std::string &n, const std::vector<const 
         RbVector<Boolean> rv( tmp.size() );
         for (size_t i = 0; i < tmp.size(); i++)
         {
-            rv[i] = (Boolean)tmp[i];
+            rv[i] = Boolean( tmp[i] );
         }
         
     }
@@ -164,7 +164,7 @@ void MatrixBoolean::executeMethod(const std::string &n, const std::vector<const 
         RbVector<Boolean> rv( tmp.size() );
         for (size_t i = 0; i < tmp.size(); i++)
         {
-            rv[i] = (Boolean)tmp[i];
+            rv[i] = Boolean( tmp[i] );
         }
     }
     else
@@ -205,7 +205,7 @@ RbVector<Boolean> MatrixBoolean::getColumn( size_t columnIndex ) const
         throw RbException( o.str() );
     }
     
-    RbVector<Boolean> col( nRows );
+    RbVector<Boolean> col( nRows, false );
 
     for (size_t i = 0; i < nRows; ++i)
     {

--- a/src/core/datatypes/math/MatrixBoolean.h
+++ b/src/core/datatypes/math/MatrixBoolean.h
@@ -3,6 +3,7 @@
 
 #include "Cloneable.h"
 #include "MemberObject.h"
+#include "RbBoolean.h"
 #include "RbVector.h"
 
 #include <cstddef>
@@ -20,7 +21,7 @@ namespace RevBayesCore {
      * in conjunction with other matrix objects as a Boolean mask.
      */
     
-    class MatrixBoolean : public Cloneable, public MemberObject<boost::dynamic_bitset<> >, public MemberObject<MatrixBoolean> {
+    class MatrixBoolean : public Cloneable, public MemberObject< RbVector<Boolean> >, public MemberObject<MatrixBoolean> {
         
     public:
         MatrixBoolean(void);                                                        //!< Default constructor required by revlanguage use of this class
@@ -51,9 +52,9 @@ namespace RevBayesCore {
         void                                    clear(void);
         MatrixBoolean*                          clone(void) const;
         MatrixBoolean                           negate(void) const;             //!< Element-wise bit flipping (turns every 'true' into 'false' and every 'false' into 'true')
-        void                                    executeMethod(const std::string &n, const std::vector<const DagNode*> &args, boost::dynamic_bitset<> &rv) const; //!< Map the member methods to internal function calls
+        void                                    executeMethod(const std::string &n, const std::vector<const DagNode*> &args, RbVector<Boolean> &rv) const;                                                         //!< Map the member methods to internal function calls
         void                                    executeMethod(const std::string &n, const std::vector<const DagNode*> &args, MatrixBoolean &rv) const;                              //!< Map the member methods to internal function calls
-        boost::dynamic_bitset<>                 getColumn(size_t i) const;      //!< Get the i-th column of the matrix
+        RbVector<Boolean>                       getColumn(size_t i) const;      //!< Get the i-th column of the matrix
         size_t                                  getDim() const;                 //!< Get matrix dimensions on the assumption that it is a square matrix
         size_t                                  getNumberOfColumns(void) const; //!< Get the number of columns for the general case
         size_t                                  getNumberOfRows(void) const;    //!< Get the number of rows for the general case

--- a/src/core/math/distributions/DistributionExponentialError.cpp
+++ b/src/core/math/distributions/DistributionExponentialError.cpp
@@ -65,34 +65,20 @@ double RbStatistics::ExponentialError::lnPdf(const AverageDistanceMatrix &avgDis
         return RbConstants::Double::neginf;
     }
     
-    std::vector<std::string> admNames( avgDistMat.getSize() );
-    for(size_t i = 0; i < admNames.size(); i++)
-    {
-        admNames[i] = avgDistMat.getTaxa()[i].getName();
-    }
-    
-    std::vector<std::string> zNames( z.getSize() );
-    for(size_t i = 0; i < zNames.size(); i++)
-    {
-        zNames[i] = z.getTaxa()[i].getName();
-    }
-    
-    std::vector<uint32_t> ix0 = StringUtilities::stringSortIndices(zNames);
-    std::vector<uint32_t> ix1 = StringUtilities::stringSortIndices(admNames);
+    /* AverageDistanceMatrix objects already have their rows and columns alphabetically sorted,
+     * so there is no need to further align them against each other by index matching (like we
+     * do in the overloaded function below)
+     */
 
     double dist = 0;
 
     for (size_t i = 0; i < avgDistMat.getSize(); i++)
     {
-        uint32_t k = ix0[i];
-        uint32_t m = ix1[i];
         for (size_t j = 0; j < i; j++)
         {
-            uint32_t l = ix0[j];
-            uint32_t n = ix1[j];
-            if (z.getMask()[k][l])
+            if (z.getMask()[i][j])
             {
-                double difference = z.getDistanceMatrix()[k][l] - avgDistMat.getDistanceMatrix()[m][n];
+                double difference = z.getDistanceMatrix()[i][j] - avgDistMat.getDistanceMatrix()[i][j];
                 dist += difference * difference;
             }
         }
@@ -218,28 +204,19 @@ double RbStatistics::ExponentialError::lnPdf(const DistanceMatrix &distMat, doub
         dmNames[i] = distMat.getTaxa()[i].getName();
     }
 
-    std::vector<std::string> zNames( z.getSize() );
-    for(size_t i = 0; i < zNames.size(); i++)
-    {
-        zNames[i] = z.getTaxa()[i].getName();
-    }
-    
-    std::vector<uint32_t> ix0 = StringUtilities::stringSortIndices(zNames);
-    std::vector<uint32_t> ix1 = StringUtilities::stringSortIndices(dmNames);
+    std::vector<uint32_t> ix = StringUtilities::stringSortIndices(dmNames);
     
     double dist = 0;
     
     for (size_t i = 0; i < distMat.getSize(); i++)
     {
-        uint32_t k = ix0[i];
-        uint32_t m = ix1[i];
+        uint32_t k = ix[i];
         for (size_t j = 0; j < i; j++)
         {
-            uint32_t l = ix0[j];
-            uint32_t n = ix1[j];
-            if (z.getMask()[k][l])
+            uint32_t l = ix[j];
+            if (z.getMask()[i][j])
             {
-                double difference = z.getDistanceMatrix()[k][l] - distMat[m][n];
+                double difference = z.getDistanceMatrix()[i][j] - distMat[k][l];
                 dist += difference * difference;
             }
         }

--- a/src/core/utils/TreeUtilities.cpp
+++ b/src/core/utils/TreeUtilities.cpp
@@ -712,6 +712,9 @@ RevBayesCore::AverageDistanceMatrix RevBayesCore::TreeUtilities::getAverageDista
 
     // repopulate the original vector with unique values only
     allNames.assign( uniqueNames.begin(), uniqueNames.end() );
+    
+    // sort alphabetically
+    std::sort( allNames.begin(), allNames.end() );
 
     // initialize the sum and divisor matrices using the size-based constructor:
     RevBayesCore::MatrixReal sumMatrix = MatrixReal( allNames.size() );

--- a/src/revlanguage/datatypes/math/RlMatrixBoolean.cpp
+++ b/src/revlanguage/datatypes/math/RlMatrixBoolean.cpp
@@ -121,7 +121,7 @@ RevPtr<RevVariable> MatrixBoolean::executeMethod(std::string const &name, const 
         const Natural& index = static_cast<const Natural&>( args[0].getVariable()->getRevObject() );
         size_t i = index.getValue() - 1;
         
-        boost::dynamic_bitset<> m = this->dag_node->getValue().getColumn( i );
+        RevBayesCore::RbVector<RevBayesCore::Boolean> m = this->dag_node->getValue().getColumn( i );
         ModelVector< RlBoolean > *bl_vect = new ModelVector< RlBoolean >;
         for(size_t j = 0; j < m.size(); ++j)
         {

--- a/src/revlanguage/datatypes/phylogenetics/RlAverageDistanceMatrix.cpp
+++ b/src/revlanguage/datatypes/phylogenetics/RlAverageDistanceMatrix.cpp
@@ -184,16 +184,22 @@ RevPtr<RevVariable> AverageDistanceMatrix::executeMethod(std::string const &name
             {
                 throw RbException("Index j out of bounds in getElement");
             }
-            
-            // This is a crude solution, but we will coerce the boolean in the second value of the std::pair
-            // to a double so that we can output a Rev vector of two values of the same type. '1.0' stands for
-            // 'true', 0.0 for 'false'.
 
             std::pair<double, bool> element = static_cast< RevBayesCore::AverageDistanceMatrix& >( this->dag_node->getValue() ).getElement(size_t(i.getValue()) - 1, size_t(j.getValue()) - 1);
             
-            ModelVector< Real > *n = new ModelVector< Real >();
-            n->push_back( element.first );
-            n->push_back( (double)element.second );
+            ModelVector<RlString> *n = new ModelVector<RlString>();
+            
+            std::stringstream s;
+            s << "[ " << element.first << ", ";
+            if (element.second)
+            {
+                s << "T ]";
+            }
+            else
+            {
+                s << "F ]";
+            }
+            n->push_back( s.str() );
 
             return new RevVariable( n );
 

--- a/src/revlanguage/datatypes/phylogenetics/RlAverageDistanceMatrix.cpp
+++ b/src/revlanguage/datatypes/phylogenetics/RlAverageDistanceMatrix.cpp
@@ -190,14 +190,14 @@ RevPtr<RevVariable> AverageDistanceMatrix::executeMethod(std::string const &name
             ModelVector<RlString> *n = new ModelVector<RlString>();
             
             std::stringstream s;
-            s << "[ " << element.first << ", ";
+            s << element.first << ", ";
             if (element.second)
             {
-                s << "T ]";
+                s << "TRUE";
             }
             else
             {
-                s << "F ]";
+                s << "FALSE";
             }
             n->push_back( s.str() );
 

--- a/tests/test_avgDistMat/output_expected/Test_avgDistMat.txt
+++ b/tests/test_avgDistMat/output_expected/Test_avgDistMat.txt
@@ -1,31 +1,31 @@
 Print the average distance matrix:
 
 AverageDistanceMatrix with 5 tips. 
-A	0.000 F	0.000 F	2.000 T	1.905 T	1.762 T
-E	0.000 F	0.000 F	2.000 T	2.000 T	2.000 T
-D	2.000 T	2.000 T	0.000 F	1.632 T	1.633 T
-C	1.905 T	2.000 T	1.632 T	0.000 F	1.585 T
-B	1.762 T	2.000 T	1.633 T	1.585 T	0.000 F
+A	0.000 F	1.762 T	1.905 T	2.000 T	0.000 F
+B	1.762 T	0.000 F	1.585 T	1.633 T	2.000 T
+C	1.905 T	1.585 T	0.000 F	1.632 T	2.000 T
+D	2.000 T	1.633 T	1.632 T	0.000 F	2.000 T
+E	0.000 F	2.000 T	2.000 T	2.000 T	0.000 F
 
 Print the element in row 4, column 1:
-[ 1.90471, TRUE ]
+[ 2, TRUE ]
 
 Print the underlying distance matrix:
-[ [ 0.0000, 0.0000, 2.0000, 1.9047, 1.7619 ] ,
-  0.0000, 0.0000, 2.0000, 2.0000, 2.0000 ] ,
-  2.0000, 2.0000, 0.0000, 1.6323, 1.6327 ] ,
-  1.9047, 2.0000, 1.6323, 0.0000, 1.5851 ] ,
-  1.7619, 2.0000, 1.6327, 1.5851, 0.0000 ] ]
+[ [ 0.0000, 1.7619, 1.9047, 2.0000, 0.0000 ] ,
+  1.7619, 0.0000, 1.5851, 1.6327, 2.0000 ] ,
+  1.9047, 1.5851, 0.0000, 1.6323, 2.0000 ] ,
+  2.0000, 1.6327, 1.6323, 0.0000, 2.0000 ] ,
+  0.0000, 2.0000, 2.0000, 2.0000, 0.0000 ] ]
 
 Print the Boolean mask indicating which distances to include in further calculations:
-[ [ F, F, T, T, T ] ,
-  [ F, F, T, T, T ] ,
+[ [ F, T, T, T, F ] ,
+  [ T, F, T, T, T ] ,
   [ T, T, F, T, T ] ,
   [ T, T, T, F, T ] ,
-  [ T, T, T, T, F ] ]
+  [ F, T, T, T, F ] ]
 
 Extract the 1st column of the underlying distance matrix:
-[ 0.000, 0.000, 2.000, 1.905, 1.762 ]
+[ 0.000, 1.762, 1.905, 2.000, 0.000 ]
 
 Extract the 1st column of the Boolean mask:
-[ FALSE, FALSE, TRUE, TRUE, TRUE ]
+[ FALSE, TRUE, TRUE, TRUE, FALSE ]

--- a/tests/test_avgDistMat/output_expected/Test_avgDistMat.txt
+++ b/tests/test_avgDistMat/output_expected/Test_avgDistMat.txt
@@ -1,0 +1,31 @@
+Print the average distance matrix:
+
+AverageDistanceMatrix with 5 tips. 
+A	0.000 F	0.000 F	2.000 T	1.905 T	1.762 T
+E	0.000 F	0.000 F	2.000 T	2.000 T	2.000 T
+D	2.000 T	2.000 T	0.000 F	1.632 T	1.633 T
+C	1.905 T	2.000 T	1.632 T	0.000 F	1.585 T
+B	1.762 T	2.000 T	1.633 T	1.585 T	0.000 F
+
+Print the element in row 4, column 1:
+[ 1.90471, TRUE ]
+
+Print the underlying distance matrix:
+[ [ 0.0000, 0.0000, 2.0000, 1.9047, 1.7619 ] ,
+  0.0000, 0.0000, 2.0000, 2.0000, 2.0000 ] ,
+  2.0000, 2.0000, 0.0000, 1.6323, 1.6327 ] ,
+  1.9047, 2.0000, 1.6323, 0.0000, 1.5851 ] ,
+  1.7619, 2.0000, 1.6327, 1.5851, 0.0000 ] ]
+
+Print the Boolean mask indicating which distances to include in further calculations:
+[ [ F, F, T, T, T ] ,
+  [ F, F, T, T, T ] ,
+  [ T, T, F, T, T ] ,
+  [ T, T, T, F, T ] ,
+  [ T, T, T, T, F ] ]
+
+Extract the 1st column of the underlying distance matrix:
+[ 0.000, 0.000, 2.000, 1.905, 1.762 ]
+
+Extract the 1st column of the Boolean mask:
+[ FALSE, FALSE, TRUE, TRUE, TRUE ]

--- a/tests/test_avgDistMat/scripts/Test_avgDistMat.Rev
+++ b/tests/test_avgDistMat/scripts/Test_avgDistMat.Rev
@@ -1,0 +1,59 @@
+################################################################################
+#
+# RevBayes Test-Script: Constructing and subsetting an average distance matrix
+#
+#
+# authors: David Cerny
+#
+################################################################################
+
+seed(12345)
+
+################################################################################
+# Create a 5-by-5 average distance matrix from two 4-tip source trees with 
+# partially overlapping taxon sets
+################################################################################
+
+speciation <- 0.1
+extinction <- 0.09
+tree_height <- 1.0
+
+taxa1 <- [taxon("A"), taxon("B"), taxon("C"), taxon("D")]
+taxa2 <- [taxon("B"), taxon("C"), taxon("D"), taxon("E")]
+
+tree1 ~ dnBDP(lambda=speciation, mu=extinction, rootAge=tree_height, condition="nTaxa", taxa=taxa1)
+tree2 ~ dnBDP(lambda=speciation, mu=extinction, rootAge=tree_height, condition="nTaxa", taxa=taxa2)
+
+distMatrices[1] := fnTreePairwiseDistances(tree1)
+distMatrices[2] := fnTreePairwiseDistances(tree2)
+
+ADM := fnAverageDistanceMatrix(distMatrices)
+
+print(filename = "output/Test_avgDistMat.txt", append = FALSE,
+      "Print the average distance matrix:\n")
+print(filename = "output/Test_avgDistMat.txt", append = TRUE, ADM)
+
+print(filename = "output/Test_avgDistMat.txt", append = TRUE, "Print the element in row 4, column 1:\n")
+print(filename = "output/Test_avgDistMat.txt", append = TRUE, ADM.getElement(4, 1))
+print(filename = "output/Test_avgDistMat.txt", append = TRUE, "\n\n")
+
+dm := ADM.distanceMatrix().matrix()
+msk := ADM.mask()
+
+print(filename = "output/Test_avgDistMat.txt", append = TRUE, "Print the underlying distance matrix:\n")
+print(filename = "output/Test_avgDistMat.txt", append = TRUE, dm)
+print(filename = "output/Test_avgDistMat.txt", append = TRUE, "\n\n")
+
+print(filename = "output/Test_avgDistMat.txt", append = TRUE, "Print the Boolean mask indicating which distances to include in further calculations:\n")
+print(filename = "output/Test_avgDistMat.txt", append = TRUE, msk)
+print(filename = "output/Test_avgDistMat.txt", append = TRUE, "\n\n")
+
+print(filename = "output/Test_avgDistMat.txt", append = TRUE, "Extract the 1st column of the underlying distance matrix:\n")
+print(filename = "output/Test_avgDistMat.txt", append = TRUE, dm[1])
+print(filename = "output/Test_avgDistMat.txt", append = TRUE, "\n\n")
+
+print(filename = "output/Test_avgDistMat.txt", append = TRUE, "Extract the 1st column of the Boolean mask:\n")
+print(filename = "output/Test_avgDistMat.txt", append = TRUE, msk[1])
+clear()
+
+q()


### PR DESCRIPTION
This PR is primarily intended to fix issue #468. Specifically, it makes the following three changes:

1. The type of the `rv` argument of one of the `executeMethod(...)` utility functions of class `MatrixBoolean` has been changed from `boost::dynamic_bitset<>` to `RbVector<Boolean>`.
2. The `.getElement()` method of class `AverageDistanceMatrix` returns a vector that no longer contains two doubles but rather a single string. This makes for nicer printing: instead of `[ 1.905, 1.000 ]`, we now get `[ 1.90471, TRUE ]`, which better indicates what's going on (i.e., each element of `AverageDistanceMatrix` is a numeric value associated with a Boolean that indicates whether or not this value should be used in further calculations).
3. A test (based on the script from #468) has been added to showcase these changes.

Interestingly, change (1) results in a very slight but consistent drop in the performance of `ExponentialError::lnPdf` (by about ~50 ms for 10,000-by-10,000 matrices), which I previously did my best to optimize (see #432, #434). It's not clear to me why: that function does subset a `MatrixBoolean` object at one point (see [here](https://github.com/revbayes/revbayes/blob/8bcc503a10936e8ef1c3ee095c9c31b0ee35a8bf/src/core/math/distributions/DistributionExponentialError.cpp#L240)), but it doesn't do so at the Rev level, i.e., it doesn't employ the `executeMethod` utility function to do it. Instead, it uses a lower-level operator which still returns `boost::dynamic_bitset<>`. However, the time difference is small enough that in any actual analysis of average distance matrices, it seems to be absorbed by the stochastic variation in the time it takes to convert a tree to a distance matrix – overall, there is no clear performance hit.