### PR TITLE
Bump version after v1.2.5 release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# RevBayes 1.2.6 (unreleased)
+
+
 # RevBayes 1.2.5 (Dec 19, 2025)
 
 ## Backwards-incompatible changes

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('RevBayes', ['cpp', 'c'],
-        version: '1.2.5',
+        version: '1.2.6-preview',
         default_options: [
           'buildtype=release',
           'cpp_std=c++17',

--- a/src/revlanguage/utils/RbVersion.cpp
+++ b/src/revlanguage/utils/RbVersion.cpp
@@ -34,7 +34,7 @@ std::string RbVersion::getGitCommit( void ) const
 
 std::string RbVersion::getVersion( void ) const
 {
-    return "1.2.5";
+    return "1.2.6-preview";
 }
 
 


### PR DESCRIPTION
Bump version to v1.2.6-preview after v1.2.5 release.