### PR TITLE
Fix mixture distribution.

### DIFF
--- a/src/core/distributions/MixtureDistribution.h
+++ b/src/core/distributions/MixtureDistribution.h
@@ -83,7 +83,7 @@ RevBayesCore::MixtureDistribution<mixtureType>::MixtureDistribution(const TypedD
     this->addParameter( parameter_values );
     this->addParameter( probabilities );
     
-    *this->value = simulate();
+    redrawValue();
 }
 
 


### PR DESCRIPTION
The initial value of MixtureDistribution objects wasn't getting set correctly.