### PR TITLE
Report values in error message

### DIFF
--- a/src/core/functions/phylogenetics/TreeAssemblyFunction.cpp
+++ b/src/core/functions/phylogenetics/TreeAssemblyFunction.cpp
@@ -37,7 +37,7 @@ TreeAssemblyFunction::TreeAssemblyFunction(const TypedDagNode<Tree> *t, const Ty
 
     if (tau->getValue().getNumberOfNodes() - 1 != brlen->getValue().size())
     {
-        throw(RbException(std::string("Number of branches (") + std::to_string(tau->getValue().getNumberOfNodes() - 1) + ") does not match the number of branch lengths (" + std::to_string(brlen->getValue().size()) + ")"));
+        throw RbException() << "Number of branches (" << (tau->getValue().getNumberOfNodes() - 1) << ") does not match the number of branch lengths (" << brlen->getValue().size() << ")";
     }
 
     // add the lambda parameter as a parent

--- a/src/core/functions/phylogenetics/TreeAssemblyFunction.cpp
+++ b/src/core/functions/phylogenetics/TreeAssemblyFunction.cpp
@@ -37,7 +37,7 @@ TreeAssemblyFunction::TreeAssemblyFunction(const TypedDagNode<Tree> *t, const Ty
 
     if (tau->getValue().getNumberOfNodes() - 1 != brlen->getValue().size())
     {
-        throw(RbException("Number of branches does not match the number of branch lengths"));
+        throw(RbException(std::string("Number of branches (") + std::to_string(tau->getValue().getNumberOfNodes() - 1) + ") does not match the number of branch lengths (" + std::to_string(brlen->getValue().size()) + ")"));
     }
 
     // add the lambda parameter as a parent


### PR DESCRIPTION
This PR makes it simpler to debug a mismatch between the number of branches and the number of branch lengths by including each value in the text of the error message.