### PR TITLE
Fix issue #354 once again

### DIFF
--- a/src/core/distributions/phylogenetics/tree/birthdeath/BirthDeathSamplingTreatmentProcess.cpp
+++ b/src/core/distributions/phylogenetics/tree/birthdeath/BirthDeathSamplingTreatmentProcess.cpp
@@ -165,17 +165,32 @@ BirthDeathSamplingTreatmentProcess::BirthDeathSamplingTreatmentProcess(const Typ
     // updateVectorParameters();
     prepareTimeline();
     prepareProbComputation();
+    
+    delete value;
 
     if ( starting_tree == NULL )
     {
-        delete value;
-        
         RbVector<Clade> constr;
         // We employ a coalescent simulator to guarantee that the starting tree matches all time constraints
         StartingTreeSimulator simulator;
         RevBayesCore::Tree *my_tree = simulator.simulateTree( taxa, constr );
         // store the new value
         value = my_tree;
+    }
+    else
+    {
+        try
+        {
+            RevBayesCore::Tree *my_tree = TreeUtilities::startingTreeInitializer( *t, taxa, age_check_precision );
+            value = my_tree->clone();
+        }
+        catch (RbException &e)
+        {
+            value = nullptr;
+            // The line above is to prevent a segfault when ~AbstractRootedTreeDistribution() tries to delete
+            // a nonexistent starting_tree
+            throw RbException( e.getMessage() );
+        }
     }
 
     countAllNodes();


### PR DESCRIPTION
This PR restores the starting tree code in `BirthDeathSamplingTreatmentProcess.cpp`, which was introduced there in PR #386 to fix issue #354, but which was then (accidentally, it seems) removed in PR #399. As a result, it's once again possible to sample fossil ages from their respective priors even when a user-supplied starting tree is employed, and the starting tree is checked for compatibility with fossil ages.