### PR TITLE
Try unbreaking macOS ARM tests.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,7 +136,7 @@ jobs:
     - name: Install (macOS)
       if: runner.os == 'macOS'
       run: |
-          brew install pkg-config boost ccache coreutils meson openlibm
+          brew install boost ccache coreutils meson openlibm
 
     - name: Install meson
       run: |


### PR DESCRIPTION
The macOS ARM tests were failing because we manually installed `pkg-config`, but `meson` now seems to depend on an alternative implementation called `pkgconf` that provides the same links.

Just stop manually installing `pkg-config` and let meson handle its own dependencies.