### PR TITLE
Mark overridden functions

### DIFF
--- a/src/core/distributions/phylogenetics/tree/birthdeath/BirthDeathSamplingTreatmentProcess.h
+++ b/src/core/distributions/phylogenetics/tree/birthdeath/BirthDeathSamplingTreatmentProcess.h
@@ -57,21 +57,21 @@ namespace RevBayesCore {
                                                     long age_check_precision);  //!< Constructor
 
         // public member functions
-        BirthDeathSamplingTreatmentProcess*             clone(void) const;                                                      //!< Create an independent clone
-        void                                            redrawValue(SimulationCondition c = SimulationCondition::MCMC);         //!< Draw a new random value from the distribution
-        bool                                            allowsSA();                                                             //!< Checks if distribution is compatible with sampled ancestors
-        virtual void                                    setValue(Tree *v, bool f=false);                                        //!< Sets value to specified tree
+        BirthDeathSamplingTreatmentProcess*             clone(void) const override;                                             //!< Create an independent clone
+        void                                            redrawValue(SimulationCondition c = SimulationCondition::MCMC) override;//!< Draw a new random value from the distribution
+        bool                                            allowsSA() override;                                                    //!< Checks if distribution is compatible with sampled ancestors
+        virtual void                                    setValue(Tree *v, bool f=false) override;                               //!< Sets value to specified tree
 
     protected:
         // Parameter management functions
-        double                                          computeLnProbabilityDivergenceTimes(void) const;                        //!< Compute the log-transformed probability of the current value.
+        double                                          computeLnProbabilityDivergenceTimes(void) const override;               //!< Compute the log-transformed probability of the current value.
         // Parameter management functions
-        void                                            swapParameterInternal(const DagNode *oldP, const DagNode *newP);        //!< Swap a parameter
+        void                                            swapParameterInternal(const DagNode *oldP, const DagNode *newP) override;//!< Swap a parameter
 
         // helper functions
         void                                            addTimesToGlobalTimeline(std::set<double> &event_times, const TypedDagNode<RbVector<double> > *par_times) const;        //!< Adds timeline for parameter to set that we will use for global timeline
         void                                            checkVectorSizes(const TypedDagNode<RbVector<double> >* v1, const TypedDagNode<RbVector<double> >* v2, int v1_minus_v2, const std::string& param_name, bool is_rate) const;
-        double                                          computeLnProbabilityTimes(void) const;                                  //!< Compute the log-transformed probability of the current value.
+        double                                          computeLnProbabilityTimes(void) const override;                         //!< Compute the log-transformed probability of the current value.
         bool                                            countAllNodes(void) const;                                              //!< Count bifurcating nodes, count all heterochronous nodes as either phi- or Phi-sampled and as either sampled ancestors or sampled extinct tips
         double                                          lnD(size_t i, double t) const;                                          //!< Branch-segment probability at time t with index i, using pre-computed vectors
         double                                          E(size_t i, double t, bool computeSurvival = false) const;                                       //!< Extinction probability at time t with index i, using pre-computed vectors
