### PR TITLE
Avoid crashing if a file changes while we are source( )-ing it.

### DIFF
--- a/src/core/utils/RbFileManager.cpp
+++ b/src/core/utils/RbFileManager.cpp
@@ -10,6 +10,7 @@
 
 #include "RbFileManager.h"
 #include "RbSettings.h"
+#include "RbException.h"
 #include "StringUtilities.h"
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
@@ -248,4 +249,22 @@ bool setStringWithNamesOfFilesInDirectory(const path& dirpath, std::vector<path>
     
     return true;
 }
+
+std::stringstream readFileAsStringStream(const path& fname)
+{
+    std::ifstream inFile(fname.string());
+    if ( not inFile )
+        throw RbException()<<"Could not open file "<<fname<<".";
+
+    std::stringstream strStream;
+    strStream << inFile.rdbuf(); //read the file
+    return strStream;
+}
+
+std::string readFileAsString(const path& fname)
+{
+    return readFileAsStringStream(fname).str();
+}
+
+
 }

--- a/src/core/utils/RbFileManager.h
+++ b/src/core/utils/RbFileManager.h
@@ -20,6 +20,9 @@ namespace RevBayesCore {
     void                    formatError(const path& p, std::string& errorStr);  //!< Format the error string when (mis)reading files
 
     void                    createDirectoryForFile(const path& p);
+
+    std::stringstream       readFileAsStringStream(const path& fname);
+    std::string             readFileAsString(const path& fname);
 }
 
 #endif

--- a/src/revlanguage/functions/io/Func_source.cpp
+++ b/src/revlanguage/functions/io/Func_source.cpp
@@ -21,8 +21,11 @@
 #include "RevVariable.h"
 #include "RlBoolean.h"
 #include "RlFunction.h"
+#include <boost/filesystem/path.hpp>
 
 using namespace RevLanguage;
+
+namespace fs = boost::filesystem;
 
 /** Default constructor */
 Func_source::Func_source( void ) : Procedure()
@@ -43,28 +46,22 @@ Func_source* Func_source::clone( void ) const
     return new Func_source( *this );
 }
 
-
 /** Execute function */
 RevPtr<RevVariable> Func_source::execute( void )
 {
     
     /* Open file */
-    std::string fname = static_cast<const RlString &>( args[0].getVariable()->getRevObject() ).getValue();
+    fs::path fname = static_cast<const RlString &>( args[0].getVariable()->getRevObject() ).getValue();
 
-    std::ifstream inFile(fname);
+    std::stringstream inFile = RevBayesCore::readFileAsStringStream(fname);
 
     bool echo_on = static_cast<const RlBoolean &>( args[1].getVariable()->getRevObject() ).getValue();
-    
-    if ( !inFile )
-    {
-        throw RbException( "Could not open file \"" + fname + "\"" );
-    }
     
     // Initialize
     std::string commandLine;
     int lineNumber = 0;
     int result = 0;     // result from processing of last command
-    RBOUT("Processing file \"" + fname + "\"");
+    RBOUT("Processing file \"" + fname.string() + "\"");
     
     // Command-processing loop
     while ( inFile.good() )
@@ -111,7 +108,7 @@ RevPtr<RevVariable> Func_source::execute( void )
     }
     
     // Return control 
-    RBOUT("Processing of file \"" + fname + "\" completed");
+    RBOUT("Processing of file \"" + fname.string() + "\" completed");
     
     return NULL;
 }


### PR DESCRIPTION
We can simply read the whole file into a string and execute the string.  That way the execution sees the way the file looked when we ran the source command.