### PR TITLE
Big object support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,11 +7,13 @@ project(RevBayes)
 
 set(CMAKE_CXX_STANDARD 17)
 
-# Congifure compiler to support big objects
-if(MSVC)
-  add_compile_options(/W4 /EHsc /bigobj)
-else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wa,-mbig-obj")
+if(WIN32)
+  # Congifure compiler to support big objects
+  if(MSVC)
+    add_compile_options(/W4 /EHsc /bigobj)
+  else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wa,-mbig-obj")
+  endif()
 endif()
 
 find_program(CCACHE_PROGRAM ccache)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,13 @@ project(RevBayes)
 
 set(CMAKE_CXX_STANDARD 17)
 
+# Congifure compiler to support big objects
+if(MSVC)
+  add_compile_options(/W4 /EHsc /bigobj)
+else()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wa,-mbig-obj")
+endif()
+
 find_program(CCACHE_PROGRAM ccache)
 if(CCACHE_PROGRAM)
   set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${CCACHE_PROGRAM}")


### PR DESCRIPTION
Big object support was necessary for me to build RevBayes.

The MSVC option is potentially unnecessary – I didn't end up getting RevBayes to build under msvc.