### PR TITLE
Making RealPos type coherent between conversion and construction

### DIFF
--- a/src/revlanguage/datatypes/basic/Integer.cpp
+++ b/src/revlanguage/datatypes/basic/Integer.cpp
@@ -127,7 +127,7 @@ RevObject* Integer::convertTo( const TypeSpec& type ) const
         return new RlString( o.str() );
     }
 
-    if ( type == RealPos::getClassTypeSpec() && dag_node->getValue() > 0 ) return RlUtils::RlTypeConverter::convertTo<Integer,RealPos>(this);
+    if ( type == RealPos::getClassTypeSpec() && dag_node->getValue() >= 0 ) return RlUtils::RlTypeConverter::convertTo<Integer,RealPos>(this);
     if ( type == IntegerPos::getClassTypeSpec() && dag_node->getValue() > 0) return RlUtils::RlTypeConverter::convertTo<Integer,IntegerPos>(this);
     if ( type == Natural::getClassTypeSpec() && dag_node->getValue() >= 0) return RlUtils::RlTypeConverter::convertTo<Integer,Natural>(this);
     

--- a/src/revlanguage/datatypes/basic/IntegerPos.h
+++ b/src/revlanguage/datatypes/basic/IntegerPos.h
@@ -13,9 +13,9 @@ namespace RevLanguage {
     class RealPos;
 
     /**
-     * Primitive type for positive integer numbers (same as Natural without 0).
+     * Primitive type for strictly positive integer numbers (same as Natural without 0).
      *
-     * Note that we derive this from Ntaural. To make
+     * Note that we derive this from Natural. To make
      * sure inheritance is safe, we restrict the range
      * of positive integers numbers from 1 to INT_MAX
      */

--- a/src/revlanguage/datatypes/basic/Natural.h
+++ b/src/revlanguage/datatypes/basic/Natural.h
@@ -13,7 +13,7 @@ namespace RevLanguage {
     class RealPos;
 
     /**
-     * Primitive type for Natural numbers (including 0).
+     * Primitive type for Natural numbers (positive integers including 0).
      *
      * Note that we derive this from Integer. To make
      * sure inheritance is safe, we restrict the range

--- a/src/revlanguage/datatypes/basic/Real.cpp
+++ b/src/revlanguage/datatypes/basic/Real.cpp
@@ -143,7 +143,7 @@ RevObject* Real::convertTo( const TypeSpec& type ) const
 
     if ( type == RlBoolean::getClassTypeSpec() ) return RlUtils::RlTypeConverter::convertTo<Real,RlBoolean>(this);
 
-    if ( type == RealPos::getClassTypeSpec() && dag_node->getValue() > 0.0) return RlUtils::RlTypeConverter::convertTo<Real,RealPos>(this);
+    if ( type == RealPos::getClassTypeSpec() && dag_node->getValue() >= 0.0) return RlUtils::RlTypeConverter::convertTo<Real,RealPos>(this);
     if ( type == Probability::getClassTypeSpec() && dag_node->getValue() >= 0.0 && dag_node->getValue() <= 1.0) 
         return RlUtils::RlTypeConverter::convertTo<Real,Probability>(this);
     

--- a/src/revlanguage/datatypes/basic/RealPos.h
+++ b/src/revlanguage/datatypes/basic/RealPos.h
@@ -1,18 +1,3 @@
-/**
- * @file
- * This file contains the declaration of RealPos, which
- * is the primitive RevBayes type for positive real numbers.
- *
- * @brief Declaration of RealPos
- *
- * (c) Copyright 2009-
- * @date Last modified: $Date$
- * @author The RevBayes Development Core Team
- * @license GPL version 3
- *
- * $Id$
- */
-
 #ifndef RealPos_H
 #define RealPos_H
 
@@ -25,6 +10,9 @@ namespace RevLanguage {
 
     class Natural;
     
+    /** Primitive type for real positive numbers (i.e. >= 0) 
+     * NB: the equivalent integer class is Natural, not IntegerPos (which excludes 0)
+    */
     class RealPos : public Real {
 
         public:


### PR DESCRIPTION
As noted in issue #99 there is a debate as to whether RealPos should be >=0 or >0 and right now the constructors assume the first and the conversions the second
I don't have a strong opinion either way but it should at least be coherent, so this PR aligns all behaviour to >=0 and documents it

Also fixes `sqrt` bug from #99