### PR TITLE
Improve MCMC checks

### DIFF
--- a/src/core/dag/StochasticNode.h
+++ b/src/core/dag/StochasticNode.h
@@ -468,8 +468,17 @@ double RevBayesCore::StochasticNode<valueType>::getLnProbability( void )
 template<class valueType>
 double RevBayesCore::StochasticNode<valueType>::getLnProbabilityRatio( void )
 {
-    
-    return getLnProbability() - stored_ln_prob.value().value();
+    // 1. If the node is not affected/touched, then the probability is the same for the current and previous state.
+    if (not stored_ln_prob)
+        return 0;
+
+    // 2. If we touched the node when the log probability was not calculated, then we don't have a value for
+    // the probability of the previous state.
+    if (not *stored_ln_prob)
+        throw RbException()<<"getLnProbabilityRatio: the log probability for the previous state was never calculated";
+
+    // 3. If (a) the node is touched/affected and (b) we know the previous probability, then use it.
+    return getLnProbability() - **stored_ln_prob;
 }
 
 

--- a/src/core/moves/MetropolisHastingsMove.cpp
+++ b/src/core/moves/MetropolisHastingsMove.cpp
@@ -276,8 +276,20 @@ void compareNodePrs(const Proposal* proposal, const std::map<const DagNode*, dou
     bool err = false;
     for(auto& [node,pr1]: untouched)
     {
-	auto pr2 = touched.at(node);
-	if (std::abs(pr1-pr2)/std::abs(pr2) > rel_err_threshhold)
+	auto pr2 = pdfs2.at(node);
+
+	// If they are both NaNs then they that is not a problem.
+	if (std::isnan(pr1) and std::isnan(pr2)) continue;
+
+	// Be a bit careful about computing a relative error.
+	double abs_err = std::abs(pr1 - pr2);
+	double scale = std::min(std::abs(pr1),std::abs(pr2));
+	if (scale < 1 or not RbMath::isAComputableNumber(scale))
+	    scale = 1;
+	double rel_err = abs_err/scale;
+
+	// Complain if rel_err is NaN.
+	if (not (rel_err < rel_err_threshhold))
 	{
 	    E<<"    "<<node->getName()<<": "<<pr1<<" != "<<pr2<<"    diff = "<<pr1-pr2<<"\n";
 	    err = true;

--- a/src/revlanguage/dag/RlContinuousStochasticNode.cpp
+++ b/src/revlanguage/dag/RlContinuousStochasticNode.cpp
@@ -267,12 +267,18 @@ void RevLanguage::ContinuousStochasticNode::printStructureInfo( std::ostream& o,
     o << "_clamped      = " << ( this->clamped ? "TRUE" : "FALSE" ) << std::endl;
     o << "_lnProb       = " << const_cast< ContinuousStochasticNode* >( this )->getLnProbability() << std::endl;
     
-    if ( this->touched == true && verbose == true)
+    if ( verbose == true)
     {
-        o << "_stored_ln_prob = " << this->stored_ln_prob << std::endl; // const_cast< ContinuousStochasticNode* >( this )->getLnProbability() << std::endl;
-    }
+        o << "_stored_ln_prob = ";
+        if (not this->stored_ln_prob)
+            o<< "EMPTY";
+        else if (not *this->stored_ln_prob)
+            o<< "UNCOMPUTED";
+        else
+            o<<**this->stored_ln_prob;
 
-    
+        o<< std::endl;
+    }
     o << "_parents      = ";
     this->printParents( o, 16, 70, verbose );
     o << std::endl;

--- a/src/revlanguage/dag/RlStochasticNode.h
+++ b/src/revlanguage/dag/RlStochasticNode.h
@@ -286,12 +286,19 @@ void RevLanguage::StochasticNode<valueType>::printStructureInfo( std::ostream& o
     o << "_distribution = " << rlDistribution->getRevDeclaration() << std::endl;
     o << "_clamped      = " << ( this->clamped ? "TRUE" : "FALSE" ) << std::endl;
     o << "_lnProb       = " << const_cast< StochasticNode<valueType>* >( this )->getLnProbability() << std::endl;    
-    if ( this->touched == true && verbose == true)
-    {
-        o << "_stored_ln_prob = " << this->stored_ln_prob << std::endl; // const_cast< StochasticNode<valueType>* >( this )->getLnProbability() << std::endl;
-    }
 
-    
+    if ( verbose == true)
+    {
+        o << "_stored_ln_prob = ";
+        if (not this->stored_ln_prob)
+            o<< "EMPTY";
+        else if (not *this->stored_ln_prob)
+            o<< "UNCOMPUTED";
+        else
+            o<<**this->stored_ln_prob;
+
+        o<< std::endl;
+    }
     o << "_parents      = ";
     this->printParents( o, 16, 70, verbose );
     o << std::endl;


### PR DESCRIPTION
This PR does four things:
1. Combine lnProb and needs_probability_recalculation into an `optional<double>`.  This prevents accessing `lnProb` when its value is invalid.
2. Change `stored_ln_prob` into an `optional<optional<double>>`.  This outer optional explicitly tracks whether there current is a previous probability or not.  The inner optional tracks whether the previous probability is invalid or not, like `lnProb`.
3. Fixes the check for different log likelihoods to catch cases like `-10 -> -Inf`, which we mistakenly did not catch before.
4. Check that final PDFs are the same as initial PDFs if the move is rejected.

