### PR TITLE
Alternative improved usage message

### DIFF
--- a/src/revlanguage/main.cpp
+++ b/src/revlanguage/main.cpp
@@ -71,10 +71,10 @@ variables_map parse_cmd_line(int argc, char* argv[])
         ("setOption",value<std::vector<std::string> >()->composing(),"Set an option key=value. See ?setOption for the list of available keys and their associated values.")
 
         // multitoken means that `--args a1 a2 a3` works the same as `--args a1 --args a2 --args a3`
-        ("args",value<std::vector<std::string> >()->multitoken(),"Command line arguments to initialize RevBayes variables.")
+        ("args",value<std::vector<std::string> >()->multitoken(),"Supply command line arguments.")
 
         // multitoken means that `--cmd script a1 a2 a3` works the same as `--cmd script --cmd a1 --cmd a2 --cmd a3`
-        ("cmd",value<std::vector<std::string> >()->multitoken(),"Script and command line arguments to initialize RevBayes variables.")
+        ("cmd",value<std::vector<std::string> >()->multitoken(),"Source a file and supply command line arguments.")
 	;
 
     // Treat all positional options as "file" options.


### PR DESCRIPTION
This PR:
- hides `--help` info on `--file`, which is only used to handle position arguments
- improves the usage message to cover --args and --cmd
- actually gives an error message when --args and --cmd are both used, instead of crashing.
- also gives an error messages when --cmd and position arguments (i.e. "file") are both used.

``` sh
$ ./rb -h
Usage: rb [OPTIONS]
       rb [OPTIONS] <file1> [<file2> ...] [--args <arg1> [<arg2> ...]]
       rb [OPTIONS] --cmd <file> [<arg1> <arg2>...]

Bayesian phylogenetic inference using probabilistic graphical models and an interpreted language

Options:
  -h [ --help ]         Show information on flags.
  -v [ --version ]      Show version and exit.
  -b [ --batch ]        Run in batch mode.
  -j [ --jupyter ]      Run in jupyter mode.
  --setOption arg       Set an option key=value. See ?setOption for the list of
                        available keys and their associated values.
  --args arg            Supply command line arguments.
  --cmd arg             Source a file and supply command line arguments.

See http://revbayes.github.io for more information.
```

``` sh
$ ./rb --args A --cmd B
Usage: rb [OPTIONS]
       rb [OPTIONS] <file1> [<file2> ...] [--args <arg1> [<arg2> ...]]
       rb [OPTIONS] --cmd <file> [<arg1> <arg2>...]

Error: received both --args and --cmd, but only one is allowed.
```

``` sh
$ ./rb file1 --cmd file2 arg1
Usage: rb [OPTIONS]
       rb [OPTIONS] <file1> [<file2> ...] [--args <arg1> [<arg2> ...]]
       rb [OPTIONS] --cmd <file> [<arg1> <arg2>...]

Error: filenames not allowed before --cmd.
```