### PR TITLE
Debug mcmc

### DIFF
--- a/src/core/analysis/mcmc/Mcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmc.cpp
@@ -30,6 +30,7 @@
 #include "RbIteratorImpl.h"
 #include "RbVector.h"
 #include "RbVectorImpl.h"
+#include "RbSettings.h" // for logMCMC setting
 #include "StringUtilities.h"
 
 #ifdef RB_MPI
@@ -940,6 +941,7 @@ void Mcmc::monitor(unsigned long g)
 
 void Mcmc::nextCycle(bool advance_cycle)
 {
+    int logMCMC = RbSettings::userSettings().getLogMCMC();
 
     size_t proposals = size_t( round( schedule->getNumberMovesPerIteration() ) );
     
@@ -948,6 +950,9 @@ void Mcmc::nextCycle(bool advance_cycle)
         
         // Get the move
         Move& the_move = schedule->nextMove( generation );
+
+	if (logMCMC >= 1)
+	    std::cerr<<"\ngeneration = "<<generation<<"    proposal = "<<i+1<<"/"<<proposals<<"    "<<the_move.getMoveName()<<"("<<the_move.getDagNodes()[0]->getName()<<")\n";
 
         // Perform the move
         the_move.performMcmcStep( chain_prior_heat, chain_likelihood_heat, chain_posterior_heat );

--- a/src/core/analysis/mcmc/Mcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmc.cpp
@@ -952,7 +952,13 @@ void Mcmc::nextCycle(bool advance_cycle)
         Move& the_move = schedule->nextMove( generation );
 
 	if (logMCMC >= 1)
-	    std::cerr<<"\ngeneration = "<<generation<<"    proposal = "<<i+1<<"/"<<proposals<<"    "<<the_move.getMoveName()<<"("<<the_move.getDagNodes()[0]->getName()<<")\n";
+	{
+	    std::vector<std::string> node_names;
+	    for(auto node: the_move.getDagNodes())
+		node_names.push_back(node->getName());
+
+	    std::cerr<<"\ngeneration = "<<generation<<"    proposal = "<<i+1<<"/"<<proposals<<"    "<<the_move.getMoveName()<<"("<<StringUtilities::join(node_names,",")<<")\n";
+	}
 
         // Perform the move
         the_move.performMcmcStep( chain_prior_heat, chain_likelihood_heat, chain_posterior_heat );

--- a/src/core/help/RbHelpDatabase.cpp
+++ b/src/core/help/RbHelpDatabase.cpp
@@ -346,18 +346,18 @@ mymcmc.run(generations=200000))");
 	help_arrays[string("dnBivariatePoisson")][string("authors")].push_back(string(R"(Sebastian Hoehna)"));
 	help_strings[string("dnBivariatePoisson")][string("description")] = string(R"(A Bivariate Poisson distribution defines probabilities for pairs of natural numbers.)");
 	help_strings[string("dnBivariatePoisson")][string("example")] = string(R"(th0 ~ dnUniform(0.0, 10.0)
-th1 ~ dnUniform(0.0, 10.0)
-th2 ~ dnUniform(0.0, 10.0)
-x ~ dnBivariatePoisson(th0, th1, th2)
-x.clamp([3, 3, 3])
-moves[1] = mvSlide(th0, delta=0.01, weight=1.0)
-moves[2] = mvSlide(th1, delta=0.01, weight=1.0)
-moves[3] = mvSlide(th2, delta=0.01, weight=1.0)
-monitors[1] = mnScreen(printgen=20000, th0)
-mymodel = model(th1)
-mymcmc = mcmc(mymodel, monitors, moves)
-mymcmc.burnin(generations=20000, tuningInterval=100)
-mymcmc.run(generations=200000))");
+    th1 ~ dnUniform(0.0, 10.0)
+    th2 ~ dnUniform(0.0, 10.0)
+    x ~ dnBivariatePoisson(th0, th1, th2)
+    x.clamp([3, 3, 3])
+    moves[1] = mvSlide(th0, delta=0.01, weight=1.0)
+    moves[2] = mvSlide(th1, delta=0.01, weight=1.0)
+    moves[3] = mvSlide(th2, delta=0.01, weight=1.0)
+    monitors[1] = mnScreen(printgen=20000, th0)
+    mymodel = model(th1)
+    mymcmc = mcmc(mymodel, monitors, moves)
+    mymcmc.burnin(generations=20000, tuningInterval=100)
+    mymcmc.run(generations=200000))");
 	help_strings[string("dnBivariatePoisson")][string("name")] = string(R"(dnBivariatePoisson)");
 	help_references[string("dnBivariatePoisson")].push_back(RbHelpReference(R"(Karlis D, Ntzoufras J (2003). Bayesian and Non-Bayesian Analysis of Soccer Data using Bivariate Poisson Regression Models. 16th Panhelenic Conference in Statistics, Kavala, April 2003.)",R"()",R"()"));
 	help_arrays[string("dnBivariatePoisson")][string("see_also")].push_back(string(R"(dnPoisson)"));
@@ -720,6 +720,74 @@ sd(x))");
 	help_strings[string("dnHeterochronousCoalescent")][string("name")] = string(R"(dnHeterochronousCoalescent)");
 	help_strings[string("dnHeterochronousCoalescentSkyline")][string("name")] = string(R"(dnHeterochronousCoalescentSkyline)");
 	help_strings[string("dnIID")][string("name")] = string(R"(dnIID)");
