### PR TITLE
Another `time()` doc fix

### DIFF
--- a/help/md/time.md
+++ b/help/md/time.md
@@ -13,7 +13,7 @@ Get the current system time.
 
 "(milli)seconds" returns the number of (milli)seconds that have elapsed since midnight.
 
-"fromBeginning", the default, returns the number of milliseconds that have elapsed since 1 January 1970, the start of the Unix epoch.
+"fromBeginning", the default, returns the number of milliseconds that have elapsed since 1400-Jan-01 00:00:00, the earliest representable date in the boost library's implementation of the Gregorian date system.
 
 ## authors
 Sebastian Hoehna

--- a/help/md/time.md
+++ b/help/md/time.md
@@ -3,8 +3,18 @@ time
 ## title
 Get the time information
 ## description
-Get the current system time in milliseconds.
+Get the current system time.
+
 ## details
+
+"year" reports the current year in the Julian calendar.
+
+"day" returns the index of the day in the year (e.g. Jan 1 = 1; Feb 1 = 32).
+
+"(milli)seconds" returns the number of (milli)seconds that have elapsed since midnight.
+
+"fromBeginning", the default, returns the number of milliseconds that have elapsed since 1 January 1970, the start of the Unix epoch.
+
 ## authors
 Sebastian Hoehna
 ## see_also

--- a/help/md/time.md
+++ b/help/md/time.md
@@ -7,7 +7,7 @@ Get the current system time.
 
 ## details
 
-"year" reports the current year in the Julian calendar.
+"year" reports the current year (e.g. 2000).
 
 "day" returns the index of the day in the year (e.g. Jan 1 = 1; Feb 1 = 32).
 


### PR DESCRIPTION
`time("fromBeginning")` counts milliseconds since 1400-Jan-01, not 1970-Jan-01.