### PR TITLE
Don't reject Metropolis-Hastings proposals because one PDF changes from NaN or Zero to something positive and finite.

### DIFF
--- a/src/core/dag/DagNode.cpp
+++ b/src/core/dag/DagNode.cpp
@@ -1108,3 +1108,8 @@ void DagNode::touchAffected(bool touchAll)
         child->touchMe( this, touchAll );
     }
 }
+
+double DagNode::getPrevLnProbability(void) const
+{
+    throw RbException()<<"getPrevLnProbability: not a stochastic node!";
+}

--- a/src/core/dag/DagNode.h
+++ b/src/core/dag/DagNode.h
@@ -87,6 +87,7 @@ template <class valueType> class RbOrderedSet;
         size_t                                                      getNumberOfChildren(void) const;                                                            //!< Get the number of children for this node
         virtual size_t                                              getNumberOfMixtureElements(void) const;                                                        //!< Get the number of elements for this value
         virtual std::vector<const DagNode*>                         getParents(void) const;                                                                     //!< Get the set of parents (empty set here)
+        virtual double                                              getPrevLnProbability(void) const;
         size_t                                                      getReferenceCount(void) const;                                                              //!< Get the reference count for reference counting in smart pointers
         const std::set<size_t>&                                     getTouchedElementIndices(void) const;                                                       //!< Get the indices of the touches elements. If the set is empty, then all elements might have changed.
         bool                                                        getVisitFlag(const size_t flagType) const;

--- a/src/core/dag/StochasticNode.h
+++ b/src/core/dag/StochasticNode.h
@@ -486,7 +486,15 @@ double RevBayesCore::StochasticNode<valueType>::getLnProbabilityRatio( void )
 template<class valueType>
 double RevBayesCore::StochasticNode<valueType>::getPrevLnProbability( void ) const
 {
-    // 1. If the node is not affected/touched, then the probability is the same for the current and previous state.
+    /*
+     * NOTE: If there is no previous probability then we could do a few things:
+     *         (1) throw an exception (current done).
+     *         (2) return an optional<double> to indicate if there is a previous probability or not.
+     *         (3) return the current probability.  This would make the method non-const.
+     *       Right now we do (1).
+     */
+
+    // 1. If the node is not affected/touched, then throw an exception.
     if (not stored_ln_prob)
         throw RbException()<<"getPrevLnProbability: no previous probability!";
 

--- a/src/core/dag/StochasticNode.h
+++ b/src/core/dag/StochasticNode.h
@@ -33,6 +33,7 @@ namespace RevBayesCore {
         virtual const TypedDistribution<valueType>&         getDistribution(void) const;
         void                                                getIntegratedParents(RbOrderedSet<DagNode *>& ip) const;
         virtual double                                      getLnProbability(void);
+        virtual double                                      getPrevLnProbability(void) const;
         virtual double                                      getLnProbabilityRatio(void);
         virtual std::vector<double>                         getMixtureLikelihoods(bool log=true) const;
         virtual std::vector<double>                         getMixtureProbabilities(void) const;
@@ -479,6 +480,23 @@ double RevBayesCore::StochasticNode<valueType>::getLnProbabilityRatio( void )
 
     // 3. If (a) the node is touched/affected and (b) we know the previous probability, then use it.
     return getLnProbability() - **stored_ln_prob;
+}
+
+
+template<class valueType>
+double RevBayesCore::StochasticNode<valueType>::getPrevLnProbability( void ) const
+{
+    // 1. If the node is not affected/touched, then the probability is the same for the current and previous state.
+    if (not stored_ln_prob)
+        throw RbException()<<"getPrevLnProbability: no previous probability!";
+
+    // 2. If we touched the node when the log probability was not calculated, then we don't have a value for
+    // the probability of the previous state.
+    if (not *stored_ln_prob)
+        throw RbException()<<"getLnProbabilityRatio: the log probability for the previous state was never calculated";
+
+    // 3. If (a) the node is touched/affected and (b) we know the previous probability, then use it.
+    return **stored_ln_prob;
 }
 
 

--- a/src/core/moves/MetropolisHastingsMove.cpp
+++ b/src/core/moves/MetropolisHastingsMove.cpp
@@ -380,9 +380,16 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
     {
         if (fail_probability) break;
 
+        if (not node->isStochastic()) continue;
+
         double ratio = 0;
         try {
-            ratio = node->getLnProbabilityRatio();
+            // There should be a previous lnProbability because the nodes have been touched.
+            double prev = node->getPrevLnProbability();
+            // Compute the current lnProbability.
+            double current = node->getLnProbability();
+
+            ratio = current - prev;
         }
         catch (const RbException &e)
         {

--- a/src/core/moves/MetropolisHastingsMove.cpp
+++ b/src/core/moves/MetropolisHastingsMove.cpp
@@ -386,12 +386,10 @@ void MetropolisHastingsMove::performMcmcMove( double prHeat, double lHeat, doubl
         }
         catch (const RbException &e)
         {
-            ratio = RbConstants::Double::neginf;
-
             if ( e.getExceptionType() != RbException::MATH_ERROR )
-            {
                 throw;
-            }
+
+            ratio = RbConstants::Double::neginf;
         }
 
         if ( node->isClamped() )

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -100,7 +100,7 @@ for t in test_*; do
     res=0
     # run the test scripts
     for f in scripts/*.[Rr]ev ; do
-        mkdir output
+        mkdir -p output
         tmp0=${f#scripts/}
         tmp1=${tmp0%.[Rr]ev}
         ${rb_exec} -b $f &> output/${tmp1}.errout # print output so we can see any error messages


### PR DESCRIPTION
Previously we always rejected any move where a stochastic node probability changed from zero or NaN to something finite.  But such moves should be fine.  This might possibly allow MCMC to solve some constraints by wandering around until PDFs that are 0 change to something non-zero.