+	help_arrays[string("dnInverse")][string("authors")].push_back(string(R"(Martin R. Smith)"));
+	help_strings[string("dnInverse")][string("description")] = string(R"(`dnInverse()` inverts a probability distribution.
+
+`dnInverse(x).probability()` returns `1 / x.probability()`; 
+`dnInverse(x).lnProbability()` returns `-x.lnProbability()`.
+
+This provides a way to perform inference using conditional probabilities,
+for example where 
+Pr(x | Model, Condition) = Pr(x | Model) / Pr(Condition is satisfied)
+
+In general, there may be cases where it is desirable to sample from or 
+observe a distribution subject to some form of ascertainment condition.
+For example, one may wish to sample from a normal distribution 
+`X ~ dnNormal(0, 1)` subject to some constraint _C(x)_ on _x_ – such
+as a condition that _x_ > 0.
+
+In order to compute the probability of an observed value of _x_ given
+the constraint, we need to divide Pr(x) by Pr(_C(x)_) – in this example,
+Pr(_x_ > 0).  This probability is difficult to calculate in general.
+But in specific cases, Pr(C(x)) corresponds to the probability of observing
+a specific value _y_ from some other distribution _dist_.
+
+In this case, our likelihood could be computed by 
+`dist.clamp(y); conditioned_probability = x.probability() / dist.probability()`.
+
+`dnInverse` allows such likelihoods to be computed during inference under MCMC(MC),
+where the overall probability is obtained by multiplies the probabilities of each
+indepedent component of the model.
+Hence, `Y ~ dnInverse(dist); Y.clamp(y)` gives a model element whose probability
+corresponds to `1 / dist.probability()`.)");
+	help_strings[string("dnInverse")][string("example")] = string(R"(```
+# Compute Pr(x = 1 | x ~ exp(y), y = 1)
+
+# First we define the distributions from which x and y are drawn
+
+# y may take the values 1 or 2 with probabilities 0.4, 0.6
+p_y := simplex(0.4, 0.6)
+y ~ dnCategorical( p_y )
+inv_y ~ dnInverse(dnCategorical( p_y ))
+
+y.clamp(1)
+inv_y.clamp(1)
+
+y.probability()      # 0.4 = 2 / 5
+inv_y.probability()  # 2.5 = 5 / 2
+
+# Compute the joint probability Pr(x, y)
+function PrXandY (x_value, y_value) {
+    x_given_y ~ dnExponential( y_value )
+    x_given_y.clamp(x_value) # To calculate Pr(x | y)
+
+    y.clamp(y_value) # To calculate Pr(y)
+
+    return(x_given_y.probability() * y.probability())
+}
+
+PrXandY(1, 1) # Pr(x = 1, y = 1)
+
+# If we wish to calculate likelihood conditioned on y = 1, we need to compute
+# Pr(x = 1 | y = 1)
+
+# Here it is trivial to compute this directly, as in PrXandY, but in more complex
+# cases it may be easier to use Pr(x = 1 | y = 1) := Pr(x = 1, y = 1) / Pr(y = 1)
+
+PrXandY(1, 1) * inv_y.probability()
+```)");
+	help_strings[string("dnInverse")][string("name")] = string(R"(dnInverse)");
+	help_strings[string("dnInverse")][string("title")] = string(R"(Inverse distribution)");
 	help_arrays[string("dnInverseGamma")][string("authors")].push_back(string(R"(Sebastian Hoehna)"));
 	help_strings[string("dnInverseGamma")][string("description")] = string(R"(inverse-gamma probability distribution for positive real numbers.)");
 	help_strings[string("dnInverseGamma")][string("details")] = string(R"(The inverse Gamma distribution is the probability of the sum of exponentially distributed variables. Thus, it provides a natural prior distribution for parameters that could be considered as sums of exponential variables.)");
@@ -2129,7 +2197,7 @@ An MCMCMC analysis is initiated using the `mcmcmc.run()` method.
 The `StoppingRule[]` argument provides a mechanism to automatically terminate a run once a set of rules are met: perhaps once the run has attained convergence, or after a certain amount of time has passed.  The run will be terminated once *all* convergence rules ([`srGelmanRubin()`], [`srGeweke()`], [`srMinESS()`], [`srStationarity()`]) have been fulfilled; or once *any* threshold rules ([`srMaxTime()`], [`srMaxIteration()`]) are met.
 The parameters `checkpointFile` and `checkpointInterval` generate snapshots of the current state of the MCMCMC run from which the run can be continued if interrupted using the `mcmc.initializeFromCheckpoint()` method. An example is given on the documentation page for [`mcmc()`].)");
 	help_strings[string("mcmcmc")][string("example")] = string(R"(# Create a simple model (unclamped)
-a ~ exponential(1)
+a ~ dnExponential(1)
 mymodel = model(a)
 
 # Create a move vector and a monitor vector

--- a/src/core/moves/MetropolisHastingsMove.cpp
+++ b/src/core/moves/MetropolisHastingsMove.cpp
@@ -277,10 +277,10 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
     int debugMCMC = RbSettings::userSettings().getDebugMCMC();
     if (logMCMC >= 3)
     {
-	std::cerr<<std::setprecision(10);
-	for(auto& [node,pr]: getNodePrs(nodes, affected_nodes))
-	    std::cerr<<"    BEFORE:   "<<node->getName()<<":  "<<pr<<"\n";
-	std::cerr<<"\n";
+        std::cerr<<std::setprecision(10);
+        for(auto& [node,pr]: getNodePrs(nodes, affected_nodes))
+            std::cerr<<"    BEFORE:   "<<node->getName()<<":  "<<pr<<"\n";
+        std::cerr<<"\n";
     }
 
     if (debugMCMC >= 2)
@@ -383,9 +383,9 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
 
     if (logMCMC >= 3)
     {
-	for(auto& [node,pr]: getNodePrs(nodes, affected_nodes))
-	    std::cerr<<"    PROPOSED: "<<node->getName()<<":  "<<pr<<"\n";
-	std::cerr<<"\n";
+        for(auto& [node,pr]: getNodePrs(nodes, affected_nodes))
+            std::cerr<<"    PROPOSED: "<<node->getName()<<":  "<<pr<<"\n";
+        std::cerr<<"\n";
     }
 
     // exponentiate with the chain heat
@@ -436,19 +436,18 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
     }
 
 
-
     if (logMCMC >= 3)
     {
-	for(auto& [node,pr]: getNodePrs(nodes, affected_nodes))
-	    std::cerr<<"    FINAL:    "<<node->getName()<<":  "<<pr<<"\n";
-	std::cerr<<"\n";
+        for(auto& [node,pr]: getNodePrs(nodes, affected_nodes))
+            std::cerr<<"    FINAL:    "<<node->getName()<<":  "<<pr<<"\n";
+        std::cerr<<"\n";
     }
 
     if (logMCMC >= 2)
     {
-	std::cerr<<"    log(posterior_ratio) = "<<ln_posterior_ratio<<"  log(likelihood_ratio) = "<<ln_likelihood_ratio<<"   log(prior_ratio) = "<<ln_prior_ratio<<"\n";
-	std::cerr<<"    log(acceptance_ratio) = "<<ln_acceptance_ratio<<"  log(hastings_ratio) = "<<ln_hastings_ratio<<"\n";
-	std::cerr << "  The move was " << (rejected ? "REJECTED." : "ACCEPTED.") << std::endl;
+        std::cerr<<"    log(posterior_ratio) = "<<ln_posterior_ratio<<"  log(likelihood_ratio) = "<<ln_likelihood_ratio<<"   log(prior_ratio) = "<<ln_prior_ratio<<"\n";
+        std::cerr<<"    log(acceptance_ratio) = "<<ln_acceptance_ratio<<"  log(hastings_ratio) = "<<ln_hastings_ratio<<"\n";
+        std::cerr << "  The move was " << (rejected ? "REJECTED." : "ACCEPTED.") << std::endl;
     }
 
     // --------------------------

--- a/src/core/moves/MetropolisHastingsMove.cpp
+++ b/src/core/moves/MetropolisHastingsMove.cpp
@@ -296,7 +296,7 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
     int debugMCMC = RbSettings::userSettings().getDebugMCMC();
     if (logMCMC >= 3)
     {
-        std::cerr<<std::setprecision(10);
+        std::cerr<<std::setprecision(11);
         for(auto& [node,pr]: getNodePrs(nodes, affected_nodes))
             std::cerr<<"    BEFORE:   "<<node->getName()<<":  "<<pr<<"\n";
         std::cerr<<"\n";

--- a/src/core/moves/MetropolisHastingsMove.cpp
+++ b/src/core/moves/MetropolisHastingsMove.cpp
@@ -291,18 +291,14 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
     if (debugMCMC >= 1)
     {
         // 1. Compute PDFs before proposal, before touch
-        std::map<const DagNode*, double> untouched_before_proposal;
-        for (auto node: views::concat(nodes, affected_nodes))
-            untouched_before_proposal.insert({node, node->getLnProbability()});
+        auto untouched_before_proposal = getNodePrs(nodes, affected_nodes);
 
         // 2. Touch nodes.
         for (auto node: nodes)
             node->touch();
 
         // 3. Compute PDFs before proposal, after touch
-        std::map<const DagNode*, double> touched_before_proposal;
-        for (auto node: views::concat(nodes, affected_nodes))
-            touched_before_proposal.insert({node, node->getLnProbability()});
+        auto touched_before_proposal = getNodePrs(nodes, affected_nodes);
 
         // 4. Keep nodes
         for (auto node: nodes)
@@ -466,18 +462,14 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
     if (debugMCMC >=1 and not rejected)
     {
         // 1. Compute PDFs after proposal, before touch
-        std::map<const DagNode*, double> untouched_after_proposal;
-        for (auto node: views::concat(nodes, affected_nodes))
-            untouched_after_proposal.insert({node, node->getLnProbability()});
+        auto untouched_after_proposal = getNodePrs(nodes, affected_nodes);
 
         // 2. Touch nodes
         for (auto node: nodes)
             node->touch();
 
         // 3. Compute PDFs after proposal, after touch
-        std::map<const DagNode*, double> touched_after_proposal;
-        for (auto node: views::concat(nodes, affected_nodes))
-            touched_after_proposal.insert({node, node->getLnProbability()});
+        auto touched_after_proposal = getNodePrs(nodes, affected_nodes);
 
         // 4. Keep nodes + affected_nodes
         for (auto node: nodes)

--- a/src/core/moves/MetropolisHastingsMove.cpp
+++ b/src/core/moves/MetropolisHastingsMove.cpp
@@ -311,11 +311,14 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
 	    node->keep();
 
 	// 5. Check that the posterior didn't change.
-	if ( fabs(ln_posterior_before_move - ln_posterior_before_move_after_touch) > 1E-6 )
+	double reldiff = std::abs(ln_posterior_before_move - ln_posterior_before_move_after_touch)/std::abs(ln_posterior_before_move_after_touch);
+	if ( reldiff > 1E-8 )
 	{
-	    throw RbException()<<"Issue before executing '" << proposal->getProposalName() << "' on '" << nodes[0]->getName()
+	    throw RbException()<<std::setprecision(10)
+			       <<"Issue before executing '" << proposal->getProposalName() << "' on '" << nodes[0]->getName()
 			       << "' before move because posterior didn't match when re-touching: "
-			       << ln_posterior_before_move << " and " << ln_posterior_before_move_after_touch << ".";
+			       << "\n  "<<ln_posterior_before_move << " and"
+			       << "\n  "<<ln_posterior_before_move_after_touch<<".";
 	}
 	// --------------------------
 	//
@@ -469,9 +472,9 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
 	for (auto node: views::concat(nodes, affected_nodes))
 	    node->keep();
 
-	if ( fabs(ln_posterior_after_move - ln_posterior_after_move_after_touch) > 1E-6 )
+	double rel_diff = std::abs(ln_posterior_after_move - ln_posterior_after_move_after_touch)/std::abs(ln_posterior_after_move_after_touch);
+	if ( rel_diff > 1E-8 )
 	{
-        
 	    for (auto node: views::concat(nodes, affected_nodes))
 		node->touch();
 
@@ -479,7 +482,11 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
 	    for (auto node: views::concat(nodes, affected_nodes))
 		ln_posterior_after_move_after_touch2 += node->getLnProbability();
 
-	    throw RbException() << "Issue in '" << proposal->getProposalName() << "' on '" << nodes[0]->getName() << "' after move because posterior of " << ln_posterior_after_move << " and " << ln_posterior_after_move_after_touch << "/" << ln_posterior_after_move_after_touch2 << ". The move was " << (rejected ? "rejected." : "accepted.");
+	    throw RbException() << std::setprecision(10)
+				<< "Issue in '" << proposal->getProposalName() << "' on '" << nodes[0]->getName()
+				<< "' after move because posterior of "
+				<< "\n  "<<ln_posterior_after_move << " and\n  " << ln_posterior_after_move_after_touch << "/" << ln_posterior_after_move_after_touch2
+				<< ". The move was " << (rejected ? "rejected." : "accepted.");
 
 	    // --------------------------
 	    //

--- a/src/core/moves/MetropolisHastingsMove.cpp
+++ b/src/core/moves/MetropolisHastingsMove.cpp
@@ -285,15 +285,18 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
         std::cerr<<"\n";
     }
 
-    if (debugMCMC >= 2)
+    // NOTE: Only touch/keep nodes, not affected_nodes, when checking PDFs.
+    //       If we touch/keep affected nodes, we can hide problems by doing more recalculation.
+
+    if (debugMCMC >= 1)
     {
         // 1. Compute PDFs before proposal, before touch
         std::map<const DagNode*, double> untouched_before_proposal;
         for (auto node: views::concat(nodes, affected_nodes))
             untouched_before_proposal.insert({node, node->getLnProbability()});
 
-        // 2. Touch nodes + affected_nodes
-        for (auto node: views::concat(nodes, affected_nodes))
+        // 2. Touch nodes.
+        for (auto node: nodes)
             node->touch();
 
         // 3. Compute PDFs before proposal, after touch
@@ -301,8 +304,8 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
         for (auto node: views::concat(nodes, affected_nodes))
             touched_before_proposal.insert({node, node->getLnProbability()});
 
-        // 4. Keep nodes + affected_nodes
-        for (auto node: views::concat(nodes, affected_nodes))
+        // 4. Keep nodes
+        for (auto node: nodes)
             node->keep();
 
         // 5. Compare pdfs for each node
@@ -447,7 +450,7 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
         std::cerr << "  The move was " << (rejected ? "REJECTED." : "ACCEPTED.") << std::endl;
     }
 
-/*
+    /*
     // This fixes the problem. in #567
     if (rejected)
     {
@@ -456,7 +459,7 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
         for(auto node: nodes)
             node->keep();
     }
-*/
+    */
 
     if ((debugMCMC >= 2 and not rejected) or debugMCMC >= 3)
     {
@@ -465,8 +468,8 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
         for (auto node: views::concat(nodes, affected_nodes))
             untouched_after_proposal.insert({node, node->getLnProbability()});
 
-        // 2. Touch nodes + affected_nodes
-        for (auto node: views::concat(nodes, affected_nodes))
+        // 2. Touch nodes
+        for (auto node: nodes)
             node->touch();
 
         // 3. Compute PDFs after proposal, after touch
@@ -475,7 +478,7 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
             touched_after_proposal.insert({node, node->getLnProbability()});
 
         // 4. Keep nodes + affected_nodes
-        for (auto node: views::concat(nodes, affected_nodes))
+        for (auto node: nodes)
             node->keep();
 
         // 5. Compare pdfs for each node

--- a/src/core/moves/MetropolisHastingsMove.cpp
+++ b/src/core/moves/MetropolisHastingsMove.cpp
@@ -461,7 +461,9 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
     }
     */
 
-    if ((debugMCMC >= 2 and not rejected) or debugMCMC >= 3)
+    /* NOTE: This can hide MCMC problems by calling touch/keep after restore. */
+    /*
+    if (debugMCMC >=1 and not rejected)
     {
         // 1. Compute PDFs after proposal, before touch
         std::map<const DagNode*, double> untouched_after_proposal;
@@ -501,6 +503,7 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
 
         if (err) throw E;
     }
+    */
 }
 
 

--- a/src/core/moves/MetropolisHastingsMove.cpp
+++ b/src/core/moves/MetropolisHastingsMove.cpp
@@ -311,7 +311,7 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
 	    node_names.push_back(node->getName());
 
         RbException E;
-        E<<std::setprecision(err_precision)<<"Executing "<<proposal->getProposalName()<<"("<<StringUtilities::join(node_names,",")<<"): PDFs don't match after touching!\n";
+        E<<std::setprecision(err_precision)<<"Executing "<<proposal->getProposalName()<<"("<<StringUtilities::join(node_names,",")<<"): PDFs not up-to-date before proposal!\n";
         bool err = false;
         for(auto& [node,pr1]: untouched_before_proposal)
         {
@@ -484,7 +484,7 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
 	    node_names.push_back(node->getName());
 
         RbException E;
-        E<<std::setprecision(err_precision)<<"Executing "<<proposal->getProposalName()<<"("<<StringUtilities::join(node_names,",")<<"): PDFs don't match after touching!\n";
+        E<<std::setprecision(err_precision)<<"Executing "<<proposal->getProposalName()<<"("<<StringUtilities::join(node_names,",")<<"): PDFs not up-to-date after proposal!\n";
         bool err = false;
         for(auto& [node,pr1]: untouched_after_proposal)
         {

--- a/src/core/moves/MetropolisHastingsMove.cpp
+++ b/src/core/moves/MetropolisHastingsMove.cpp
@@ -306,8 +306,12 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
             node->keep();
 
         // 5. Compare pdfs for each node
+	std::vector<std::string> node_names;
+	for(auto node: nodes)
+	    node_names.push_back(node->getName());
+
         RbException E;
-        E<<std::setprecision(err_precision)<<"Executing "<<proposal->getProposalName()<<"("<<nodes[0]->getName()<<"): PDFs don't match after touching!\n";
+        E<<std::setprecision(err_precision)<<"Executing "<<proposal->getProposalName()<<"("<<StringUtilities::join(node_names,",")<<"): PDFs don't match after touching!\n";
         bool err = false;
         for(auto& [node,pr1]: untouched_before_proposal)
         {
@@ -475,8 +479,12 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
             node->keep();
 
         // 5. Compare pdfs for each node
+	std::vector<std::string> node_names;
+	for(auto node: nodes)
+	    node_names.push_back(node->getName());
+
         RbException E;
-        E<<std::setprecision(err_precision)<<"Executing "<<proposal->getProposalName()<<"("<<nodes[0]->getName()<<"): PDFs don't match after touching!\n";
+        E<<std::setprecision(err_precision)<<"Executing "<<proposal->getProposalName()<<"("<<StringUtilities::join(node_names,",")<<"): PDFs don't match after touching!\n";
         bool err = false;
         for(auto& [node,pr1]: untouched_after_proposal)
         {

--- a/src/core/moves/MetropolisHastingsMove.cpp
+++ b/src/core/moves/MetropolisHastingsMove.cpp
@@ -453,7 +453,7 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
     //     DEBUG (BEGIN)
     //
     // --------------------------
-    if (debugMCMC >= 2)
+    if (debugMCMC >= 3)
     {
 	double ln_posterior_after_move = 0.0;
 	for (auto node: views::concat(nodes, affected_nodes))

--- a/src/core/moves/MetropolisHastingsMove.cpp
+++ b/src/core/moves/MetropolisHastingsMove.cpp
@@ -267,10 +267,11 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
     const RbOrderedSet<DagNode*> &affected_nodes = getAffectedNodes();
     const std::vector<DagNode*> nodes = getDagNodes();
 
-    int debugMCMC = RbSettings::userSettings().getDebugMCMC();
-    if (debugMCMC >= 3)
-	std::cerr<<"performMcmcMove: '"<< proposal->getProposalName()<<"' on '"<<nodes[0]->getName()<<"'\n";
+    int logMCMC = RbSettings::userSettings().getLogMCMC();
+    if (logMCMC >= 1)
+	std::cerr<<"MetropolisHastings: '"<< proposal->getProposalName()<<"' on '"<<nodes[0]->getName()<<"'\n";
 
+    int debugMCMC = RbSettings::userSettings().getDebugMCMC();
     if (debugMCMC >= 2)
     {
 	// --------------------------
@@ -371,6 +372,12 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
 
     double ln_acceptance_ratio = ln_posterior_ratio + ln_hastings_ratio;
 
+    if (logMCMC >= 2)
+    {
+	std::cerr<<"   log(posterior_ratio) = "<<ln_posterior_ratio<<"  log(likelihood_ratio) = "<<ln_likelihood_ratio<<"   log(prior_ratio) = "<<ln_prior_ratio<<"\n";
+	std::cerr<<"   log(acceptance_ratio) = "<<ln_acceptance_ratio<<"  log(hastings_ratio) = "<<ln_hastings_ratio<<"\n";
+    }
+
     bool rejected = false;
 
     if ( RbMath::isAComputableNumber(ln_posterior_ratio) == false )
@@ -414,6 +421,9 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
     }
 
 
+    if (logMCMC >= 2)
+	std::cerr << "   The move was " << (rejected ? "rejected." : "accepted.") << std::endl;
+
     // --------------------------
     //
     //     DEBUG (BEGIN)
@@ -421,9 +431,6 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
     // --------------------------
     if (debugMCMC >= 2)
     {
-	if (debugMCMC >= 3)
-	    std::cerr << "   The move was " << (rejected ? "rejected." : "accepted.") << std::endl;
-
 	double ln_posterior_after_move = 0.0;
 	for (auto node: views::concat(nodes, affected_nodes))
 	    ln_posterior_after_move += node->getLnProbability();

--- a/src/core/moves/MetropolisHastingsMove.cpp
+++ b/src/core/moves/MetropolisHastingsMove.cpp
@@ -272,7 +272,7 @@ constexpr int err_precision = 11;
 void compareNodePrs(const Proposal* proposal, const std::map<const DagNode*, double>& untouched, const std::map<const DagNode*, double>& touched, const std::string& before_after)
 {
     RbException E;
-    E<<std::setprecision(err_precision)<<"Executing "<<proposal->getLongProposalName()<<"): PDFs not up-to-date "<<before_after<<" proposal!\n";
+    E<<std::setprecision(err_precision)<<"Executing "<<proposal->getLongProposalName()<<": PDFs not up-to-date "<<before_after<<" proposal!\n";
     bool err = false;
     for(auto& [node,pr1]: untouched)
     {

--- a/src/core/moves/SliceSamplingMove.cpp
+++ b/src/core/moves/SliceSamplingMove.cpp
@@ -190,14 +190,14 @@ namespace  {
             auto Prs = getNodePrs();
             double Prx = operator()(x);
             auto Prsx = getNodePrs();
-            if (std::abs(Pr - Prx) > 1.0e-9)
+            if (std::abs(Pr - Prx)/abs(Prx) > 1.0e-8)
             {
                 std::cerr<<std::setprecision(10)<<std::endl;
                 std::cerr<<"mvSlice for "<<variable->getName()<<": probability is "<<Pr<<" but should be "<<Prx<<":  delta = "<<Pr - Prx<<"\n";
                 for(auto& [n,pr1]: Prs)
                 {
                     double pr2 = Prsx.at(n);
-                    if (std::abs(pr1-pr2) > 1.0e-6)
+                    if (std::abs(pr1-pr2)/std::abs(pr2) > 1.0e-8)
                         std::cerr<<"         cause: probability for "<<n->getName()<<" is "<<pr1<<" but should be "<<pr2<<":  delta = "<<pr1-pr2<<"\n";
                 }
                 std::abort();

--- a/src/core/moves/SliceSamplingMove.cpp
+++ b/src/core/moves/SliceSamplingMove.cpp
@@ -190,14 +190,14 @@ namespace  {
             auto Prs = getNodePrs();
             double Prx = operator()(x);
             auto Prsx = getNodePrs();
-            if (std::abs(Pr - Prx)/abs(Prx) > 1.0e-8)
+            if (std::abs(Pr - Prx)/abs(Prx) > 1.0e-11)
             {
-                std::cerr<<std::setprecision(10)<<std::endl;
+                std::cerr<<std::setprecision(11)<<std::endl;
                 std::cerr<<"mvSlice for "<<variable->getName()<<": probability is "<<Pr<<" but should be "<<Prx<<":  delta = "<<Pr - Prx<<"\n";
                 for(auto& [n,pr1]: Prs)
                 {
                     double pr2 = Prsx.at(n);
-                    if (std::abs(pr1-pr2)/std::abs(pr2) > 1.0e-8)
+                    if (std::abs(pr1-pr2)/std::abs(pr2) > 1.0e-11)
                         std::cerr<<"         cause: probability for "<<n->getName()<<" is "<<pr1<<" but should be "<<pr2<<":  delta = "<<pr1-pr2<<"\n";
                 }
                 std::abort();

--- a/src/core/moves/SliceSamplingMove.cpp
+++ b/src/core/moves/SliceSamplingMove.cpp
@@ -349,12 +349,16 @@ find_slice_boundaries_doubling(double x0,slice_function& g,double logy, double w
 
 double search_interval(double x0,double& L, double& R, slice_function& g,double logy)
 {
+    int logMCMC = RbSettings::userSettings().getLogMCMC();
+    int debugMCMC = RbSettings::userSettings().getDebugMCMC();
+
+    if (debugMCMC >= 1)
+	g.checkPrs();
+
     //  assert(g(x0) > g(L) and g(x0) > g(R));
-    g.checkPrs();
     assert(g(x0) >= logy);
     assert(L < R);
     assert(L <= x0 and x0 <= R);
-    int logMCMC = RbSettings::userSettings().getLogMCMC();
 
     //double L0 = L, R0 = R;
 

--- a/src/core/moves/SliceSamplingMove.cpp
+++ b/src/core/moves/SliceSamplingMove.cpp
@@ -24,9 +24,6 @@ using namespace RevBayesCore;
 
 const double log_0 = RbConstants::Double::neginf;
 
-// How can we make a run-time adjustable log level?
-int log_level = 0;
-
 /** 
  * Constructor
  *
@@ -112,15 +109,6 @@ struct interval
     interval(optional<double> lb, optional<double> ub): lower_bound(lb), upper_bound(ub) {}
 };
 
-std::map<const DagNode*, double> getNodePrs(DagNode* node, const RbOrderedSet<DagNode*>& affectedNodes)
-{
-    std::map<const DagNode*, double> Prs;
-    Prs.insert({node, node->getLnProbability()});
-    for(auto affectedNode: affectedNodes)
-	Prs.insert({affectedNode, affectedNode->getLnProbability()});
-    return Prs;
-}
-
 namespace  {
 
 /// This object allow computing the probability of the current point, and also store the variable's range
@@ -186,10 +174,42 @@ namespace  {
                 return Pr_;
             }
 
+        std::map<const DagNode*, double> getNodePrs()
+        {
+            std::map<const DagNode*, double> Prs;
+            Prs.insert({variable, variable->getLnProbability()});
+            for(auto affectedNode: affectedNodes)
+                Prs.insert({affectedNode, affectedNode->getLnProbability()});
+            return Prs;
+        }
+
+        void checkPrs()
+        {
+            double x = current_value();
+            double Pr = operator()();
+            auto Prs = getNodePrs();
+            double Prx = operator()(x);
+            auto Prsx = getNodePrs();
+            if (std::abs(Pr - Prx) > 1.0e-9)
+            {
+                std::cerr<<std::setprecision(10)<<std::endl;
+                std::cerr<<"mvSlice for "<<variable->getName()<<": probability is "<<Pr<<" but should be "<<Prx<<":  delta = "<<Pr - Prx<<"\n";
+                for(auto& [n,pr1]: Prs)
+                {
+                    double pr2 = Prsx.at(n);
+                    if (std::abs(pr1-pr2) > 1.0e-6)
+                        std::cerr<<"         cause: probability for "<<n->getName()<<" is "<<pr1<<" but should be "<<pr2<<":  delta = "<<pr1-pr2<<"\n";
+                }
+                std::abort();
+            }
+        }
+
         double current_value() const
             {
                 return variable->getValue();
             }
+
+        std::string name() const {return variable->getName();}
 
         slice_function(StochasticNode<double> *n, optional<double> lb, optional<double> ub, double pr, double l, double p)
             :interval(lb,ub),
@@ -202,27 +222,7 @@ namespace  {
                 variable->initiateGetAffectedNodes( affectedNodes );
 
                 if (RbSettings::userSettings().getDebugMCMC() > 0)
-                {
-                    std::map<const DagNode*, double> NodePrs;
-
-                    double x = current_value();
-                    double Pr = operator()();
-                    auto Prs = getNodePrs(variable,affectedNodes);
-                    double Prx = operator()(x);
-                    auto Prsx = getNodePrs(variable,affectedNodes);
-                    if (std::abs(Pr - Prx) > 1.0e-9)
-                    {
-                        std::cerr<<std::setprecision(10)<<std::endl;
-                        std::cerr<<"mvSlice for "<<variable->getName()<<": probability is "<<Pr<<" but should be "<<Prx<<":  delta = "<<Pr - Prx<<"\n";
-                        for(auto& [n,pr1]: Prs)
-                        {
-                            double pr2 = Prsx.at(n);
-                            if (std::abs(pr1-pr2) > 1.0e-6)
-                                std::cerr<<"         cause: probability for "<<n->getName()<<" is "<<pr1<<" but should be "<<pr2<<":  delta = "<<pr1-pr2<<"\n";
-                        }
-                        std::abort();
-                    }
-                }
+		    checkPrs();
             }
     };
 
@@ -231,11 +231,18 @@ namespace  {
 std::pair<double,double> 
 find_slice_boundaries_stepping_out(double x0,slice_function& g,double logy, double w,int m)
 {
+    int logMCMC = RbSettings::userSettings().getLogMCMC();
+
+    assert(x0 + w > x0);
     assert(g.in_range(x0));
 
     double u = uniform()*w;
     double L = x0 - u;
     double R = x0 + (w-u);
+    assert(L < x0);
+    assert(x0 < R);
+
+    if (logMCMC >= 4) std::cerr<<"    L = "<<L<<"  x0 = "<<x0<<"   R0 = "<<R<<"\n";
 
     // Expand the interval until its ends are outside the slice, or until
     // the limit on steps is reached.
@@ -275,6 +282,7 @@ find_slice_boundaries_stepping_out(double x0,slice_function& g,double logy, doub
 std::tuple<double,double,optional<double>,optional<double>>
 find_slice_boundaries_doubling(double x0,slice_function& g,double logy, double w, int K)
 {
+    int logMCMC = RbSettings::userSettings().getLogMCMC();
     assert(x0 + w > x0);
     assert(g.in_range(x0));
 
@@ -309,7 +317,7 @@ find_slice_boundaries_doubling(double x0,slice_function& g,double logy, double w
 
     while ( K > 0 and (gL() > logy or gR() > logy))
     {
-        if (log_level >= 4)
+        if (logMCMC >= 4)
             std::cerr<<"!!    L0 = "<<L<<" (g(L) = "<<gL()<<")  x0 = "<<x0<<"   R0 = "<<R<<" (g(R) = "<<gR()<<")\n";
 
         double W2 = (R-L);
@@ -336,25 +344,31 @@ find_slice_boundaries_doubling(double x0,slice_function& g,double logy, double w
     assert(L < R);
     assert( L < (L+R)/2 and (L+R)/2 < R);
 
-    //  std::cerr<<"[]    L0 = "<<L<<"   x0 = "<<x0<<"   R0 = "<<R<<"\n";
+    if (logMCMC >= 1)
+	std::cerr<<"     L0 = "<<L<<"   x0 = "<<x0<<"   R0 = "<<R<<"\n";
 
-    // FIXME: GCC 5 complains if we don't write out the tuple type. GCC 7 does not need it.  How about GCC 6?
     return {L,R,gL_cached,gR_cached};
 }
 
 double search_interval(double x0,double& L, double& R, slice_function& g,double logy)
 {
     //  assert(g(x0) > g(L) and g(x0) > g(R));
+    g.checkPrs();
     assert(g(x0) >= logy);
     assert(L < R);
     assert(L <= x0 and x0 <= R);
+    int logMCMC = RbSettings::userSettings().getLogMCMC();
 
     //double L0 = L, R0 = R;
 
     for (int i=0;i<200;i++)
     {
         double x1 = L + uniform()*(R-L);
+
         double gx1 = g(x1);
+
+        if (logMCMC >= 4)
+	    std::cerr<<"    L0 = "<<L<<"  x1 = "<<x1<<" g(x1) = "<<gx1<<"  R0 = "<<R<<"\n";
 
         if (gx1 >= logy) return x1;
 
@@ -375,7 +389,8 @@ bool pre_slice_sampling_check_OK(double x0, slice_function& g)
     // If x is not in the range then this could be a range that is reduced to avoid loss of precision.
     if (not g.in_range(x0))
     {
-        if (log_level >= 4) std::cerr<<x0<<" not in range!";
+        int logMCMC = RbSettings::userSettings().getLogMCMC();
+        if (logMCMC >= 4) std::cerr<<"   "<<x0<<" not in range!";
         return false;
     }
     else
@@ -444,14 +459,17 @@ double slice_sample_stepping_out(double x0, slice_function& g,double w, int m)
     assert(g.in_range(x0));
 
     double gx0 = g();
-#ifndef NDEBUG
-    volatile double diff = gx0 - g(x0);
-    assert(std::abs(diff) < 1.0e-9);
-#endif
 
     // Determine the slice level, in log terms.
 
     double logy = gx0 + log(uniform()); // - exponential(1.0);
+
+    int debugMCMC = RbSettings::userSettings().getDebugMCMC();
+    int logMCMC = RbSettings::userSettings().getLogMCMC();
+    if (logMCMC >= 1 or debugMCMC >=1)
+	std::cerr<<"mvSlice("<<g.name()<<",stepping_out):  x0 = "<<x0<<"  g(x0) = "<<gx0<<"   logy = "<<logy<<"\n";
+
+    if (debugMCMC >= 1) g.checkPrs();
 
     // Find the initial interval to sample from.
     auto [L, R] = find_slice_boundaries_stepping_out(x0,g,logy,w,m);
@@ -471,7 +489,15 @@ double slice_sample_doubling(double x0, slice_function& g, double w, int m)
         return x0;
 
     // 1. Determine the slice level, in log terms.
-    double logy = g() + log(uniform()); // - exponential(1);
+    double gx0 = g();
+
+    double logy = gx0 + log(uniform()); // - exponential(1);
+
+    int debugMCMC = RbSettings::userSettings().getDebugMCMC();
+    int logMCMC = RbSettings::userSettings().getLogMCMC();
+    if (logMCMC >= 1 or debugMCMC >= 1) std::cerr<<"mvSlice("<<g.name()<<",stepping_out):  x0 = "<<x0<<"  g(x0) = "<<gx0<<"   logy = "<<logy<<"\n";
+
+    if (debugMCMC >= 1) g.checkPrs();
 
     // 2. Find the initial interval to sample from.
     auto [L, R, gL_cached, gR_cached]  = find_slice_boundaries_doubling(x0,g,logy,w,m);

--- a/src/core/moves/SliceSamplingMove.cpp
+++ b/src/core/moves/SliceSamplingMove.cpp
@@ -220,9 +220,6 @@ namespace  {
              num_evals(0)
             {
                 variable->initiateGetAffectedNodes( affectedNodes );
-
-                if (RbSettings::userSettings().getDebugMCMC() > 0)
-		    checkPrs();
             }
     };
 

--- a/src/core/moves/proposal/Proposal.cpp
+++ b/src/core/moves/proposal/Proposal.cpp
@@ -220,3 +220,12 @@ void Proposal::swapNode(DagNode *oldP, DagNode *newP)
     }
     
 }
+
+std::string Proposal::getLongProposalName() const
+{
+    std::vector<std::string> node_names;
+    for(auto node: nodes)
+	node_names.push_back(node->getName());
+
+    return getProposalName() + "(" + StringUtilities::join(node_names,",") +")";
+}

--- a/src/core/moves/proposal/Proposal.h
+++ b/src/core/moves/proposal/Proposal.h
@@ -38,6 +38,7 @@ namespace RevBayesCore {
         virtual Proposal*                                       clone(void) const = 0;                                                                  //!< Make a deep copy
         virtual double                                          doProposal(void) = 0;                                                                   //!< Actually do the proposal.
         virtual const std::string&                              getProposalName(void) const = 0;                                                        //!< Get the name of this proposal used for printing out info.
+        virtual std::string                                     getLongProposalName(void) const;                                                        //!< Get the name of this proposal used for printing out info.
         virtual double                                          getProposalTuningParameter(void) const = 0;
         virtual std::vector<DagNode*>                           identifyNodesToTouch(void);
         virtual void                                            prepareProposal(void) = 0;                                                              //!< Propose a new state

--- a/src/core/utils/RbSettings.cpp
+++ b/src/core/utils/RbSettings.cpp
@@ -58,6 +58,12 @@ int RbSettings::getDebugMCMC( void ) const
     return debugMCMC;
 }
 
+int RbSettings::getLogMCMC( void ) const
+{
+    // return the internal value
+    return logMCMC;
+}
+
 std::string RbSettings::getOption(const std::string &key) const
 {
     if ( key == "moduledir" )
@@ -91,6 +97,10 @@ std::string RbSettings::getOption(const std::string &key) const
     else if ( key == "debugMCMC" )
     {
         return std::to_string(debugMCMC);
+    }
+    else if ( key == "logMCMC" )
+    {
+        return std::to_string(logMCMC);
     }
     else
     {
@@ -162,6 +172,7 @@ void RbSettings::listOptions() const
     std::cout << "useScaling = " << (useScaling ? "true" : "false") << std::endl;
     std::cout << "scalingDensity = " << scalingDensity << std::endl;
     std::cout << "debugMCMC = " << debugMCMC << std::endl;
+    std::cout << "logMCMC = " << logMCMC << std::endl;
 }
 
 
@@ -217,6 +228,16 @@ void RbSettings::setDebugMCMC(int d)
 }
 
 
+void RbSettings::setLogMCMC(int d)
+{
+    // replace the internal value with this new value
+    logMCMC = d;
+
+    // save the current settings for the future.
+    writeUserSettings();
+}
+
+
 void RbSettings::setOption(const std::string &key, const std::string &v, bool write)
 {
 
@@ -260,6 +281,10 @@ void RbSettings::setOption(const std::string &key, const std::string &v, bool wr
     else if ( key == "debugMCMC" )
     {
         debugMCMC = boost::lexical_cast<int>(value);
+    }
+    else if ( key == "logMCMC" )
+    {
+        logMCMC = boost::lexical_cast<int>(value);
     }
     else
     {

--- a/src/core/utils/RbSettings.h
+++ b/src/core/utils/RbSettings.h
@@ -30,7 +30,7 @@ public:
     double                      getTolerance(void) const;                           //!< Retrieve the tolerance for comparing doubles
     bool                        getUseScaling(void) const;                          //!< Retrieve the flag whether we should scale the likelihood in CTMC models
     int                         getDebugMCMC(void) const;                           //!< How much work should we perform to check MCMC?
-    int                         getLogMCMC(void) const;                           //!< How much work should we perform to check MCMC?
+    int                         getLogMCMC(void) const;                             //!< How much logging should we perform to check MCMC?
 
     // setters
     void                        setLineWidth(size_t w);                             //!< Set the line width that will be used for the screen width when printing
@@ -42,7 +42,7 @@ public:
     void                        setTolerance(double t);                             //!< Set the tolerance for comparing double
     void                        setUseScaling(bool s);                              //!< Set the flag whether we should scale the likelihood in CTMC models
     void                        setDebugMCMC(int d);                                //!< How much work should we perform to check MCMC?
-    void                        setLogMCMC(int d);                                //!< How much work should we perform to check MCMC?
+    void                        setLogMCMC(int d);                                  //!< How much logging should we perform to check MCMC?
     
 private:
     RbSettings(void);                                   //!< Default constructor

--- a/src/core/utils/RbSettings.h
+++ b/src/core/utils/RbSettings.h
@@ -30,6 +30,7 @@ public:
     double                      getTolerance(void) const;                           //!< Retrieve the tolerance for comparing doubles
     bool                        getUseScaling(void) const;                          //!< Retrieve the flag whether we should scale the likelihood in CTMC models
     int                         getDebugMCMC(void) const;                           //!< How much work should we perform to check MCMC?
+    int                         getLogMCMC(void) const;                           //!< How much work should we perform to check MCMC?
 
     // setters
     void                        setLineWidth(size_t w);                             //!< Set the line width that will be used for the screen width when printing
@@ -41,6 +42,7 @@ public:
     void                        setTolerance(double t);                             //!< Set the tolerance for comparing double
     void                        setUseScaling(bool s);                              //!< Set the flag whether we should scale the likelihood in CTMC models
     void                        setDebugMCMC(int d);                                //!< How much work should we perform to check MCMC?
+    void                        setLogMCMC(int d);                                //!< How much work should we perform to check MCMC?
     
 private:
     RbSettings(void);                                   //!< Default constructor
@@ -57,6 +59,7 @@ private:
     double                      tolerance=10e-10;                                          //!< Tolerance for comparison of doubles
     bool                        useScaling=true;
     int                         debugMCMC = 0;
+    int                         logMCMC = 0;
 };
 
 #endif

--- a/src/revlanguage/functions/io/Func_source.cpp
+++ b/src/revlanguage/functions/io/Func_source.cpp
@@ -100,9 +100,7 @@ RevPtr<RevVariable> Func_source::execute( void )
         result = Parser::getParser().processCommand( commandLine, &Workspace::userWorkspace() );
         if ( result == 2 )
         {
-            std::ostringstream msg;
-            msg << "Problem processing line " << lineNumber << " in file \"" << fname << "\"";
-            throw RbException( msg.str() );
+            throw RbException() << "Problem processing line " << lineNumber << " in file " << fname;
         }
         
     }


### PR DESCRIPTION
This change makes `--setOption debugMCMC=1` actually work for Metropolis-Hastings moves.  Previously some of the code to check the node PDFs was actually hiding the recalculation bugs by doing extra recalculation, but only during debugging!

This change also separates logging from debugging.  The logging option is `logMCMC`.  For Metropolis-Hastings moves and the values are:
- `1`  writes out the generation, step within each generation, and move name for each move.
- `2` also writes out posterior, likelihood, prior, and Hastings ratios.
- `3` writes out each changed PDF along with its node name.

Together, these should allow debugging #565 and #567.
