### PR TITLE
Sampling fossil ages with dnConstrainedTopology + initial tree

### DIFF
--- a/src/core/distributions/phylogenetics/tree/TopologyConstrainedTreeDistribution.cpp
+++ b/src/core/distributions/phylogenetics/tree/TopologyConstrainedTreeDistribution.cpp
@@ -27,6 +27,7 @@
 #include "Tree.h"
 #include "TreeChangeEventHandler.h"
 #include "TreeChangeEventMessage.h"
+#include "TreeUtilities.h"
 #include "TypedDagNode.h"
 #include "TypedDistribution.h"
 
@@ -44,7 +45,10 @@ using namespace RevBayesCore;
  *
  * \param[in]    c         Clade constraints.
  */
-TopologyConstrainedTreeDistribution::TopologyConstrainedTreeDistribution(TypedDistribution<Tree>* base_dist, const std::vector<Clade> &c, Tree *t) : TypedDistribution<Tree>( NULL ),
+TopologyConstrainedTreeDistribution::TopologyConstrainedTreeDistribution(TypedDistribution<Tree>* base_dist,
+                                                                          const std::vector<Clade> &c,
+                                                                          Tree *t,
+                                                                          long age_check_precision = 4) : TypedDistribution<Tree>( NULL ),
 //    active_backbone_clades( base_dist->getValue().getNumberOfInteriorNodes(), RbBitSet() ),
     active_clades( base_dist->getValue().getNumberOfInteriorNodes(), RbBitSet() ),
     backbone_topology(NULL),
@@ -71,6 +75,42 @@ TopologyConstrainedTreeDistribution::TopologyConstrainedTreeDistribution(TypedDi
     }
     
     value = &base_distribution->getValue();
+    
+    // Are there any fossils in the starting tree?
+    if (starting_tree != NULL)
+    {
+        std::vector<bool> fossils;
+        for (size_t i = 0; i < t->getNumberOfTips(); ++i)
+        {
+            TopologyNode* node = &t->getNode(i);
+            fossils.push_back( node->isFossil() );
+        }
+        
+        bool no_fossil = std::none_of(fossils.begin(), fossils.end(), [](bool v) { return v; });
+        
+        std::cout << "No fossils found in the starting tree: " << no_fossil << std::endl;
+        
+        if (!no_fossil)
+        {
+            delete value;
+            
+            AbstractRootedTreeDistribution* tree_base_distribution = dynamic_cast<AbstractRootedTreeDistribution*>( base_distribution );
+            std::vector<Taxon> taxa = tree_base_distribution->getTaxa();
+            
+            try
+            {
+                RevBayesCore::Tree *my_tree = TreeUtilities::startingTreeInitializer( *t, taxa, age_check_precision );
+                value = my_tree->clone();
+            }
+            catch (RbException &e)
+            {
+                value = nullptr;
+                // The line above is to prevent a segfault when ~AbstractRootedTreeDistribution() tries to delete
+                // a nonexistent starting_tree
+                throw RbException( e.getMessage() );
+            }
+        }
+    }
     
     initializeBitSets();
     redrawValue( SimulationCondition::MCMC );

