### PR TITLE
Prevent NaN heats in MC^3

### DIFF
--- a/src/core/analysis/mcmc/Mcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmc.cpp
@@ -1236,6 +1236,7 @@ void Mcmc::setChainActive(bool tf)
  */
 void Mcmc::setChainLikelihoodHeat(double h)
 {
+    assert(0 <= h);
     chain_likelihood_heat = h;
 }
 
@@ -1254,6 +1255,7 @@ void Mcmc::setCheckpointFile(const path &f)
  */
 void Mcmc::setLikelihoodHeat(double h)
 {
+    assert(0 <= h);
     chain_likelihood_heat = h;
 }
 
@@ -1265,12 +1267,14 @@ void Mcmc::setLikelihoodHeat(double h)
  */
 void Mcmc::setChainPosteriorHeat(double h)
 {
+    assert(0 <= h);
     chain_posterior_heat = h;
 }
 
 
 void Mcmc::setChainPriorHeat(double h)
 {
+    assert(0 <= h);
     chain_prior_heat = h;
 }
 

--- a/src/core/analysis/mcmc/Mcmcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmcmc.cpp
@@ -1143,7 +1143,7 @@ void Mcmcmc::setHeatsInitial(const std::vector<double>& ht)
     }
 
     // 3. Check that the heats are sorted with the largest heat first (== smallest temperature first).
-    for(size_t i=0;i<ht.size()-1;i++)
+    for(size_t i=0; i+1 < ht.size(); i++)
         if (ht[i] < ht[i+1])
             throw RbException()<<"Heat "<<i+1<<" ("<<ht[i]<<") should be greater than heat "<<i+2<<" ("<<ht[i+1]<<")";
 

--- a/src/core/analysis/mcmc/Mcmcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmcmc.cpp
@@ -1870,14 +1870,31 @@ void Mcmcmc::tune( void )
         // to fall between the lowest heat that is greater than the minimum bound and the minimum bound
         if (j < num_chains)
         {
-            double rho = pow(chain_heats[colderChainIdx] / heatMinBound, 1.0 / (num_chains - j));
-            size_t k = j;
+            std::cout << "The following should be sorted from largest to smallest:" << std::endl;
+            for (size_t l = 0; l < chain_heats.size(); ++l)
+            {
+                if (l == j)
+                {
+                    std::cout << chain_heats[ chainForHeatIndex(l) ] << " <--- You are here" << std::endl;
+                }
+                else
+                {
+                    std::cout << chain_heats[ chainForHeatIndex(l) ] << std::endl;
+                }
+            }
+            
+            double rho = pow(chain_heats[ chainForHeatIndex(j) ] / heatMinBound, 1.0 / (num_chains - j + 1));
+            std::cout << "Current rho is: " << rho << std::endl;
+            size_t k = j + 1;
             
             for (; k < num_chains; ++k)
             {
-                chain_heats[hotterChainIdx] = chain_heats[colderChainIdx] / pow(rho, k + 1 - j);
+                std::cout << "Attempting to set the heat of chain " << k << " to " << (chain_heats[ chainForHeatIndex(j) ] / pow(rho, k + 1 - j)) << std::endl;
+                chain_heats[ chainForHeatIndex(k) ] = chain_heats[ chainForHeatIndex(j) ] / pow(rho, k + 1 - j);
 //                std::cout << "chain_heats[k" << hotterChainIdx << "]=" << chain_heats[hotterChainIdx] << std::endl;
             }
+            
+            std::cout << "" << std::endl;
         }
         
         resetCounters();

--- a/src/core/analysis/mcmc/Mcmcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmcmc.cpp
@@ -1872,10 +1872,10 @@ void Mcmcmc::tune( void )
         std::vector<double> greaterThanMin;
         std::vector<size_t> badChainIdx;
         
-        std::cout << "The following should be sorted from largest to smallest:" << std::endl;
+        // std::cout << "The following should be sorted from largest to smallest:" << std::endl;
         for (size_t l = 0; l < num_chains; ++l)
         {
-            std::cout << chain_heats[ chainForHeatIndex(l) ] << std::endl;
+            // std::cout << chain_heats[ chainForHeatIndex(l) ] << std::endl;
             if ( chain_heats[ chainForHeatIndex(l) ] > heatMinBound )
             {
                 greaterThanMin.push_back( chain_heats[ chainForHeatIndex(l) ] );
@@ -1886,7 +1886,7 @@ void Mcmcmc::tune( void )
             }
         }
         
