### PR TITLE
Fix version number for 1.2.5

### DIFF
--- a/src/revlanguage/utils/RbVersion.cpp
+++ b/src/revlanguage/utils/RbVersion.cpp
@@ -34,7 +34,7 @@ std::string RbVersion::getGitCommit( void ) const
 
 std::string RbVersion::getVersion( void ) const
 {
-    return "1.2.5-preview";
+    return "1.2.5";
 }
 
 


### PR DESCRIPTION
Oops -- I apparently changed the version number only in `meson.build`, but it also has to be changed in `revlanguage/utils/RbVersion.cpp'.
