### PR TITLE
simmap bugfix for when some characters are excluded

### DIFF
--- a/src/core/distributions/phylogenetics/substitution/AbstractPhyloCTMCSiteHomogeneous.h
+++ b/src/core/distributions/phylogenetics/substitution/AbstractPhyloCTMCSiteHomogeneous.h
@@ -1521,6 +1521,7 @@ bool RevBayesCore::AbstractPhyloCTMCSiteHomogeneous<charType>::recursivelyDrawSt
     // NOTE: ambiguous tip states are sampled along with internal node states
     end_state = end_states[node_index][site].getStateIndex();
 
+
     // set up vectors to hold the character transition events
     std::vector<size_t> transition_states;
     std::vector<double> transition_times;
@@ -2053,14 +2054,16 @@ void RevBayesCore::AbstractPhyloCTMCSiteHomogeneous<charType>::tipDrawJointCondi
 
     // ideally sample ambiguous tip states given the underlying process and ancestral state
     // for now, always sample the clamped character
+    
+    // create a vector with the correct site indices
+    // some of the sites may have been excluded
+    std::vector<size_t> site_indices = getIncludedSiteIndices();
 
     // sample characters conditioned on start states, going to end states
     std::vector<double> p(this->num_chars, 0.0);
     for (size_t i = 0; i < this->num_sites; i++)
     {
-
-        charType c = td.getCharacter(i);
-
+        charType c = td.getCharacter(site_indices[i]);
 
         if ( c.isAmbiguous() == false )
         {


### PR DESCRIPTION
There seems to be a small problem if you have a data matrix that looks something like this
```  
MATRIX                                  [HCP]
    balaenoptera_borealis                010
    balaenoptera_edeni                   010
    balaenoptera_musculus                011
    balaenoptera_physalus                010
    balantiopteryx_infusca               011
    balantiopteryx_io                    011
    balantiopteryx_plicata               011
    bandicota_savilei                    000
    barbastella_barbastellus             011
    barbastella_leucomelas               011
    bassaricyon_gabbii                   000
    bassariscus_sumichrasti              000
    bathyergus_janetta                   101
    batomys_granti                       100
    batomys_salomonseni                  100
    bdeogale_crassicauda                 010
    bdeogale_nigripes                    010
    beamys_hindei                        100
    beatragus_hunteri                    101
    blastocerus_dichotomus               101
    bos_gaurus                           101
    bos_sauveli                          101
    boselaphus_tragocamelus              100
```
and you want to use the `mnStochasticCharacterMap` monitor. The tutorial works fine because there is only one character, but if you exclude the 1st and 3rd character, and want to draw stochastic character maps from the 2nd character, you can get some unexpected results. I think it is because there is some problem with the site or character indices

This is the results from before the change (black is character state 0 and red is character state 1)
<img src="https://github.com/user-attachments/assets/da8c7a46-1572-43ac-aa7e-8d340b4fde0e" width="550">
For example, look at `batomys_salomonseni` and `batomys_granti` which have the incorrect state (the 2nd character, middle column of the matrix) at the tip. In `bandicota_savilei`, however, both the 1st and 2nd character are coded as a 0, and therefore we are lucky and we get the "correct" character state for the tip. You can see many of the taxa that the incorrect tip states are assigned

and this is the results from after the change
<img src="https://github.com/user-attachments/assets/291990d6-80f9-4e38-9268-2a55466bac97" width="550">
which looks more reasonable

I only changed a couple lines in the code but I am not sure whether one should do other edits as well

Also attaching the data and code for how to reproduce it
[ase_debug_mwe.zip](https://github.com/user-attachments/files/18292009/ase_debug_mwe.zip)