### PR TITLE
Use different seeds for replicates in MPI run

### DIFF
--- a/src/core/analysis/MonteCarloAnalysis.cpp
+++ b/src/core/analysis/MonteCarloAnalysis.cpp
@@ -517,8 +517,7 @@ void MonteCarloAnalysis::resetReplicates( void )
     size_t replicate_start = size_t(floor( (double(pid-active_PID) / num_processes ) * replicates ) ) + active_PID;
     
     RandomNumberGenerator *rng = GLOBAL_RNG;
-    for (size_t j=0; j<(2*replicate_start); ++j) rng->uniform01();
-    
+    rng->setSeed(rng->getSeed() + 2*replicate_start);    
     
     // redraw initial states for replicates
     for (size_t i = 0; i < replicates; ++i)

--- a/src/core/analysis/MonteCarloAnalysis.cpp
+++ b/src/core/analysis/MonteCarloAnalysis.cpp
@@ -517,7 +517,7 @@ void MonteCarloAnalysis::resetReplicates( void )
     size_t replicate_start = size_t(floor( (double(pid-active_PID) / num_processes ) * replicates ) ) + active_PID;
     
     RandomNumberGenerator *rng = GLOBAL_RNG;
-    rng->setSeed(rng->getSeed() + 2*replicate_start);    
+    if(replicate_start > 0) rng->setSeed(rng->getSeed() + 2*replicate_start);    
     
     // redraw initial states for replicates
     for (size_t i = 0; i < replicates; ++i)


### PR DESCRIPTION
This is an attempt to fix issue #428 by explicitly setting seeds instead of doing draws
I have tested it with the issue script and I obtain 10 separate log files with no identical output