### PR TITLE
Document simplex moves

### DIFF
--- a/help/md/Simplex.md
+++ b/help/md/Simplex.md
@@ -1,9 +1,23 @@
 ## name
 Simplex
 ## title
+Simplex
 ## description
+A simplex is a vector of elements that sum to 1.
 ## details
 ## authors
 ## see_also
+
+Moves that operate on Simplexes:
+- mvBetaSimplex
+- mvDirichletSimplex
+- mvDPPValueBetaSimplex
+- mvElementSwapSimplex
+
 ## example
+```rb
+x <- simplex([2, 2, 6])
+x # = [ 0.2, 0.2, 0.6]
+sum(x) # 1, by definition
+```
 ## references

--- a/help/md/mvBetaSimplex.md
+++ b/help/md/mvBetaSimplex.md
@@ -7,11 +7,9 @@ The Beta Simplex move selects one element of the a vector and proposes a new val
 ## details
 ## authors
 ## see_also
-
-mvBetaSimplex
-mvDirichletSimplex
-mvDPPValueBetaSimplex
-mvElementSwapSimplex
+- mvDirichletSimplex
+- mvDPPValueBetaSimplex
+- mvElementSwapSimplex
 
 ## example
 A usage example can be found at https://revbayes.github.io/tutorials/chromo/#root

--- a/help/md/mvBetaSimplex.md
+++ b/help/md/mvBetaSimplex.md
@@ -7,6 +7,13 @@ The Beta Simplex move selects one element of the a vector and proposes a new val
 ## details
 ## authors
 ## see_also
-https://revbayes.github.io/tutorials/chromo/#root
+
+mvBetaSimplex
+mvDirichletSimplex
+mvDPPValueBetaSimplex
+mvElementSwapSimplex
+
 ## example
+A usage example can be found at https://revbayes.github.io/tutorials/chromo/#root
+
 ## references

--- a/help/md/mvBetaSimplex.md
+++ b/help/md/mvBetaSimplex.md
@@ -1,9 +1,12 @@
 ## name
 mvBetaSimplex
 ## title
+Beta Simplex move
 ## description
+The Beta Simplex move selects one element of the a vector and proposes a new value for it drawn from a Beta distribution.
 ## details
 ## authors
 ## see_also
+https://revbayes.github.io/tutorials/chromo/#root
 ## example
 ## references

--- a/help/md/mvDirichletSimplex.md
+++ b/help/md/mvDirichletSimplex.md
@@ -1,9 +1,23 @@
 ## name
 mvDirichletSimplex
 ## title
+Dirichlet Simplex move
 ## description
+A Dirichlet-simplex proposal randomly changes some values of a [Simplex] (a vector whose elements sum to 1),
+although the other values change too because of renormalization.
+ 
+First, some random indices are drawn.
+Then, the proposal draws a new simplex `u ~ Dirichlet(val[index] * alpha)`, where alpha is the tuning parameter.
+The new value is set to `u`.
+The simplex is then renormalized.
+
 ## details
 ## authors
 ## see_also
+- mvBetaSimplex
+- mvDPPValueBetaSimplex
+- mvElementSwapSimplex
+
 ## example
+Usage examples can be found at https://revbayes.github.io/tutorials/morph_tree/V2.html and https://revbayes.github.io/tutorials/morph_ase/ase_free.html
 ## references

--- a/help/md/mvDirichletSimplex.md
+++ b/help/md/mvDirichletSimplex.md
@@ -3,8 +3,8 @@ mvDirichletSimplex
 ## title
 Dirichlet Simplex move
 ## description
-A Dirichlet-simplex proposal randomly changes some values of a [Simplex] (a vector whose elements sum to 1),
-although the other values change too because of renormalization.
+A Dirichlet-simplex proposal randomly changes some values of a [Simplex](https://revbayes.github.io/documentation/Simplex.html)
+(a vector whose elements sum to 1). The other values change too because of renormalization.
  
 First, some random indices are drawn.
 Then, the proposal draws a new simplex `u ~ Dirichlet(val[index] * alpha)`, where alpha is the tuning parameter.

--- a/help/md/mvElementSwapSimplex.md
+++ b/help/md/mvElementSwapSimplex.md
@@ -1,9 +1,14 @@
 ## name
 mvElementSwapSimplex
 ## title
+Element Swap Simplex move
 ## description
+An Element Swap Simplex move selects two elements of a vector and exchanges their values.
 ## details
 ## authors
 ## see_also
+mvBetaSimplex
+mvDirichletSimplex
+mvDPPValueBetaSimplex
 ## example
 ## references


### PR DESCRIPTION
In the spirit of "something is better than nothing", this PR proposes some skeletal documentation to moves pertaining to simplexes.

A documentation page exists for `mvDPPValueBetaSimplex` but I can't find the corresponding source code; this is listed at https://revbayes.github.io/tutorials/mcmc/moves.html but never explained.

https://revbayes.github.io/tutorials/mcmc/moves.html also contains moves (e.g. `mvSimplex`) that don't obviously exist.