### PR TITLE
Better convergence msg

### DIFF
--- a/src/core/analysis/MonteCarloAnalysis.cpp
+++ b/src/core/analysis/MonteCarloAnalysis.cpp
@@ -162,9 +162,9 @@ void MonteCarloAnalysis::addMonitor(const Monitor &m)
 
 /** Run burnin and auto-tune */
 #ifdef RB_MPI
-void MonteCarloAnalysis::burnin(size_t generations, const MPI_Comm &analysis_comm, size_t tuningInterval, bool verbose)
+void MonteCarloAnalysis::burnin(size_t generations, const MPI_Comm &analysis_comm, size_t tuningInterval, int verbose)
 #else
-void MonteCarloAnalysis::burnin(size_t generations, size_t tuningInterval, bool verbose)
+void MonteCarloAnalysis::burnin(size_t generations, size_t tuningInterval, int verbose)
 #endif
 {
     
@@ -194,7 +194,7 @@ void MonteCarloAnalysis::burnin(size_t generations, size_t tuningInterval, bool 
     // start the progress bar
     ProgressBar progress = ProgressBar(generations, 0);
 
-    if ( verbose == true && runs[0] != NULL && process_active == true )
+    if ( verbose >= 1 && runs[0] != NULL && process_active == true )
     {
         // Let user know what we are doing
         std::stringstream ss;
@@ -213,7 +213,7 @@ void MonteCarloAnalysis::burnin(size_t generations, size_t tuningInterval, bool 
     for (size_t k=1; k<=generations; ++k)
     {
         
-        if ( verbose == true && process_active == true)
+        if ( verbose >= 1 && process_active == true)
         {
             progress.update(k);
         }
@@ -241,7 +241,7 @@ void MonteCarloAnalysis::burnin(size_t generations, size_t tuningInterval, bool 
     MPI_Barrier(MPI_COMM_WORLD);
 #endif
     
-    if ( verbose == true && process_active == true )
+    if ( verbose >= 1 && process_active == true )
     {
         progress.finish();
     }
@@ -562,9 +562,9 @@ void MonteCarloAnalysis::resetReplicates( void )
 
 
 #ifdef RB_MPI
-void MonteCarloAnalysis::run( size_t kIterations, RbVector<StoppingRule> rules, const MPI_Comm &analysis_comm, size_t tuning_interval, const path &checkpoint_file, size_t checkpoint_interval, bool verbose )
+void MonteCarloAnalysis::run( size_t kIterations, RbVector<StoppingRule> rules, const MPI_Comm &analysis_comm, size_t tuning_interval, const path &checkpoint_file, size_t checkpoint_interval, int verbose )
 #else
-void MonteCarloAnalysis::run( size_t kIterations, RbVector<StoppingRule> rules, size_t tuning_interval, const path &checkpoint_file, size_t checkpoint_interval, bool verbose )
+void MonteCarloAnalysis::run( size_t kIterations, RbVector<StoppingRule> rules, size_t tuning_interval, const path &checkpoint_file, size_t checkpoint_interval, int verbose )
 #endif
 {
     
@@ -604,7 +604,7 @@ void MonteCarloAnalysis::run( size_t kIterations, RbVector<StoppingRule> rules, 
     
     // Let user know what we are doing
     std::stringstream ss;
-    if ( process_active == true && runs[0] != NULL && verbose == true )
+    if ( process_active == true && runs[0] != NULL && verbose >= 1 )
     {
         
         if ( runs[0]->getCurrentGeneration() == 0 )

--- a/src/core/analysis/MonteCarloAnalysis.cpp
+++ b/src/core/analysis/MonteCarloAnalysis.cpp
@@ -551,7 +551,7 @@ void MonteCarloAnalysis::resetReplicates( void )
     
     // to be safe, we should synchronize the random number generators
     // Sebastian: We cannot re-synchronize the RNG after we just shifted it.
-    // If an anlysis has all values preset, then each replicate would be identical!!!
+    // If an analysis had all values preset, then each replicate would be identical!!!
 //#ifdef RB_MPI
 //    MpiUtilities::synchronizeRNG( analysis_comm );
 //#else
@@ -620,7 +620,7 @@ void MonteCarloAnalysis::run( size_t kIterations, RbVector<StoppingRule> rules, 
         ss << runs[0]->getStrategyDescription();
         
         // Print stopping rule targets only if have more than one or if the only one we have is not MaxIteration
-        if (rules.size() > 1 || rules[0].printAsStatement(0) != "")
+        if (rules.size() > 1 || rules[0].printAsStatement(0, true) != "")
         {
             ss << "\n";
             ss << "Stopping rule" << (rules.size() > 1 ? "s" : "") << ":\n";

--- a/src/core/analysis/MonteCarloAnalysis.cpp
+++ b/src/core/analysis/MonteCarloAnalysis.cpp
@@ -618,6 +618,18 @@ void MonteCarloAnalysis::run( size_t kIterations, RbVector<StoppingRule> rules, 
         }
         ss << "This simulation runs " << replicates << " independent replicate" << (replicates > 1 ? "s" : "") << ".\n";
         ss << runs[0]->getStrategyDescription();
+        
+        // Print stopping rule targets only if have more than one or if the only one we have is not MaxIteration
+        if (rules.size() > 1 || rules[0].printAsStatement(0) != "")
+        {
+            ss << "\n";
+            ss << "Stopping rule" << (rules.size() > 1 ? "s" : "") << ":\n";
+            for (size_t i=0; i<rules.size(); ++i)
+            {
+                ss << "    " << rules[i].printAsStatement(0, true);
+            }
+        }
+        
         RBOUT( ss.str() );
     }
     

--- a/src/core/analysis/MonteCarloAnalysis.h
+++ b/src/core/analysis/MonteCarloAnalysis.h
@@ -48,9 +48,9 @@ namespace RevBayesCore {
         void                                                addMonitor(const Monitor &m);
         MonteCarloAnalysis*                                 clone(void) const;                                              //!< Clone function. This is similar to the copy constructor but useful in inheritance.
 #ifdef RB_MPI
-        void                                                burnin(size_t g, const MPI_Comm &c, size_t ti, bool verbose=true);
+        void                                                burnin(size_t g, const MPI_Comm &c, size_t ti, int verbose=1);
 #else
-        void                                                burnin(size_t g, size_t ti, bool verbose=true);
+        void                                                burnin(size_t g, size_t ti, int verbose=1);
 #endif
         void                                                disableScreenMonitors(bool all);
         size_t                                              getCurrentGeneration(void) const;                               //!< Get the current generations number
@@ -59,9 +59,9 @@ namespace RevBayesCore {
         void                                                printPerformanceSummary(bool current_period = false) const;
         void                                                removeMonitors(void);                                           //!< Remove all monitors
 #ifdef RB_MPI
-        void                                                run(size_t k, RbVector<StoppingRule> r, const MPI_Comm &c, size_t ti, const path &cp_file, size_t ci=0, bool verbose=true);
+        void                                                run(size_t k, RbVector<StoppingRule> r, const MPI_Comm &c, size_t ti, const path &cp_file, size_t ci=0, int verbose=1);
 #else
-        void                                                run(size_t k, RbVector<StoppingRule> r, size_t ti, const path &cp_file, size_t ci=0, bool verbose=true);
+        void                                                run(size_t k, RbVector<StoppingRule> r, size_t ti, const path &cp_file, size_t ci=0, int verbose=1);
 #endif
 #ifdef RB_MPI
         void                                                setModel(Model *m, bool redraw, const MPI_Comm &c);

--- a/src/core/analysis/PosteriorPredictiveAnalysis.cpp
+++ b/src/core/analysis/PosteriorPredictiveAnalysis.cpp
@@ -209,9 +209,9 @@ void PosteriorPredictiveAnalysis::runSim(MonteCarloAnalysis *sampler, size_t gen
     rules.push_back( MaxIterationStoppingRule(gen + currentGen) );
     
 #ifdef RB_MPI
-    sampler->run(gen, rules, c, 100, "", 0, false);
+    sampler->run(gen, rules, c, 100, "", 0, 0);
 #else
-    sampler->run(gen, rules, 100, "", 0, false);
+    sampler->run(gen, rules, 100, "", 0, 0);
 #endif
     
 }

--- a/src/core/analysis/ValidationAnalysis.cpp
+++ b/src/core/analysis/ValidationAnalysis.cpp
@@ -238,9 +238,9 @@ void ValidationAnalysis::burnin(size_t generations, size_t tuningInterval)
         if ( runs[i] == NULL ) std::cerr << "Runing bad burnin (pid=" << pid <<", run="<< i << ") of runs.size()=" << runs.size() << "." << std::endl;
         // run the i-th analyses
 #ifdef RB_MPI
-        runs[i]->burnin(generations, MPI_COMM_WORLD, tuningInterval, false);
+        runs[i]->burnin(generations, MPI_COMM_WORLD, tuningInterval, 0);
 #else
-        runs[i]->burnin(generations, tuningInterval, false);
+        runs[i]->burnin(generations, tuningInterval, 0);
 #endif
         if ( process_active == true )
         {
@@ -329,9 +329,9 @@ void ValidationAnalysis::runSim(size_t idx, size_t gen)
     
     
 #ifdef RB_MPI
-    analysis->run(gen, rules, MPI_COMM_WORLD, 100, "", 0, false);
+    analysis->run(gen, rules, MPI_COMM_WORLD, 100, "", 0, 0);
 #else
-    analysis->run(gen, rules, 100, "", 0, false);
+    analysis->run(gen, rules, 100, "", 0, 0);
 #endif
 
 }

--- a/src/core/analysis/stoppingRule/AbstractConvergenceStoppingRule.h
+++ b/src/core/analysis/stoppingRule/AbstractConvergenceStoppingRule.h
@@ -38,7 +38,7 @@ namespace RevBayesCore {
 
         virtual AbstractConvergenceStoppingRule*            clone(void) const = 0;                                      //!< Clone function. This is similar to the copy constructor but useful in inheritance.
         virtual double                                      getStatistic(size_t g) = 0;                                 //!< Compute the value of the rule's test statistic / criterion at generation g.
-        virtual std::string                                 printAsStatement(size_t g) = 0;                             //!< Print a statement about the current value of the rule's test statistic / criterion.
+        virtual std::string                                 printAsStatement(size_t g, bool target_only) = 0;           //!< Print a statement about the current value of the rule's test statistic / criterion, or just the target value.
         virtual bool                                        stop(size_t g) = 0;                                         //!< Should we stop at generation g?
         
     protected:

--- a/src/core/analysis/stoppingRule/GelmanRubinStoppingRule.cpp
+++ b/src/core/analysis/stoppingRule/GelmanRubinStoppingRule.cpp
@@ -132,16 +132,26 @@ double GelmanRubinStoppingRule::getStatistic( size_t g )
 }
 
 
-std::string GelmanRubinStoppingRule::printAsStatement( size_t g )
+std::string GelmanRubinStoppingRule::printAsStatement( size_t g, bool target_only )
 {
     // Nicely format the target value
     std::stringstream tss;
     tss << std::setprecision(5) << std::noshowpoint << R;
     std::string target = tss.str();
     
-    double val = getStatistic(g);
-    std::string preamble = "Maximum value of the Gelman-Rubin statistic (PSRF): ";
-    std::string statement = preamble + std::to_string(val) + " (target: < " + target + ")\n";
+    std::string statement;
+    
+    if (target_only)
+    {
+        statement = "Target value for the Gelman-Rubin statistic (PSRF): < " + target + "\n";
+    }
+    else
+    {
+        double val = getStatistic(g);
+        std::string preamble = "Maximum value of the Gelman-Rubin statistic (PSRF): ";
+        statement = preamble + std::to_string(val) + " (target: < " + target + ")\n";
+    }
+    
     return statement;
 }
 

--- a/src/core/analysis/stoppingRule/GelmanRubinStoppingRule.h
+++ b/src/core/analysis/stoppingRule/GelmanRubinStoppingRule.h
@@ -33,7 +33,7 @@ namespace RevBayesCore {
         GelmanRubinStoppingRule*                            clone(void) const;                                          //!< Clone function. This is similar to the copy constructor but useful in inheritance.
         void                                                setNumberOfRuns(size_t n);                                  //!< Set how many runs/replicates there are.
         double                                              getStatistic(size_t g);                                     //!< Compute the value of the rule's test statistic / criterion at generation g.
-        std::string                                         printAsStatement(size_t g);                                 //!< Print a statement about the current value of the rule's test statistic / criterion.
+        std::string                                         printAsStatement(size_t g, bool target_only);               //!< Print a statement about the current value of the rule's test statistic / criterion, or just the target value.
         bool                                                stop(size_t g);                                             //!< Should we stop at generation g?
         
     private:

--- a/src/core/analysis/stoppingRule/GewekeStoppingRule.cpp
+++ b/src/core/analysis/stoppingRule/GewekeStoppingRule.cpp
@@ -113,7 +113,7 @@ std::string GewekeStoppingRule::printAsStatement( size_t g, bool target_only )
     
     if (target_only)
     {
-        statement = "Target value of the Geweke test statistic: > " + lbound + "and < " + ubound;
+        statement = "Target value of the Geweke test statistic: > " + lbound + " and < " + ubound + "\n";
     }
     else
     {

--- a/src/core/analysis/stoppingRule/GewekeStoppingRule.cpp
+++ b/src/core/analysis/stoppingRule/GewekeStoppingRule.cpp
@@ -98,15 +98,8 @@ double GewekeStoppingRule::getStatistic( size_t g )
 }
 
 
-std::string GewekeStoppingRule::printAsStatement( size_t g )
+std::string GewekeStoppingRule::printAsStatement( size_t g, bool target_only )
 {
-    // Note that # of comparisons = (# of replicates) * (# of parameters)
-    // If there are multiple runs, we will grab the # of parameters from the 1st run
-    path fn = (numReplicates > 1) ? appendToStem(filename, "_run_" + StringUtilities::to_string(1)) : filename;
-    TraceContinuousReader reader = TraceContinuousReader( fn );
-    std::vector<TraceNumeric> &data = reader.getTraces();
-    size_t nComp = numReplicates * data.size();
-    
     // Nicely format the confidence interval bounds
     std::stringstream lss;
     lss << std::setprecision(5) << std::noshowpoint << alpha/2;
@@ -116,9 +109,26 @@ std::string GewekeStoppingRule::printAsStatement( size_t g )
     uss << std::setprecision(5) << std::noshowpoint << 1 - alpha/2;
     std::string ubound = uss.str();
     
-    size_t val = (size_t)getStatistic(g);
-    std::string pt1 = "Comparisons in which the Geweke test statistic is < " + lbound + " or > " + ubound + ": " + std::to_string(val);
-    std::string statement = pt1 + "/" + std::to_string(nComp) + " (target: 0/" + std::to_string(nComp) + ")\n";
+    std::string statement;
+    
+    if (target_only)
+    {
+        statement = "Target value of the Geweke test statistic: > " + lbound + "and < " + ubound;
+    }
+    else
+    {
+        // Note that # of comparisons = (# of replicates) * (# of parameters)
+        // If there are multiple runs, we will grab the # of parameters from the 1st run
+        path fn = (numReplicates > 1) ? appendToStem(filename, "_run_" + StringUtilities::to_string(1)) : filename;
+        TraceContinuousReader reader = TraceContinuousReader( fn );
+        std::vector<TraceNumeric> &data = reader.getTraces();
+        size_t nComp = numReplicates * data.size();
+        
+        size_t val = (size_t)getStatistic(g);
+        std::string pt1 = "Comparisons in which the Geweke test statistic is < " + lbound + " or > " + ubound + ": " + std::to_string(val);
+        statement = pt1 + "/" + std::to_string(nComp) + " (target: 0/" + std::to_string(nComp) + ")\n";
+    }
+    
     return statement;
 }
 

--- a/src/core/analysis/stoppingRule/GewekeStoppingRule.h
+++ b/src/core/analysis/stoppingRule/GewekeStoppingRule.h
@@ -29,7 +29,7 @@ namespace RevBayesCore {
         // public methods
         GewekeStoppingRule*                                 clone(void) const;                                          //!< Clone function. This is similar to the copy constructor but useful in inheritance.
         double                                              getStatistic(size_t g);                                     //!< Compute the value of the rule's test statistic / criterion at generation g.
-        std::string                                         printAsStatement(size_t g);                                 //!< Print a statement about the current value of the rule's test statistic / criterion.
+        std::string                                         printAsStatement(size_t g, bool target_only);               //!< Print a statement about the current value of the rule's test statistic / criterion, or just the target value.
         bool                                                stop(size_t g);                                             //!< Should we stop at generation g?
         
     private:

--- a/src/core/analysis/stoppingRule/MaxIterationStoppingRule.cpp
+++ b/src/core/analysis/stoppingRule/MaxIterationStoppingRule.cpp
@@ -82,8 +82,9 @@ double MaxIterationStoppingRule::getStatistic( size_t g )
 }
 
 
-std::string MaxIterationStoppingRule::printAsStatement( size_t g )
+std::string MaxIterationStoppingRule::printAsStatement( size_t g, bool target_only )
 {
+    // We always return an empty string regardless of the arguments
     std::string statement = "";
     return statement;
 }

--- a/src/core/analysis/stoppingRule/MaxIterationStoppingRule.h
+++ b/src/core/analysis/stoppingRule/MaxIterationStoppingRule.h
@@ -35,7 +35,7 @@ namespace RevBayesCore {
         void                                                runStarted(void);                                           //!< The run just started. Here we do not need to do anything.
         void                                                setNumberOfRuns(size_t n);                                  //!< Set how many runs/replicates there are.
         double                                              getStatistic(size_t g);                                     //!< Compute the value of the rule's test statistic / criterion at generation g.
-        std::string                                         printAsStatement(size_t g);                                 //!< Print a statement about the current value of the rule's test statistic / criterion.
+        std::string                                         printAsStatement(size_t g, bool target_only);               //!< Print a statement about the current value of the rule's test statistic / criterion, or just the target value.
         bool                                                stop(size_t g);                                             //!< Should we stop at generation g?
         
     private:

--- a/src/core/analysis/stoppingRule/MaxTimeStoppingRule.cpp
+++ b/src/core/analysis/stoppingRule/MaxTimeStoppingRule.cpp
@@ -87,19 +87,8 @@ double MaxTimeStoppingRule::getStatistic( size_t g )
 }
 
 
-std::string MaxTimeStoppingRule::printAsStatement( size_t g )
+std::string MaxTimeStoppingRule::printAsStatement( size_t g, bool target_only )
 {
-    double timeUsed = getStatistic(g);
-    
-    std::stringstream ess;
-    size_t elapsed_hours   = timeUsed / 3600;
-    size_t elapsed_minutes = timeUsed / 60 - elapsed_hours * 60;
-    size_t elapsed_seconds = timeUsed - elapsed_minutes * 60 - elapsed_hours * 3600;
-    
-    ess << std::setw( 2 ) << std::setfill( '0' ) << elapsed_hours << ":";
-    ess << std::setw( 2 ) << std::setfill( '0' ) << elapsed_minutes << ":";
-    ess << std::setw( 2 ) << std::setfill( '0' ) << elapsed_seconds;
-    
     std::stringstream mss;
     size_t max_hours   = maxTime / 3600;
     size_t max_minutes = maxTime / 60 - max_hours * 60;
@@ -109,10 +98,29 @@ std::string MaxTimeStoppingRule::printAsStatement( size_t g )
     mss << std::setw( 2 ) << std::setfill( '0' ) << max_minutes << ":";
     mss << std::setw( 2 ) << std::setfill( '0' ) << max_seconds;
     
-    std::string elapsed = ess.str();
     std::string allowed = mss.str();
+    std::string statement;
     
-    std::string statement = "Elapsed time: " + elapsed + " (target: " + allowed + ")\n";
+    if (target_only)
+    {
+        statement = "Maximum allowed time: " + allowed + "\n";
+    }
+    else
+    {
+        double timeUsed = getStatistic(g);
+        
+        std::stringstream ess;
+        size_t elapsed_hours   = timeUsed / 3600;
+        size_t elapsed_minutes = timeUsed / 60 - elapsed_hours * 60;
+        size_t elapsed_seconds = timeUsed - elapsed_minutes * 60 - elapsed_hours * 3600;
+        
+        ess << std::setw( 2 ) << std::setfill( '0' ) << elapsed_hours << ":";
+        ess << std::setw( 2 ) << std::setfill( '0' ) << elapsed_minutes << ":";
+        ess << std::setw( 2 ) << std::setfill( '0' ) << elapsed_seconds;
+        
+        statement = "Elapsed time: " + ess.str() + " (target: " + allowed + ")\n";
+    }
+    
     return statement;
 }
 

--- a/src/core/analysis/stoppingRule/MaxTimeStoppingRule.h
+++ b/src/core/analysis/stoppingRule/MaxTimeStoppingRule.h
@@ -34,7 +34,7 @@ namespace RevBayesCore {
         void                                                runStarted(void);                                           //!< The run just started. Here we do not need to do anything.
         void                                                setNumberOfRuns(size_t n);                                  //!< Set how many runs/replicates there are.
         double                                              getStatistic(size_t g);                                     //!< Compute the value of the rule's test statistic / criterion at generation g.
-        std::string                                         printAsStatement(size_t g);                                 //!< Print a statement about the current value of the rule's test statistic / criterion.
+        std::string                                         printAsStatement(size_t g, bool target_only);               //!< Print a statement about the current value of the rule's test statistic / criterion, or just the target value.
         bool                                                stop(size_t g);                                             //!< Should we stop at generation g?
         
     private:

--- a/src/core/analysis/stoppingRule/MinEssStoppingRule.cpp
+++ b/src/core/analysis/stoppingRule/MinEssStoppingRule.cpp
@@ -92,16 +92,26 @@ double MinEssStoppingRule::getStatistic( size_t g )
 }
 
 
-std::string MinEssStoppingRule::printAsStatement( size_t g )
+std::string MinEssStoppingRule::printAsStatement( size_t g, bool target_only )
 {
     // Nicely format the target value
     std::stringstream tss;
     tss << std::setprecision(5) << std::noshowpoint << minEss;
     std::string target = tss.str();
     
-    double val = getStatistic(g);
-    std::string preamble = "Minimum effective sample size (ESS): ";
-    std::string statement = preamble + std::to_string(val) + " (target: > " + target + ")\n";
+    std::string statement;
+    
+    if (target_only)
+    {
+        statement = "Target value for effective sample size (ESS): > " + target + "\n";
+    }
+    else
+    {
+        double val = getStatistic(g);
+        std::string preamble = "Minimum effective sample size (ESS): ";
+        statement = preamble + std::to_string(val) + " (target: > " + target + ")\n";
+    }
+    
     return statement;
 }
 

--- a/src/core/analysis/stoppingRule/MinEssStoppingRule.h
+++ b/src/core/analysis/stoppingRule/MinEssStoppingRule.h
@@ -28,7 +28,7 @@ namespace RevBayesCore {
         // public methods
         MinEssStoppingRule*                                 clone(void) const;                                          //!< Clone function. This is similar to the copy constructor but useful in inheritance.
         double                                              getStatistic(size_t g);                                     //!< Compute the value of the rule's test statistic / criterion at generation g.
-        std::string                                         printAsStatement(size_t g);                                 //!< Print a statement about the current value of the rule's test statistic / criterion.
+        std::string                                         printAsStatement(size_t g, bool target_only);               //!< Print a statement about the current value of the rule's test statistic / criterion, or just the target value.
         bool                                                stop(size_t g);                                             //!< Should we stop at generation g?
         
     private:

--- a/src/core/analysis/stoppingRule/StationarityStoppingRule.cpp
+++ b/src/core/analysis/stoppingRule/StationarityStoppingRule.cpp
@@ -131,23 +131,32 @@ double StationarityStoppingRule::getStatistic( size_t g )
 }
 
 
-std::string StationarityStoppingRule::printAsStatement( size_t g )
+std::string StationarityStoppingRule::printAsStatement( size_t g, bool target_only )
 {
-    // Note that # of comparisons = (# of replicates) * (# of parameters)
-    // If there are multiple runs, we will grab the # of parameters from the 1st run
-    path fn = (numReplicates > 1) ? appendToStem(filename, "_run_" + StringUtilities::to_string(1)) : filename;
-    TraceContinuousReader reader = TraceContinuousReader( fn );
-    std::vector<TraceNumeric> &data = reader.getTraces();
-    size_t nComp = numReplicates * data.size();
-    
     // Nicely format the target value
     std::stringstream tss;
     tss << std::setprecision(5) << std::noshowpoint << prob;
     std::string target = tss.str();
     
-    size_t val = (size_t)getStatistic(g);
-    std::string preamble = "Comparisons in which the CI of a single-chain mean excludes the overall mean at p = " + target + ": ";
-    std::string statement = preamble + std::to_string(val) + "/" + std::to_string(nComp) + " (target: 0/" + std::to_string(nComp) + ")\n";
+    std::string statement;
+    
+    if (target_only)
+    {
+        statement = "P-value used to test the inclusion of the overall mean in the CI of a single-chain mean: " + target + "\n";
+    }
+    else {
+        // Note that # of comparisons = (# of replicates) * (# of parameters)
+        // If there are multiple runs, we will grab the # of parameters from the 1st run
+        path fn = (numReplicates > 1) ? appendToStem(filename, "_run_" + StringUtilities::to_string(1)) : filename;
+        TraceContinuousReader reader = TraceContinuousReader( fn );
+        std::vector<TraceNumeric> &data = reader.getTraces();
+        size_t nComp = numReplicates * data.size();
+        
+        size_t val = (size_t)getStatistic(g);
+        std::string preamble = "Comparisons in which the CI of a single-chain mean excludes the overall mean at p = " + target + ": ";
+        statement = preamble + std::to_string(val) + "/" + std::to_string(nComp) + " (target: 0/" + std::to_string(nComp) + ")\n";
+    }
+    
     return statement;
 }
 

--- a/src/core/analysis/stoppingRule/StationarityStoppingRule.h
+++ b/src/core/analysis/stoppingRule/StationarityStoppingRule.h
@@ -33,7 +33,7 @@ namespace RevBayesCore {
         StationarityStoppingRule*           clone(void) const;                                                //!< Clone function. This is similar to the copy constructor but useful in inheritance.
         void                                setNumberOfRuns(size_t n);                                        //!< Set how many runs/replicates there are.
         double                              getStatistic(size_t g);                                           //!< Compute the value of the rule's test statistic / criterion at generation g.
-        std::string                         printAsStatement(size_t g);                                       //!< Print a statement about the current value of the rule's test statistic / criterion.
+        std::string                         printAsStatement(size_t g, bool target_only);                     //!< Print a statement about the current value of the rule's test statistic / criterion, or just the target value.
         bool                                stop(size_t g);                                                   //!< Should we stop at generation g?
         
     private:

--- a/src/core/analysis/stoppingRule/StoppingRule.h
+++ b/src/core/analysis/stoppingRule/StoppingRule.h
@@ -33,7 +33,7 @@ namespace RevBayesCore {
         virtual void                                        runStarted(void) = 0;                                       //!< The run just started. Here we can set any flags like the timer.
         virtual void                                        setNumberOfRuns(size_t n) = 0;                              //!< Set how many runs/replicates there are.
         virtual double                                      getStatistic(size_t g) = 0;                                 //!< Compute the value of the rule's test statistic / criterion at generation g.
-        virtual std::string                                 printAsStatement(size_t g) = 0;                             //!< Print a statement about the current value of the rule's test statistic / criterion.
+        virtual std::string                                 printAsStatement(size_t g, bool target_only = false) = 0;   //!< Print a statement about the current value of the rule's test statistic / criterion, or just the target value.
         virtual bool                                        stop(size_t g) = 0;                                         //!< Should we stop at generation g?
         
     protected:

--- a/src/revlanguage/analysis/mcmc/RlMonteCarloAnalysis.cpp
+++ b/src/revlanguage/analysis/mcmc/RlMonteCarloAnalysis.cpp
@@ -149,13 +149,15 @@ RevPtr<RevVariable> MonteCarloAnalysis::executeMethod(std::string const &name, c
         {
             throw RbException("For checkpointing you have to provide both the checkpoint file and the checkpoint frequency (interval).");
         }
+        
+        int verbose = (int)static_cast<const Natural &>( args[args_index++].getVariable()->getRevObject() ).getValue();
 
         deprecateUnderPrior("run", args[args_index++]);
 
 #ifdef RB_MPI
-        value->run( gen, rules, MPI_COMM_WORLD, tuning_interval, checkpoint_file, checkpoint_interval );
+        value->run( gen, rules, MPI_COMM_WORLD, tuning_interval, checkpoint_file, checkpoint_interval, verbose );
 #else
-        value->run( gen, rules, tuning_interval, checkpoint_file, checkpoint_interval );
+        value->run( gen, rules, tuning_interval, checkpoint_file, checkpoint_interval, verbose );
 #endif
         return NULL;
     }
@@ -166,13 +168,14 @@ RevPtr<RevVariable> MonteCarloAnalysis::executeMethod(std::string const &name, c
         // get the member with give index
         int gen = (int)static_cast<const Natural &>( args[0].getVariable()->getRevObject() ).getValue();
         int tuningInterval = (int)static_cast<const Natural &>( args[1].getVariable()->getRevObject() ).getValue();
+        int verbose = (int)static_cast<const Natural &>( args[2].getVariable()->getRevObject() ).getValue();
 
-        deprecateUnderPrior("burnin", args[2]);
+        deprecateUnderPrior("burnin", args[3]);
 
 #ifdef RB_MPI
-        value->burnin( gen, MPI_COMM_WORLD, tuningInterval );
+        value->burnin( gen, MPI_COMM_WORLD, tuningInterval, verbose );
 #else
-        value->burnin( gen, tuningInterval );
+        value->burnin( gen, tuningInterval, verbose );
 #endif
         
         return NULL;
@@ -281,12 +284,14 @@ void MonteCarloAnalysis::initializeMethods()
     run_arg_rules->push_back( new ArgumentRule( "tuningInterval", Natural::getClassTypeSpec(), "The interval when to update the tuning parameters of the moves.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new Natural(0L)  ) );
     run_arg_rules->push_back( new ArgumentRule( "checkpointFile", RlString::getClassTypeSpec(), "The filename for the checkpoint file.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("")  ) );
     run_arg_rules->push_back( new ArgumentRule( "checkpointInterval", Natural::getClassTypeSpec(), "The interval when to write parameters values to a files for checkpointing.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new Natural(0L)  ) );
+    run_arg_rules->push_back( new ArgumentRule( "verbose" , Natural::getClassTypeSpec(), "How much information to print to the screen (0: none, 1: basic information only, 2: more information at extra CPU time cost).", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new Natural(1L)  ) );
     run_arg_rules->push_back( new ArgumentRule( "underPrior" , RlBoolean::getClassTypeSpec(), "DEPRECATED", ArgumentRule::BY_VALUE, ArgumentRule::ANY, nullptr ) );
     methods.addFunction( new MemberProcedure( "run", RlUtils::Void, run_arg_rules) );
 
     ArgumentRules* burninArgRules = new ArgumentRules();
     burninArgRules->push_back( new ArgumentRule( "generations"   , Natural::getClassTypeSpec(), "The number of generation to run this burnin simulation.", ArgumentRule::BY_VALUE, ArgumentRule::ANY  ) );
     burninArgRules->push_back( new ArgumentRule( "tuningInterval", Natural::getClassTypeSpec(), "The interval when to update the tuning parameters of the moves.", ArgumentRule::BY_VALUE, ArgumentRule::ANY  ) );
+    burninArgRules->push_back( new ArgumentRule( "verbose", Natural::getClassTypeSpec(), "How much information to print to the screen (0: none, 1: basic information only, 2: more information at extra CPU time cost).", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new Natural(1L)  ) );
     burninArgRules->push_back( new ArgumentRule( "underPrior" , RlBoolean::getClassTypeSpec(), "DEPRECATED", ArgumentRule::BY_VALUE, ArgumentRule::ANY, nullptr ) );
     methods.addFunction( new MemberProcedure( "burnin", RlUtils::Void, burninArgRules) );
 

--- a/src/revlanguage/main.cpp
+++ b/src/revlanguage/main.cpp
@@ -163,11 +163,6 @@ int main(int argc, char* argv[]) {
         exit(0);
     }
 
-    if ( args.count("verbose") > 0 )
-    {
-        int verbosity = args["verbose"].as<int>();
-    }
-
     if ( args.count("setOption") > 0 )
     {
         std::vector<std::string> options = args["setOption"].as<std::vector<std::string> >();

--- a/tests/test_convergenceRules/output_expected/Test_ESS.errout
+++ b/tests/test_convergenceRules/output_expected/Test_ESS.errout
@@ -3,6 +3,9 @@
    This simulation runs 4 independent replicates.
    The simulator uses 1 different moves in a random move schedule with 1 moves per iteration
    
+   Stopping rule:
+       Target value for effective sample size (ESS): > 50
+   
    
    Minimum effective sample size (ESS): 9.636138 (target: > 50)
    

--- a/tests/test_convergenceRules/output_expected/Test_GelmanRubin.errout
+++ b/tests/test_convergenceRules/output_expected/Test_GelmanRubin.errout
@@ -3,6 +3,9 @@
    This simulation runs 4 independent replicates.
    The simulator uses 1 different moves in a random move schedule with 1 moves per iteration
    
+   Stopping rule:
+       Target value for the Gelman-Rubin statistic (PSRF): < 1.01
+   
    
    Maximum value of the Gelman-Rubin statistic (PSRF): 1.013099 (target: < 1.01)
    

--- a/tests/test_convergenceRules/output_expected/Test_Geweke.errout
+++ b/tests/test_convergenceRules/output_expected/Test_Geweke.errout
@@ -3,6 +3,9 @@
    This simulation runs 4 independent replicates.
    The simulator uses 1 different moves in a random move schedule with 1 moves per iteration
    
+   Stopping rule:
+       Target value of the Geweke test statistic: > 0.0005 and < 0.9995
+   
    
    Comparisons in which the Geweke test statistic is < 0.0005 or > 0.9995: 15/20 (target: 0/20)
    

--- a/tests/test_convergenceRules/output_expected/Test_multipleRules.errout
+++ b/tests/test_convergenceRules/output_expected/Test_multipleRules.errout
@@ -3,6 +3,12 @@
    This simulation runs 4 independent replicates.
    The simulator uses 1 different moves in a random move schedule with 1 moves per iteration
    
+   Stopping rules:
+       Target value for effective sample size (ESS): > 50
+       Target value for the Gelman-Rubin statistic (PSRF): < 1.01
+       Target value of the Geweke test statistic: > 0.0005 and < 0.9995
+       P-value used to test the inclusion of the overall mean in the CI of a single-chain mean: 0.25
+   
    
    Minimum effective sample size (ESS): 9.636138 (target: > 50)
    Maximum value of the Gelman-Rubin statistic (PSRF): 1.013099 (target: < 1.01)

--- a/tests/test_convergenceRules/output_expected/Test_stationarity.errout
+++ b/tests/test_convergenceRules/output_expected/Test_stationarity.errout
@@ -3,6 +3,9 @@
    This simulation runs 4 independent replicates.
    The simulator uses 1 different moves in a random move schedule with 1 moves per iteration
    
+   Stopping rule:
+       P-value used to test the inclusion of the overall mean in the CI of a single-chain mean: 0.25
+   
    
    Comparisons in which the CI of a single-chain mean excludes the overall mean at p = 0.25: 5/20 (target: 0/20)
    

--- a/tests/test_convergenceRules/scripts/Test_ESS.Rev
+++ b/tests/test_convergenceRules/scripts/Test_ESS.Rev
@@ -41,7 +41,7 @@ mymcmc = mcmc(mymodel, monitors, moves, nruns = 4)
 stopping_rules[1] = srMinESS(50, file = "output/ESS_test.log", freq = 1000)
 
 # Start the MCMC run
-mymcmc.run(rules = stopping_rules)
+mymcmc.run(rules = stopping_rules, verbose = 2)
 
 clear()
 q()

--- a/tests/test_convergenceRules/scripts/Test_GelmanRubin.Rev
+++ b/tests/test_convergenceRules/scripts/Test_GelmanRubin.Rev
@@ -41,7 +41,7 @@ mymcmc = mcmc(mymodel, monitors, moves, nruns = 4)
 stopping_rules[1] = srGelmanRubin(1.01, file = "output/GelmanRubin_test.log", freq = 1000)
 
 # Start the MCMC run
-mymcmc.run(rules = stopping_rules)
+mymcmc.run(rules = stopping_rules, verbose = 2)
 
 clear()
 q()

--- a/tests/test_convergenceRules/scripts/Test_Geweke.Rev
+++ b/tests/test_convergenceRules/scripts/Test_Geweke.Rev
@@ -43,7 +43,7 @@ mymcmc = mcmc(mymodel, monitors, moves, nruns = 4)
 stopping_rules[1] = srGeweke(0.001, file = "output/Geweke_test.log", freq = 1000)
 
 # Start the MCMC run
-mymcmc.run(rules = stopping_rules)
+mymcmc.run(rules = stopping_rules, verbose = 2)
 
 clear()
 q()

--- a/tests/test_convergenceRules/scripts/Test_multipleRules.Rev
+++ b/tests/test_convergenceRules/scripts/Test_multipleRules.Rev
@@ -44,7 +44,7 @@ stopping_rules[3] = srGeweke(0.001, file = "output/multipleRules_test.log", freq
 stopping_rules[4] = srStationarity(0.25, file = "output/multipleRules_test.log", freq = 1000)
 
 # Start the MCMC run
-mymcmc.run(rules = stopping_rules)
+mymcmc.run(rules = stopping_rules, verbose = 2)
 
 clear()
 q()

--- a/tests/test_convergenceRules/scripts/Test_stationarity.Rev
+++ b/tests/test_convergenceRules/scripts/Test_stationarity.Rev
@@ -41,7 +41,7 @@ mymcmc = mcmc(mymodel, monitors, moves, nruns = 4)
 stopping_rules[1] = srStationarity(0.25, file = "output/stationarity_test.log", freq = 1000)
 
 # Start the MCMC run
-mymcmc.run(rules = stopping_rules)
+mymcmc.run(rules = stopping_rules, verbose = 2)
 
 clear()
 q()


### PR DESCRIPTION
This is a follow-up to PR #645, motivated by the following considerations:

- @ms609 requested that the target values of MCMC stopping rules be printed at the beginning of each run that includes them. This can help debug cases where a script specifies a different stopping criterion than the user intended.
- I noticed that in my previous solution, each rule's test statistic was being calculated twice: once to decide if the analysis should stop, and another time to be printed to the screen. With a large enough log file, it's conceivable that this duplicated calculation could slow the analysis down, so the printing should remain optional.

Accordingly, this PR:

- Changes the `verbose` argument of the `.run()` and `.burnin()` methods of `MonteCarloAnalysis` objects from a boolean to an integer, and exposes it to the user. The previous default setting of `true` corresponds to the new default setting of `1`, but now it's also possible to set `verbose = 2`. This only has an effect when the analysis includes one or more convergence rules, and causes their values to be printed to the screen every time they are checked.
- Prints the target values of all stopping rules at the beginning of the run, as requested. This happens regardless of the verbosity setting, because it involves no extra calculation.
- Removes the unused global verbosity setting, which was supposed to be specified by the `-v` command-line flag. Doing so had no actual effect; in general, our philosophy seems to be to allow more fine-grained control over verbosity instead of using a single switch.