### PR TITLE
Fixing issue with simulation under ACRV and variable coding

### DIFF
--- a/src/core/distributions/phylogenetics/substitution/PhyloCTMCSiteHomogeneousConditional.h
+++ b/src/core/distributions/phylogenetics/substitution/PhyloCTMCSiteHomogeneousConditional.h
@@ -1048,8 +1048,9 @@ void RevBayesCore::PhyloCTMCSiteHomogeneousConditional<charType>::redrawValue( v
 
     // sample the rate categories in proportion to the total probability (correction) for each mixture.
     double total = 0.0;
+    std::vector<double> mixtureProbs = this->getMixtureProbs();
     for ( size_t i = 0; i < this->num_site_mixtures; ++i )
-        total += perMaskMixtureCorrections[i];
+        total += mixtureProbs[i];
 
     std::vector<size_t> perSiteRates;
     for ( size_t i = 0; i < this->num_sites; ++i )
@@ -1061,7 +1062,7 @@ void RevBayesCore::PhyloCTMCSiteHomogeneousConditional<charType>::redrawValue( v
         double tmp = 0.0;
         while(tmp < u)
         {
-            tmp += perMaskMixtureCorrections[rateIndex];
+            tmp += mixtureProbs[rateIndex];
             if (tmp < u)
                 rateIndex++;
         }


### PR DESCRIPTION
There was previously an issue that mainly manifested itself when using posterior predictive simulations. The problem was that the site rate categories were not correctly drawn in the PhyloCTMC when it condition on variable coding. This is fixed now.