### PR TITLE
Remove empty touch( ), keep( ), and  restore( ) specializations.

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -163,7 +163,7 @@ subdir('tests')
 
 if get_option('help2yml')
 
-  executable(rb_name+'help2yml',
+  executable(rb_name+'-help2yml',
              ['src/help2yml/main.cpp'],
              link_with: [core, revlanguage, libs, help2yml],
              include_directories: [src_inc],

--- a/src/core/functions/phylogenetics/CheckNodeOrderConstraintsFunction.cpp
+++ b/src/core/functions/phylogenetics/CheckNodeOrderConstraintsFunction.cpp
@@ -50,33 +50,9 @@ CheckNodeOrderConstraintsFunction* CheckNodeOrderConstraintsFunction::clone( voi
 }
 
 
-void CheckNodeOrderConstraintsFunction::keep( const DagNode *affecter)
-{
-    //delegate to base class
-    TypedFunction< Boolean >::keep( affecter );
-    
-}
-
-
 void CheckNodeOrderConstraintsFunction::reInitialized( void )
 {
     *value = Boolean(false);
-}
-
-
-void CheckNodeOrderConstraintsFunction::restore( const DagNode *restorer)
-{
-    //delegate to base class
-    TypedFunction< Boolean >::restore( restorer );
-}
-
-
-void CheckNodeOrderConstraintsFunction::touch(const DagNode *toucher)
-{
-    
-    //delegate to base class
-    TypedFunction< Boolean >::touch( toucher );
-    
 }
 
 

--- a/src/core/functions/phylogenetics/CheckNodeOrderConstraintsFunction.h
+++ b/src/core/functions/phylogenetics/CheckNodeOrderConstraintsFunction.h
@@ -23,11 +23,8 @@ template <class valueType> class TypedDagNode;
         virtual                                            ~CheckNodeOrderConstraintsFunction(void);                                                         //!< Virtual destructor
         
         // public member functions
-        CheckNodeOrderConstraintsFunction*                                  clone(void) const;                                                                  //!< Create an independent clone
-        void                                                keep(const DagNode* affecter);
-        void                                                restore(const DagNode *restorer);
+        CheckNodeOrderConstraintsFunction*                  clone(void) const;                                                                  //!< Create an independent clone
         void                                                reInitialized(void);                                                                //!< The arguments have been re-initialized
-        void                                                touch(const DagNode *toucher );
         void                                                update(void);
         
     protected:

--- a/src/core/functions/phylogenetics/ComputeWeightedNodeOrderConstraintsScoreFunction.cpp
+++ b/src/core/functions/phylogenetics/ComputeWeightedNodeOrderConstraintsScoreFunction.cpp
@@ -52,33 +52,9 @@ computeWeightedNodeOrderConstraintsScoreFunction* computeWeightedNodeOrderConstr
 }
 
 
-void computeWeightedNodeOrderConstraintsScoreFunction::keep( const DagNode *affecter)
-{
-    //delegate to base class
-    TypedFunction< double >::keep( affecter );
-
-}
-
-
 void computeWeightedNodeOrderConstraintsScoreFunction::reInitialized( void )
 {
     *value = 0.0;
-}
-
-
-void computeWeightedNodeOrderConstraintsScoreFunction::restore( const DagNode *restorer)
-{
-    //delegate to base class
-    TypedFunction< double >::restore( restorer );
-}
-
-
-void computeWeightedNodeOrderConstraintsScoreFunction::touch(const DagNode *toucher)
-{
-
-    //delegate to base class
-    TypedFunction< double >::touch( toucher );
-
 }
 
 

--- a/src/core/functions/phylogenetics/ComputeWeightedNodeOrderConstraintsScoreFunction.h
+++ b/src/core/functions/phylogenetics/ComputeWeightedNodeOrderConstraintsScoreFunction.h
@@ -23,10 +23,7 @@ template <class valueType> class TypedDagNode;
         
         // public member functions
         computeWeightedNodeOrderConstraintsScoreFunction*                                  clone(void) const;                                                                  //!< Create an independent clone
-        void                                                keep(const DagNode* affecter);
-        void                                                restore(const DagNode *restorer);
         void                                                reInitialized(void);                                                                //!< The arguments have been re-initialized
-        void                                                touch(const DagNode *toucher );
         void                                                update(void);
         
     protected:

--- a/src/core/functions/phylogenetics/DispersalExtinctionRateStructureFunction.cpp
+++ b/src/core/functions/phylogenetics/DispersalExtinctionRateStructureFunction.cpp
@@ -56,13 +56,6 @@ DispersalExtinctionRateStructureFunction* DispersalExtinctionRateStructureFuncti
 }
 
 
