### PR TITLE
Boost_INCLUDE_DIR*S*

### DIFF
--- a/projects/cmake/regenerate.sh
+++ b/projects/cmake/regenerate.sh
@@ -32,7 +32,7 @@ INCLUDE_DIRECTORIES('
         sort |
         uniq |
         sed 's|^|    ${PROJECT_SOURCE_DIR}/|g'
-    echo ' ${Boost_INCLUDE_DIR} )
+    echo ' ${Boost_INCLUDE_DIRS} )
 '
 ) > "$SRC_DIR/generated_include_dirs.cmake"
 


### PR DESCRIPTION
Another instance of the typo addressed in #491 – this time causing boost libraries not to be included via `generated_include_dirs.cmake`