### PR TITLE
Add `build/` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ src/generated_include_dirs.cmake
 src/*/CMakeLists.txt
 
 # ----------------------------------------------
+build/
 projects/cmake/*
 !projects/cmake/README.txt
 !projects/cmake/*.sh

--- a/.gitignore
+++ b/.gitignore
@@ -39,10 +39,19 @@ doxygen/DoxygenWarningLog.txt
 .project
 .settings/
 .vscode
+*.tlog
+*.filters
+*.vcxproj
+*.stamp
+*.depend
+*.obj
+*.sln
+*.recipe
 revbayes.code-workspace
 
 #--------- Backups -----------
 *.orig
+*.bak
 *GitVersion_backup.cpp
 *~
 *#


### PR DESCRIPTION
https://revbayes.github.io/developer/setup/ tells the user to add `build/` to `.gitignore`; but as the repo does not contain any tracked files in the `build/` directory, it's not clear why `build/` shouldn't just be included in the default `.gitignore` file.

This would also simplify the process of switching between branches using Git.