### PR TITLE
Missing `S` in `Boost_INCLUDE_DIRS`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -159,7 +159,7 @@ filesystem
 date_time
 serialization REQUIRED)
 MESSAGE("Boost configuration results:")
-MESSAGE("  Boost_INCLUDE_DIRS: ${Boost_INCLUDE_DIR}")
+MESSAGE("  Boost_INCLUDE_DIRS: ${Boost_INCLUDE_DIRS}")
 MESSAGE("  Boost_LIBRARY_DIRS: ${Boost_LIBRARY_DIRS}")
 MESSAGE("  Boost_LIBRARIES: ${Boost_LIBRARIES}")
 LINK_DIRECTORIES(${Boost_LIBRARY_DIRS})


### PR DESCRIPTION
Reported variable should match message.

I believe `S` is intended to match the output of `find_package()`.

https://stackoverflow.com/questions/63660054/cmake-finds-boost-but-boost-include-dir-is-not-set