### PR TITLE
Get rid of `sprintf` in favor of `snprintf`

### DIFF
--- a/src/core/datatypes/phylogenetics/characterdata/ContinuousTaxonData.cpp
+++ b/src/core/datatypes/phylogenetics/characterdata/ContinuousTaxonData.cpp
@@ -193,7 +193,7 @@ std::string ContinuousTaxonData::getJsonRepresentation(void) const {
     for (int i=0; i<sequence.size(); i++)
         {
         char tempCStr[20];
-        sprintf(tempCStr, "%.10e", sequence[i]);
+        snprintf(tempCStr, sizeof(tempCStr), "%.10e", sequence[i]);
         std::string tempStr = tempCStr;
         jsonStr += tempStr;
         if (i + 1 < sequence.size())
@@ -251,7 +251,7 @@ std::string ContinuousTaxonData::getStringRepresentation(size_t idx) const
     }
     
     char tempCStr[20];
-    sprintf(tempCStr, "%1.2lf", sequence[idx]);
+    snprintf(tempCStr, sizeof(tempCStr), "%1.2lf", sequence[idx]);
     std::string tempStr = tempCStr;
     return tempStr;
 }


### PR DESCRIPTION
In the spirit of cleaning up the code base and getting rid of compiler warnings (see e.g. #589), here's another small change to prevent Xcode from screaming at me...