--- a/src/core/distributions/phylogenetics/tree/TopologyConstrainedTreeDistribution.cpp
+++ b/src/core/distributions/phylogenetics/tree/TopologyConstrainedTreeDistribution.cpp
@@ -88,8 +88,6 @@ TopologyConstrainedTreeDistribution::TopologyConstrainedTreeDistribution(TypedDi
         
         bool no_fossil = std::none_of(fossils.begin(), fossils.end(), [](bool v) { return v; });
         
-        std::cout << "No fossils found in the starting tree: " << no_fossil << std::endl;
-        
         if (!no_fossil)
         {
             delete value;

--- a/src/core/distributions/phylogenetics/tree/TopologyConstrainedTreeDistribution.cpp
+++ b/src/core/distributions/phylogenetics/tree/TopologyConstrainedTreeDistribution.cpp
@@ -48,7 +48,7 @@ using namespace RevBayesCore;
 TopologyConstrainedTreeDistribution::TopologyConstrainedTreeDistribution(TypedDistribution<Tree>* base_dist,
                                                                           const std::vector<Clade> &c,
                                                                           Tree *t,
-                                                                          long age_check_precision = 4) : TypedDistribution<Tree>( NULL ),
+                                                                          long age_check_precision) : TypedDistribution<Tree>( NULL ),
 //    active_backbone_clades( base_dist->getValue().getNumberOfInteriorNodes(), RbBitSet() ),
     active_clades( base_dist->getValue().getNumberOfInteriorNodes(), RbBitSet() ),
     backbone_topology(NULL),

--- a/src/core/distributions/phylogenetics/tree/TopologyConstrainedTreeDistribution.h
+++ b/src/core/distributions/phylogenetics/tree/TopologyConstrainedTreeDistribution.h
@@ -15,7 +15,7 @@ namespace RevBayesCore {
     class TopologyConstrainedTreeDistribution : public TypedDistribution<Tree>, TreeChangeEventListener {
         
     public:
-        TopologyConstrainedTreeDistribution(TypedDistribution<Tree>* base_dist, const std::vector<Clade> &c, Tree *t);
+        TopologyConstrainedTreeDistribution(TypedDistribution<Tree>* base_dist, const std::vector<Clade> &c, Tree *t, long age_check_precision);
         TopologyConstrainedTreeDistribution(const TopologyConstrainedTreeDistribution &d);
         
         virtual ~TopologyConstrainedTreeDistribution(void);

--- a/src/revlanguage/distributions/phylogenetics/tree/Dist_ConstrainedTopology.cpp
+++ b/src/revlanguage/distributions/phylogenetics/tree/Dist_ConstrainedTopology.cpp
@@ -93,8 +93,15 @@ RevBayesCore::TopologyConstrainedTreeDistribution* Dist_ConstrainedTopology::cre
         init = static_cast<const TimeTree &>( initial_tree->getRevObject() ).getDagNode()->getValue().clone();
     }
     
+    // number of decimal places to use when checking the initial tree against taxon ages
+    long pr = NULL;
+    if ( age_check_precision != NULL )
+    {
+        pr = static_cast<const Natural &>( age_check_precision->getRevObject() ).getValue();
+    }
+    
     // create the internal distribution object
-    RevBayesCore::TopologyConstrainedTreeDistribution* dist = new RevBayesCore::TopologyConstrainedTreeDistribution(base, c, init); // , bb);
+    RevBayesCore::TopologyConstrainedTreeDistribution* dist = new RevBayesCore::TopologyConstrainedTreeDistribution(base, c, init, pr); // , bb);
     
     if (backbone == NULL && backbone->getRevObject() != RevNullObject::getInstance()) {
         ; // do nothing
@@ -192,6 +199,7 @@ const MemberRules& Dist_ConstrainedTopology::getParameterRules(void) const
         member_rules.push_back( new ArgumentRule( "treeDistribution", TypedDistribution<TimeTree>::getClassTypeSpec(), "The base distribution for the tree.",   ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
         member_rules.push_back( new ArgumentRule( "constraints",      ModelVector<Clade>::getClassTypeSpec(),          "The topological constraints.",          ArgumentRule::BY_VALUE, ArgumentRule::ANY, new ModelVector<Clade>() ) );
         member_rules.push_back( new ArgumentRule( "initialTree" ,     TimeTree::getClassTypeSpec() , "Instead of drawing a tree from the distribution, initialize distribution with this tree.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, NULL ) );
+        member_rules.push_back( new ArgumentRule( "ageCheckPrecision", Natural::getClassTypeSpec(), "If an initial tree is provided, how many decimal places should be used when checking its tip ages against a taxon file?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new Natural(4) ) );
 
         std::vector<TypeSpec> backboneTypes;
         backboneTypes.push_back( TimeTree::getClassTypeSpec() );
@@ -249,6 +257,10 @@ void Dist_ConstrainedTopology::setConstParameter(const std::string& name, const 
     else if ( name == "initialTree" )
     {
         initial_tree = var;
+    }
+    else if ( name == "ageCheckPrecision" )
+    {
+        age_check_precision = var;
     }
     else
     {

--- a/src/revlanguage/distributions/phylogenetics/tree/Dist_ConstrainedTopology.h
+++ b/src/revlanguage/distributions/phylogenetics/tree/Dist_ConstrainedTopology.h
@@ -46,6 +46,7 @@ namespace RevLanguage {
         RevPtr<const RevVariable>                           backbone;
         RevPtr<const RevVariable>                           invert_constraint;                                                                      //!< Boolean indicating whether topologies are rooted
         RevPtr<const RevVariable>                           initial_tree;
+        RevPtr<const RevVariable>                           age_check_precision;                                                                    //!< Number of decimal places to use when checking the initial tree against taxon ages
     };
 }
 

--- a/src/revlanguage/distributions/phylogenetics/tree/Dist_ConstrainedUnrootedTopology.cpp
+++ b/src/revlanguage/distributions/phylogenetics/tree/Dist_ConstrainedUnrootedTopology.cpp
@@ -92,8 +92,14 @@ RevBayesCore::TopologyConstrainedTreeDistribution* Dist_ConstrainedUnrootedTopol
         init = static_cast<const BranchLengthTree &>( initial_tree->getRevObject() ).getDagNode()->getValue().clone();
     }
     
+    /* Since an unrooted topology is not a time tree, its tips are not associated with times that would require checking.
+     * Therefore, this distribution has no user-facing (= Rev-level) "age check precision" argument, but because
+     * TopologyConstrainedTreeDistribution expects one, here we set it to NULL and pass it to the constructor.
+     */
+    long pr = NULL;
+    
     // create the internal distribution object
-    RevBayesCore::TopologyConstrainedTreeDistribution* dist = new RevBayesCore::TopologyConstrainedTreeDistribution(base, c, init); // , bb);
+    RevBayesCore::TopologyConstrainedTreeDistribution* dist = new RevBayesCore::TopologyConstrainedTreeDistribution(base, c, init, pr); // , bb);
     
     if (backbone == NULL && backbone->getRevObject() != RevNullObject::getInstance())
     {


### PR DESCRIPTION
This PR is intended to fix issue #477, which turned out to be essentially the same as issue #354 except that it affected `dnConstrainedTopology` rather than `dnBDSTP`: supplying a user-specified initial tree overwrote the ages of fossil taxa (min = max = 0), making it impossible to sample them from the [min, max] intervals specified in a taxon info file. I have added extra code to the `TopologyConstrainedTreeDistribution` constructor that checks whether a starting tree is present and whether it contains fossils. If both of these conditions are satisfied, it runs `TreeUtilities::startingTreeInitializer()` on the initial tree to replace each of its tips with the previously specified taxon of the same name. As with `dnBDSTP`, a new `ageCheckPrecision` argument has been added to specify how strict we should be when assessing whether the ages of the fossils in the initial tree are compatible with the age ranges specified in the taxon info file.

I have verified that the code works as intended, and that it doesn't affect other uses of `dnConstrainedTopology` (e.g., when it is used for non-clock trees).