@@ -81,13 +81,13 @@ namespace RevBayesCore {
         size_t                                          findIndex(double t, const std::vector<double>& timeline) const;
         void                                            getOffset(void) const;
         bool                                            isConstantRate(void) const;                                             //!< Checks if we have a constant-rate process
-        double                                          lnProbNumTaxa(size_t n, double start, double end, bool MRCA) const { throw RbException("Cannot compute P(nTaxa)."); }
-        double                                          lnProbTreeShape(void) const;
+        double                                          lnProbNumTaxa(size_t n, double start, double end, bool MRCA) const override { throw RbException("Cannot compute P(nTaxa)."); }
+        double                                          lnProbTreeShape(void) const override;
         void                                            prepareTimeline(void) const;
         void                                            prepareProbComputation(void) const override;
         double                                          pSampling(double t) const;
-        double                                          pSurvival(double start, double end) const;
-        double                                          simulateDivergenceTime(double origin, double present) const;            //!< Simulate a speciation event.
+        double                                          pSurvival(double start, double end) const override;
+        double                                          simulateDivergenceTime(double origin, double present) const override;   //!< Simulate a speciation event.
         void                                            sortGlobalTimesAndVectorParameter(void) const;                          //!< Sorts times to run from 0->inf, and orders ALL vector parameters to match
         void                                            sortNonGlobalTimesAndVectorParameter(std::vector<double>& times, std::vector<double>& par) const;     //!< Sorts times to run from 0->inf, and orders par to match
         int                                             survivors(double t) const;                                              //!< Number of species alive at time t.

--- a/src/core/distributions/phylogenetics/tree/birthdeath/EpisodicBirthDeathProcess.h
+++ b/src/core/distributions/phylogenetics/tree/birthdeath/EpisodicBirthDeathProcess.h
@@ -26,22 +26,22 @@ namespace RevBayesCore {
                                   Tree *t);
         
         // public member functions
-        EpisodicBirthDeathProcess*                          clone(void) const;                                                              //!< Create an independent clone
+        EpisodicBirthDeathProcess*                          clone(void) const  override;                                                      //!< Create an independent clone
         
         
     protected:
         // Parameter management functions
-        void                                                swapParameterInternal(const DagNode *oldP, const DagNode *newP);                //!< Swap a parameter
+        void                                                swapParameterInternal(const DagNode *oldP, const DagNode *newP) override;                //!< Swap a parameter
         void                                                prepareProbComputation(void) const override;
         
         void                                                prepareRateIntegral(double end);                                                        //!< Compute the rate integral.
         void                                                prepareSurvivalProbability(double end, double r);                                       //!< Compute the rate integral.
 
         // helper functions
-        double                                              lnSpeciationRate(double t) const;
-        double                                              rateIntegral(double t_low, double t_high) const;
-        double                                              computeProbabilitySurvival(double start, double end) const;
-        double                                              simulateDivergenceTime(double origin, double present) const;                            //!< Simulate a speciation event.
+        double                                              lnSpeciationRate(double t) const override;
+        double                                              rateIntegral(double t_low, double t_high) const override;
+        double                                              computeProbabilitySurvival(double start, double end) const override;
+        double                                              simulateDivergenceTime(double origin, double present) const override;                            //!< Simulate a speciation event.
 
     private:
         

--- a/src/core/distributions/phylogenetics/tree/birthdeath/FossilizedBirthDeathSpeciationProcess.h
+++ b/src/core/distributions/phylogenetics/tree/birthdeath/FossilizedBirthDeathSpeciationProcess.h
@@ -43,35 +43,35 @@ namespace RevBayesCore {
                                       bool resampling);  //!< Constructor
         
         // public member functions
-        FossilizedBirthDeathSpeciationProcess*          clone(void) const;                                         //!< Create an independent clone
+        FossilizedBirthDeathSpeciationProcess*          clone(void) const override;                                //!< Create an independent clone
 
-        void                                            redrawValue(void);
-        void                                            simulateClade(std::vector<TopologyNode *> &n, double age, double present, bool alwaysReturn);
+        void                                            redrawValue(void) override;
+        void                                            simulateClade(std::vector<TopologyNode *> &n, double age, double present, bool alwaysReturn) override;
 
     protected:
-        void                                            updateStartEndTimes(void);
+        void                                            updateStartEndTimes(void) override;
         int                                             updateStartEndTimes(const TopologyNode & );
 
-        double                                          pSurvival(double start, double end) const;             //!< Compute the probability of survival of the process (without incomplete taxon sampling).
+        double                                          pSurvival(double start, double end) const override;             //!< Compute the probability of survival of the process (without incomplete taxon sampling).
 
         // Parameter management functions
-        double                                          computeLnProbabilityTimes(void) const;                            //!< Compute the log-transformed probability of the current value.
+        double                                          computeLnProbabilityTimes(void) const override;                            //!< Compute the log-transformed probability of the current value.
         double                                          computeLnProbabilityDivergenceTimes(void);                            //!< Compute the log-transformed probability of the current value.
 
-        double                                          lnProbNumTaxa(size_t n, double start, double end, bool MRCA) const { throw RbException("Cannot compute P(nTaxa)."); }
-        double                                          lnProbTreeShape(void) const;
+        double                                          lnProbNumTaxa(size_t n, double start, double end, bool MRCA) const override { throw RbException("Cannot compute P(nTaxa)."); }
+        double                                          lnProbTreeShape(void) const override;
 
-        double                                          q(size_t i, double t, bool tilde = false) const;
+        double                                          q(size_t i, double t, bool tilde = false) const override;
 
-        double                                          simulateDivergenceTime(double origin, double present) const;    //!< Simulate a speciation event.
-        std::vector<double>                             simulateDivergenceTimes(size_t n, double origin, double present, double min, bool alwaysReturn) const;                 //!< Simulate n speciation events.
+        double                                          simulateDivergenceTime(double origin, double present) const override;    //!< Simulate a speciation event.
+        std::vector<double>                             simulateDivergenceTimes(size_t n, double origin, double present, double min, bool alwaysReturn) const override;                 //!< Simulate n speciation events.
 
         void                                            keepSpecialization(DagNode *toucher);
         void                                            restoreSpecialization(DagNode *toucher);
         void                                            touchSpecialization(DagNode *toucher, bool touchAll);
 
         // Parameter management functions
-        void                                            swapParameterInternal(const DagNode *oldP, const DagNode *newP);                //!< Swap a parameter
+        void                                            swapParameterInternal(const DagNode *oldP, const DagNode *newP) override;                //!< Swap a parameter
 
         void                                            prepareProbComputation(void) const override;
 

--- a/src/revlanguage/distributions/phylogenetics/tree/Dist_FBDP.h
+++ b/src/revlanguage/distributions/phylogenetics/tree/Dist_FBDP.h
@@ -15,16 +15,16 @@ namespace RevLanguage {
     public:
 
         // Basic utility functions
-        Dist_FBDP*                                              clone(void) const;                                                                      //!< Clone the object
+        Dist_FBDP*                                              clone(void) const override;                                                             //!< Clone the object
         static const std::string&                               getClassType(void);                                                                     //!< Get Rev type
-        std::vector<std::string>                                getDistributionFunctionAliases(void) const;                                             //!< Get the alternative names used for the constructor function in Rev.
-        std::string                                             getDistributionFunctionName(void) const;                                                //!< Get the Rev-name for this distribution.
-        const TypeSpec&                                         getTypeSpec(void) const;                                                                //!< Get the type spec of the instance
-        const MemberRules&                                      getParameterRules(void) const;                                                          //!< Get member rules (const)
+        std::vector<std::string>                                getDistributionFunctionAliases(void) const override;                                    //!< Get the alternative names used for the constructor function in Rev.
+        std::string                                             getDistributionFunctionName(void) const override;                                       //!< Get the Rev-name for this distribution.
+        const TypeSpec&                                         getTypeSpec(void) const override;                                                       //!< Get the type spec of the instance
+        const MemberRules&                                      getParameterRules(void) const override;                                                 //!< Get member rules (const)
 
     protected:
 
-        virtual void                                            setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var);       //!< Set member variable
+        virtual void                                            setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var) override; //!< Set member variable
         virtual RevBayesCore::DagNode*                          getRemovalProbability( void ) const override;
     };
 


### PR DESCRIPTION
Flagged with a warning on xcode 15 – and worth fixing I think; I've found explicit override marking helpful recently.