-void DispersalExtinctionRateStructureFunction::keep( const DagNode *affecter)
-{
-    //delegate to base class
-    TypedFunction< RbVector<double> >::keep( affecter );
-    
-}
-
 void DispersalExtinctionRateStructureFunction::makeBits(void)
 {
     bits = std::vector<std::vector<unsigned> >(num_states, std::vector<unsigned>(numCharacters, 0));
@@ -135,22 +128,6 @@ void DispersalExtinctionRateStructureFunction::makeTransitions(void)
 void DispersalExtinctionRateStructureFunction::reInitialized( void )
 {
     ;//    *value = tau->getValue();
-}
-
-
-void DispersalExtinctionRateStructureFunction::restore( const DagNode *restorer)
-{
-    //delegate to base class
-    TypedFunction< RbVector<double> >::restore( restorer );
-}
-
-
-void DispersalExtinctionRateStructureFunction::touch(const DagNode *toucher)
-{
-    
-    //delegate to base class
-    TypedFunction< RbVector<double> >::touch( toucher );
-    
 }
 
 

--- a/src/core/functions/phylogenetics/DispersalExtinctionRateStructureFunction.h
+++ b/src/core/functions/phylogenetics/DispersalExtinctionRateStructureFunction.h
@@ -20,10 +20,7 @@ template <class valueType> class TypedDagNode;
         
         // public member functions
         DispersalExtinctionRateStructureFunction*           clone(void) const;                                                                  //!< Create an independent clone
-        void                                                keep(const DagNode* affecter);
-        void                                                restore(const DagNode *restorer);
         void                                                reInitialized(void);                                                                //!< The arguments have been re-initialized
-        void                                                touch(const DagNode *toucher );
         void                                                update(void);
         
     protected:

--- a/src/core/functions/phylogenetics/DispersalExtinctionRootStructureFunction.cpp
+++ b/src/core/functions/phylogenetics/DispersalExtinctionRootStructureFunction.cpp
@@ -51,13 +51,6 @@ DispersalExtinctionRootStructureFunction* DispersalExtinctionRootStructureFuncti
 }
 
 
-void DispersalExtinctionRootStructureFunction::keep(const DagNode *affecter)
-{
-    //delegate to base class
-    TypedFunction< Simplex >::keep( affecter );
-    
-}
-
 void DispersalExtinctionRootStructureFunction::makeBits(void)
 {
     bits = std::vector<std::vector<unsigned> >(num_states, std::vector<unsigned>(numCharacters, 0));
@@ -93,22 +86,6 @@ void DispersalExtinctionRootStructureFunction::makeIdxByRangeSize(void)
 void DispersalExtinctionRootStructureFunction::reInitialized( void )
 {
     ;//    *value = tau->getValue();
-}
-
-
-void DispersalExtinctionRootStructureFunction::restore( const DagNode *restorer )
-{
-    //delegate to base class
-    TypedFunction< Simplex >::restore( restorer );
-}
-
-
-void DispersalExtinctionRootStructureFunction::touch( const DagNode *toucher )
-{
-    
-    //delegate to base class
-    TypedFunction< Simplex >::touch( toucher );
-    
 }
 
 

--- a/src/core/functions/phylogenetics/DispersalExtinctionRootStructureFunction.h
+++ b/src/core/functions/phylogenetics/DispersalExtinctionRootStructureFunction.h
@@ -21,10 +21,7 @@ template <class valueType> class TypedDagNode;
         
         // public member functions
         DispersalExtinctionRootStructureFunction*           clone(void) const;                                                                  //!< Create an independent clone
-        void                                                keep(const DagNode* affecter);
-        void                                                restore(const DagNode *restorer);
         void                                                reInitialized(void);                                                                //!< The arguments have been re-initialized
-        void                                                touch(const DagNode *toucher );
         void                                                update(void);
         
     protected:

--- a/src/core/functions/phylogenetics/StitchTreeFunction.cpp
+++ b/src/core/functions/phylogenetics/StitchTreeFunction.cpp
@@ -137,13 +137,6 @@ void StitchTreeFunction::initTaxonGroups(void)
     return;
 }
 
-void StitchTreeFunction::keep( const DagNode *affecter )
-{
-    //delegate to base class
-    TypedFunction< Tree >::keep( affecter );
-    
-}
-
 void StitchTreeFunction::recursivelyCleanPatchClade(TopologyNode* node, TopologyNode*& newRoot, std::set<Taxon>& remainingTaxa, size_t& index, size_t patchIndex)
 {
     
@@ -272,22 +265,6 @@ void StitchTreeFunction::reInitialized( void )
 }
 
 