-        std::cout << "We have " << badChainIdx.size() << " bad chain(s)" << std::endl;
+        // std::cout << "We have " << badChainIdx.size() << " bad chain(s)" << std::endl;
         if ( badChainIdx.size() != 0 )
         {
             double lowestGreaterThanMin = *std::min_element( greaterThanMin.begin(), greaterThanMin.end() );
@@ -1894,15 +1894,13 @@ void Mcmcmc::tune( void )
             size_t m = k - 1;
             
             double rho = pow(lowestGreaterThanMin / heatMinBound, 1.0 / (num_chains - m));
-            std::cout << "Current rho is: " << rho << std::endl;
+            // std::cout << "Current rho is: " << rho << std::endl;
             
             for (; k < num_chains; ++k)
             {
-                std::cout << "Attempting to set the heat of chain " << k << " to " << (lowestGreaterThanMin / pow(rho, k - m)) << std::endl;
+                // std::cout << "Attempting to set the heat of chain " << k << " to " << (lowestGreaterThanMin / pow(rho, k - m)) << std::endl;
                 chain_heats[ chainForHeatIndex(k) ] = lowestGreaterThanMin / pow(rho, k - m);
             }
-            
-            std::cout << "" << std::endl;
         }
         
         resetCounters();

--- a/src/core/analysis/mcmc/Mcmcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmcmc.cpp
@@ -1878,9 +1878,9 @@ void Mcmcmc::tune( void )
          *
          * Let us further denote heat(k-1) as "lowestGreaterThanMin", and k-1 as "m". Then,
          *
-         * log(heat(k)) = log(heatMinBound) + [ log(lowestGreaterThanMin) - log(heatMinBound) ]*[ 1 / (num_chains - m) ]
+         * log(heat(k)) = log(lowestGreaterThanMin) - [ log(lowestGreaterThanMin) - log(heatMinBound) ]*[ 1 / (num_chains - m) ]
          *
-         * Finally, let us denote the second addend on the right-hand side of the equation above by log(rho). Then,
+         * Finally, let us denote the subtrahend on the right-hand side of the equation above by log(rho). Then,
          *
          *       rho = (lowestGreaterThanMin / heatMinBound)^[ 1 / (num_chains - m) ],
          *   heat(k) = lowestGreaterThanMin / rho

--- a/src/core/analysis/mcmc/Mcmcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmcmc.cpp
@@ -1894,11 +1894,11 @@ void Mcmcmc::tune( void )
          */
 
         // Make a lambda function to access the kth chain heat as heat(k).
-        auto heat = [&](int k) -> auto& { return chain_heats[ chainForHeatIndex(k) ]; };
+        auto heat = [&](size_t k) -> auto& { return chain_heats[ chainForHeatIndex(k) ]; };
         assert(heat(0) == 1.0);
 
         // Find the largest heat index m such that heat(m) > heatMinBound.
-        int m = 0;
+        size_t m = 0;
         for (size_t k = 1; k < num_chains; ++k)
         {
             // Check that heat(k) is non-increasing in k.
@@ -1914,7 +1914,7 @@ void Mcmcmc::tune( void )
         assert(0 < phi and phi < 1);
 
         // If there are any chain heats that are below heatMinBound, then redefine them by linear interpolation on the log scale.
-        for (int k = m + 1; k < num_chains; ++k)
+        for (size_t k = m + 1; k < num_chains; ++k)
         {
             // std::cout << "Attempting to set the heat of chain " << k << " to " << heat(m) * pow(phi, double(k - m)/(num_chains-m)) << std::endl;
             heat(k) = heat(m) * pow(phi, double(k - m)/(num_chains-m));


### PR DESCRIPTION
This PR makes the following changes to `Mcmcmc.cpp`:

1. Addresses @bredelings's comment under PR #652 (which was probably merged prematurely) and avoids subtraction in a `for`-loop that checks if `ht[i+1]` is valid;
2. Solves issue #651 (and partially #609), which ultimately stems from the fact that the interpolation system we are using to correct lower-than-allowed chain heats can, under certain circumstances, produce `nan` values, which then screw up everything else.

It's still not clear to me why the problem with `nan` heats only appeared on certain platforms, but I am confident that the interpolation system now does what the corresponding source code comment says it should do. I have verified that this PR solves the issue on macOS(ARM64) 15.3 with clang 16 (where it was previously giving a bus error) and Red Hate Enterprise Unix 8.4 with gcc 10.2 (where it was previously causing a segfault), but I would be grateful if @ms609 could check that it works on his setup as well.

I could add a pared down version of @ms609's analysis as an integration test, but it would be a demanding one – it would require running 16 (!) MCMC chains of ~10,000 moves each.