### PR TITLE
Remove useless exceptions

### DIFF
--- a/src/revlanguage/datatypes/AbstractModelObject.h
+++ b/src/revlanguage/datatypes/AbstractModelObject.h
@@ -39,6 +39,7 @@ namespace RevLanguage {
         // pure virtual methods
         virtual AbstractModelObject*            clone(void) const = 0;                                                          //!< Clone object
         virtual RevBayesCore::DagNode*          getDagNode(void) const = 0;                                                     //!< Get the internal DAG node
+        virtual bool                            hasDagNode(void) const = 0;                                                     //!< Do we have an internal DAG node
         virtual void                            setDagNode(RevBayesCore::DagNode *newNode) = 0;                                 //!< Set or replace the internal dag node (and keep me)
         virtual void                            setName(const std::string &n) = 0;                                              //!< Set the name of the variable (if applicable)
         

--- a/src/revlanguage/datatypes/ModelObject.h
+++ b/src/revlanguage/datatypes/ModelObject.h
@@ -42,6 +42,7 @@ namespace RevLanguage {
         
         // Getters and setters
         RevBayesCore::TypedDagNode<rbType>*     getDagNode(void) const;                                                     //!< Get the internal DAG node
+        bool                                    hasDagNode(void) const;                                                     //!< Get the internal DAG node
         virtual const rbType&                   getValue(void) const;                                                       //!< Get the value (const)
         virtual rbType&                         getValue(void);                                                             //!< Get the value (non-const)
         void                                    setValue(rbType *x);                                                        //!< Set new constant value
@@ -247,8 +248,13 @@ const RevLanguage::TypeSpec& RevLanguage::ModelObject<rbType>::getClassTypeSpec(
 template <typename rbType>
 RevBayesCore::TypedDagNode<rbType>* RevLanguage::ModelObject<rbType>::getDagNode( void ) const
 {
-    
     return dag_node;
+}
+
+template <typename rbType>
+bool RevLanguage::ModelObject<rbType>::hasDagNode( void ) const
+{
+    return (dag_node != nullptr);
 }
 
 template <typename rbType>

--- a/src/revlanguage/datatypes/RevObject.cpp
+++ b/src/revlanguage/datatypes/RevObject.cpp
@@ -206,10 +206,18 @@ const std::string& RevObject::getType( void ) const
  */
 RevBayesCore::DagNode* RevObject::getDagNode( void ) const
 {
-    
     throw RbException("Workspace objects cannot be used inside DAG's! You tried to access the DAG node of type '" + getClassType() + "'.");
     
     return NULL;
+}
+
+
+/**
+ * Get the value as a DAG node. This default implementation throws an error.
+ */
+bool RevObject::hasDagNode( void ) const
+{
+    return false;
 }
 
 

--- a/src/revlanguage/datatypes/RevObject.h
+++ b/src/revlanguage/datatypes/RevObject.h
@@ -61,6 +61,7 @@ namespace RevLanguage {
         virtual RevObject*                                      convertTo(const TypeSpec& type) const;                                                          //!< Convert to type
         virtual RevPtr<RevVariable>                             executeMethod(const std::string& name, const std::vector<Argument>& args, bool &found);         //!< Execute member method (if applicable)
         virtual RevBayesCore::DagNode*                          getDagNode(void) const;                                                                         //!< Get my internal value node (if applicable)
+        virtual bool                                            hasDagNode(void) const;                                                                         //!< Check if we have an internal value node.
         virtual const MemberRules&                              getParameterRules(void) const;                                                                  //!< Get member rules
         virtual bool                                            isAbstract(void) const;                                                                         //!< Is this an abstract type/object?
         virtual bool                                            isAssignable(void) const;                                                                       //!< Is object or upstream members assignable?

--- a/src/revlanguage/functions/MemberProcedure.cpp
+++ b/src/revlanguage/functions/MemberProcedure.cpp
@@ -86,18 +86,12 @@ RevPtr<RevVariable> MemberProcedure::execute( void )
         throw RbException("Couldn't find member procedure called '" + getFunctionName() + "'");
     }
     
-    try
+    if (object->getRevObject().hasDagNode())
     {
         RevBayesCore::DagNode* the_node = object->getRevObject().getDagNode();
-        
-        if ( the_node != NULL )
-        {
-            the_node->touch();
-        }
-    }
-    catch (RbException &e)
-    {
-        // we do nothing ...
+	assert(the_node);
+
+	the_node->touch();
     }
     
     return retValue;

--- a/src/revlanguage/functions/argumentrules/ArgumentRule.cpp
+++ b/src/revlanguage/functions/argumentrules/ArgumentRule.cpp
@@ -477,17 +477,8 @@ double ArgumentRule::isArgumentValid( Argument &arg, bool once) const
             args.push_back( the_var );
                 
             Environment& env = Workspace::globalWorkspace();
-            try
-            {
-                // we just want to check if the function exists and can be found
-                env.getFunction(function_name, args, once);
-                return 0.1;
-            }
-            catch (RbException& e)
-            {
-                // we do nothing here
-            }
-
+	    if (env.findFunction(function_name, args, once) != nullptr)
+		return 0.1;
         }
             
     }

--- a/src/revlanguage/workspace/FunctionTable.h
+++ b/src/revlanguage/workspace/FunctionTable.h
@@ -42,7 +42,7 @@ namespace RevLanguage {
         void                                    printValue(std::ostream& o, bool env) const;                                                //!< Print table for user
 
         // FunctionTable functions
-        virtual void                            addFunction(Function *func);                                       //!< Add function
+        bool                                    addFunction(Function *func, bool no_except=false);                                          //!< Add function
         void                                    clear(void);                                                                                //!< Clear table
 //        RevPtr<RevVariable>                        executeFunction(const std::string&           name,
 //                                                                const std::vector<Argument>& args);                                         //!< Evaluate function (once)

--- a/src/revlanguage/workspace/MethodTable.cpp
+++ b/src/revlanguage/workspace/MethodTable.cpp
@@ -22,15 +22,7 @@ void MethodTable::insertInheritedMethods( const MethodTable& inheritedMethods )
     {
         Function* the_function = (*it).second->clone();
 
-        try
-        {
-            addFunction( the_function );
-        }
-        catch (RbException &)
-        {
-            
-        }
-        
+	addFunction( the_function, true );
     }
     
 }


### PR DESCRIPTION
Revbayes throw a lot of exceptions that are immediately caught and ignored.  This PR removes some of these exceptions.  The main benefits are:
1. should be faster
2. it is possible to do `catch throw` in gdb and find where an error comes from.


