### PR TITLE
Add stdout/stderr test.

### DIFF
--- a/tests/test_basics/output_expected/ignore.errout
+++ b/tests/test_basics/output_expected/ignore.errout
@@ -1,0 +1,5 @@
+   
+   Running MCMC simulation
+   This simulation runs 1 independent replicate.
+   The simulator uses 1 different moves in a random move schedule with 1 moves per iteration
+   

--- a/tests/test_basics/scripts/ignore.Rev
+++ b/tests/test_basics/scripts/ignore.Rev
@@ -22,8 +22,6 @@ z[1][2][2].clamp(2)
 
 mymodel = model(mu)
 
-mymodel.graph("output/ignore.dot")
-
 # mymodel.ignoreData(mu)
 # mymodel.ignoreData(x1)
 # mymodel.ignoreData(f)


### PR DESCRIPTION
Add ignore.errout test output.

Adding a test to check that we get the right errors would indeed be useful.  Right now I have some commented-out lines in the test that could be added in to check errors.  However, it seems that RevBayes quits running the script at the first error which means that you can't test multiple errors per script.  I plan to address this after 1.2.5 as part of changing the options to match Rscript.