-void StitchTreeFunction::restore( const DagNode *restorer )
-{
-    //delegate to base class
-    TypedFunction< Tree >::restore( restorer );
-}
-
-
-void StitchTreeFunction::touch(const DagNode *toucher)
-{
-    
-    //delegate to base class
-    TypedFunction< Tree >::touch( toucher );
-    
-}
-
-
 // NB: Could be vastly improved with TreeListener events and touchSpecialization
 void StitchTreeFunction::update( void )
 {
@@ -296,7 +273,7 @@ void StitchTreeFunction::update( void )
 
 void StitchTreeFunction::updateStitchTree( void )
 {
-    
+  
     delete value;
     
     // start with backbone tree

--- a/src/core/functions/phylogenetics/StitchTreeFunction.h
+++ b/src/core/functions/phylogenetics/StitchTreeFunction.h
@@ -33,10 +33,7 @@ template <class valueType> class TypedDagNode;
         
         // public member functions
         StitchTreeFunction*                                 clone(void) const;                                                                  //!< Create an independent clone
-        void                                                keep(const DagNode* affecter);
-        void                                                restore(const DagNode *restorer);
         void                                                reInitialized(void);                                                                //!< The arguments have been re-initialized
-        void                                                touch(const DagNode *toucher );
         void                                                update(void);
         
     protected:

--- a/src/core/functions/phylogenetics/TreeScaleFunction.cpp
+++ b/src/core/functions/phylogenetics/TreeScaleFunction.cpp
@@ -56,33 +56,9 @@ TreeScaleFunction* TreeScaleFunction::clone( void ) const
 }
 
 
-void TreeScaleFunction::keep( const DagNode *affecter)
-{
-    //delegate to base class
-    TypedFunction< Tree >::keep( affecter );
-
-}
-
-
 void TreeScaleFunction::reInitialized( void )
 {
     *value = tau->getValue();
-}
-
-
-void TreeScaleFunction::restore( const DagNode *restorer)
-{
-    //delegate to base class
-    TypedFunction< Tree >::restore( restorer );
-}
-
-
-void TreeScaleFunction::touch(const DagNode *toucher)
-{
-    
-    //delegate to base class
-    TypedFunction< Tree >::touch( toucher );
-    
 }
 
 

--- a/src/core/functions/phylogenetics/TreeScaleFunction.h
+++ b/src/core/functions/phylogenetics/TreeScaleFunction.h
@@ -28,10 +28,7 @@ template <class valueType> class TypedDagNode;
         
         // public member functions
         TreeScaleFunction*                                  clone(void) const;                                                                  //!< Create an independent clone
-        void                                                keep(const DagNode* affecter);
-        void                                                restore(const DagNode *restorer);
         void                                                reInitialized(void);                                                                //!< The arguments have been re-initialized
-        void                                                touch(const DagNode *toucher );
         void                                                update(void);
         
     protected:

--- a/src/core/functions/phylogenetics/tree/ExtantTreeFunction.cpp
+++ b/src/core/functions/phylogenetics/tree/ExtantTreeFunction.cpp
@@ -35,33 +35,9 @@ ExtantTreeFunction* ExtantTreeFunction::clone( void ) const
 }
 
 
-void ExtantTreeFunction::keep( const DagNode *affecter )
-{
-    //delegate to base class
-    TypedFunction< Tree >::keep( affecter );
-    
-}
-
-
 void ExtantTreeFunction::reInitialized( void )
 {
     ; // *value = tau->getValue();
-    
-}
-
-
-void ExtantTreeFunction::restore( const DagNode *restorer )
-{
-    //delegate to base class
-    TypedFunction< Tree >::restore( restorer );
-}
-
-
-void ExtantTreeFunction::touch(const DagNode *toucher)
-{
-    
-    //delegate to base class
-    TypedFunction< Tree >::touch( toucher );
     
 }
 

--- a/src/core/functions/phylogenetics/tree/ExtantTreeFunction.h
+++ b/src/core/functions/phylogenetics/tree/ExtantTreeFunction.h
@@ -25,10 +25,7 @@ template <class valueType> class TypedDagNode;
         
         // public member functions
         ExtantTreeFunction*                                 clone(void) const;                                                                  //!< Create an independent clone
-        void                                                keep(const DagNode* affecter);
-        void                                                restore(const DagNode *restorer);
         void                                                reInitialized(void);                                                                //!< The arguments have been re-initialized
-        void                                                touch(const DagNode *toucher );
         void                                                update(void);
         
     protected:


### PR DESCRIPTION
Very few functions specialize touch( ), keep( ), and restore( ).
These functions do specialize them, but then just call the parent class function which (a) would happen anyway without the specialization and (b) also doesn't do anything.
Let's remove these specializations so that its clear which few functions actually specialize touch/keep/restore.

I have also tacked on an unrelated change that fixes the name of rb-help2yml for the meson build.