### PR TITLE
Log reason for -Inf and NaN

### DIFF
--- a/src/core/distributions/phylogenetics/tree/AbstractRootedTreeDistribution.cpp
+++ b/src/core/distributions/phylogenetics/tree/AbstractRootedTreeDistribution.cpp
@@ -20,6 +20,7 @@
 #include "Tree.h"
 #include "TypedDagNode.h"
 #include "TypedDistribution.h"
+#include "RbSettings.h"
 
 namespace RevBayesCore { class DagNode; }
 namespace RevBayesCore { template <class valueType> class RbOrderedSet; }
@@ -168,13 +169,14 @@ void AbstractRootedTreeDistribution::buildRandomBinaryTree(std::vector<TopologyN
 
 double AbstractRootedTreeDistribution::computeLnProbability( void )
 {
-    
+    using namespace RbConstants;
+
     // proceed as long as derived classes validate a non-zero likeilhood
     if ( isLnProbabilityNonZero() == false )
     {
-        return RbConstants::Double::neginf;
+        return Double::neginf;
     }
-    
+
     // check that the ages are in correct chronological order
     // i.e., no child is older than its parent
     const std::vector<TopologyNode*>& nodes = value->getNodes();
@@ -190,39 +192,43 @@ double AbstractRootedTreeDistribution::computeLnProbability( void )
                 {
                     if ( the_node.getAge() - the_node.getParent().getAge() != 0 )
                     {
-                        return RbConstants::Double::neginf;
+                        return withReason(Double::neginf)<<"Pr(tree)=0: sampled ancestor "<<the_node.getTaxon().getName()<<" tip age "<<the_node.getAge()<<" differs from parent age "<<the_node.getParent().getAge();
                     }
                     else if ( the_node.isFossil() == false )
                     {
-                        return RbConstants::Double::neginf;
+                        return withReason(Double::neginf)<<"Pr(tree)=0: sampled ancestor tip "<<the_node.getTaxon().getName()<<" is not a fossil";
                     }
                     else if ( the_node.getBranchLength() != 0 )
                     {
-                        return RbConstants::Double::neginf;
+                        return withReason(Double::neginf)<<"Pr(tree)=0: sampled ancestor tip "<<the_node.getTaxon().getName()<<" has non-zero branch length "<<the_node.getBranchLength();
                     }
 
                 }
-                if(the_node.getTaxon().getName() != "" && the_node.getTaxon().getMinAge() != the_node.getTaxon().getMaxAge()) {
-                    if(the_node.getAge() < the_node.getTaxon().getMinAge() || the_node.getAge() > the_node.getTaxon().getMaxAge()) {
-                        std::cerr << "Age of taxa " << the_node.getTaxon().getName() << " incompatible with age range";
-                        return RbConstants::Double::neginf;
+                auto taxon = the_node.getTaxon();
+                if(taxon.getName() != "" && taxon.getMinAge() != taxon.getMaxAge())
+                {
+                    if(the_node.getAge() < taxon.getMinAge() || the_node.getAge() > taxon.getMaxAge())
+                    {
+                        std::cerr << "Age of taxon " << taxon.getName() << " incompatible with age range";
+                        return withReason(Double::neginf)<< "Pr(tree)=0: taxon " << taxon.getName() <<" has age "<<the_node.getAge()
+                                                         <<" outside of age range ["<<taxon.getMinAge()<<", "<<taxon.getMaxAge()<<"]";
                     }
                 }
             }
             if( the_node.getAge() - the_node.getParent().getAge() > 0 )
             {
-                return RbConstants::Double::neginf;
+                return withReason(Double::neginf)<<"Pr(tree)=0: node age "<<the_node.getAge()<<" greater than parent age "<<the_node.getParent().getAge();
             }
             
         }
         else if ( the_node.getAge() > getOriginAge() )
         {
-            return RbConstants::Double::neginf;
+            return withReason(Double::neginf)<<"Pr(tree)=0: node age "<<the_node.getAge()<<" greater than origin age "<<getOriginAge();
         }
         
         if ( the_node.getBranchLength() < 0 )
         {
-            return RbConstants::Double::neginf;
+	    return withReason(Double::neginf)<<"Pr(tree)=0: branch length "<<the_node.getBranchLength()<<" < 0";
         }
 
     }
@@ -230,18 +236,23 @@ double AbstractRootedTreeDistribution::computeLnProbability( void )
     // present time
     double ra = value->getRoot().getAge();
     
-    if ( ra > getOriginAge() || ra != getRootAge() )
+    if ( ra > getOriginAge())
     {
-        return RbConstants::Double::neginf;
+        return withReason(Double::neginf)<<"Pr(tree)=0: root age ("<<ra<<") > origin age ("<<getOriginAge()<<")";
+    }
+
+    if ( ra != getRootAge() )
+    {
+        return withReason(Double::neginf)<<"Pr(tree)=0: root age ("<<ra<<") != getRootAge() ("<<getRootAge()<<")";
     }
         
     const std::vector<TopologyNode*> &c = value->getRoot().getChildren();
     
-    for (std::vector<TopologyNode*>::const_iterator it = c.begin(); it != c.end(); ++it)
+    for (auto child: c)
     {
-        if ( ra < (*it)->getAge() )
+        if ( ra < child->getAge() )
         {
-            return RbConstants::Double::neginf;
+            return withReason(Double::neginf)<<"Pr(tree)=0: node age ("<<child->getAge()<<") greater than root age ("<<ra<<")";
         }
     }
     

--- a/src/core/distributions/phylogenetics/tree/TopologyConstrainedTreeDistribution.cpp
+++ b/src/core/distributions/phylogenetics/tree/TopologyConstrainedTreeDistribution.cpp
@@ -30,6 +30,7 @@
 #include "TreeUtilities.h"
 #include "TypedDagNode.h"
 #include "TypedDistribution.h"
+#include "RbSettings.h"
 
 namespace RevBayesCore { class DagNode; }
 namespace RevBayesCore { template <class valueType> class RbOrderedSet; }
@@ -235,17 +236,19 @@ TopologyConstrainedTreeDistribution* TopologyConstrainedTreeDistribution::clone(
  */
 double TopologyConstrainedTreeDistribution::computeLnProbability( void )
 {
+    using namespace RbConstants;
+
     recursivelyUpdateClades( value->getRoot() );
     
     // first check if the current tree matches the clade constraints
     if ( matchesConstraints() == false )
     {
-        return RbConstants::Double::neginf;
+        return withReason(Double::neginf)<<"Pr(tree)=0: clade constraints do not match";
     }
     
     if ( matchesBackbone() == false )
     {
-        return RbConstants::Double::neginf;
+        return withReason(Double::neginf)<<"Pr(tree)=0: backbone constraints do not match";
     }
     
     double lnProb = base_distribution->computeLnProbability();

--- a/src/core/utils/RbSettings.cpp
+++ b/src/core/utils/RbSettings.cpp
@@ -346,3 +346,9 @@ void RbSettings::writeUserSettings( void )
     writeStream.close();
 
 }
+
+void showDebug(const std::string& s, int level)
+{
+    if (RbSettings::userSettings().getLogMCMC() >= level)
+	std::cerr<<s<<"\n";
+}

--- a/src/core/utils/RbSettings.h
+++ b/src/core/utils/RbSettings.h
@@ -4,6 +4,7 @@
 #include <cstddef>
 #include <iosfwd>
 #include <string> // IWYU pragma: keep
+#include <sstream>
 
 #include "RbFileManager.h"
 
@@ -60,6 +61,24 @@ private:
     bool                        useScaling=true;
     int                         debugMCMC = 0;
     int                         logMCMC = 0;
+};
+
+void showDebug(const std::string& s, int level=1);
+
+class withReason
+{
+    double value;
+    int level = 2;
+    std::ostringstream reason;
+
+public:
+    template <typename T>
+    withReason& operator<<(const T& t) {reason<<t; return *this;}
+
+    operator double() const {showDebug(reason.str(), level); return value;}
+
+    withReason(double d):value(d) {}
+    withReason(double d, int l):value(d), level(l) {}
 };
 
 #endif


### PR DESCRIPTION
This PR allows logging a reason why we return -Inf.

```
             if( the_node.getAge() - the_node.getParent().getAge() > 0 )
            {
                return withReason(Double::neginf)<<"Pr(tree)=0: node age "<<the_node.getAge()<<" greater than parent age "<<the_node.getParent().getAge();
            }
```

The reason is only logged if `logMCMC >= 2`.

Issues:
- should we use a separate option?  Or `logMCMC >= 1`?

Changes:
- The message no longer needs to specify "\n".
