### PR TITLE
Retain cache when switching branches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,8 @@ src/generated_include_dirs.cmake
 src/*/CMakeLists.txt
 
 # ----------------------------------------------
-build/
+/build/*
+!/build/.gitkeep
 projects/cmake/*
 !projects/cmake/README.txt
 !projects/cmake/*.sh

--- a/build/.gitkeep
+++ b/build/.gitkeep
@@ -1,0 +1,1 @@
+This file ensures that cached build files are retained when switching branches.


### PR DESCRIPTION
[Adding `build/` to `.gitignore`](https://github.com/revbayes/revbayes/commit/6f2a02d2f93e4790e919c15619739238f1d7ce74) causes the cached build artefacts to be lost when switching branches, meaning that rb must be built from scratch whenever moving to a new branch. 

I believe that these modifications should cause the `build` directory to be retained when switching branches.  The content of the `.gitkeep` file is arbitrary – I felt a brief explanation was more useful than a blank file.