### PR TITLE
Document DPP moves

### DIFF
--- a/help/md/mvDPPValueBetaSimplex.md
+++ b/help/md/mvDPPValueBetaSimplex.md
@@ -1,0 +1,31 @@
+## name
+mvDPPValueBetaSimplex
+## title
+Beta simplex move applied to individual categories of a Dirichlet process mixture
+## description
+Operates on draws from a Dirichlet process prior (DPP) on mixtures of [Simplex](https://revbayes.github.io/documentation/Simplex.html) distributions, i.e., distributions defined over vectors whose elements are positive and sum to 1.
+## details
+In Dirichlet process mixtures, the number of categories (= clusters) is not specified beforehand but inferred from the data, and can range anywhere from 1 to the total number of elements (= observations). The move takes the current number of categories and simultaneously updates the value of every category using the beta simplex move with a concentration parameter (alpha) of 10.
+## authors
+Sebastian Hoehna
+## see_also
+- dnDPP
+- mvBetaSimplex
+- mvDPPValueScaling
+- mvDPPValueSliding
+## example
+	# Here, we draw from a DP mixture for 3 elements, where every element
+	# is itself a 2-element simplex drawn from a flat Dirichlet distribution
+	x ~ dnDPP(1, dnDirichlet( [1, 1] ), 3)
+	
+	# Next, we add the move. Note that without moves other than
+	# mvDPPValueBetaSimplex, only the values of the categories will be
+        # updated: the total number of categories and the assignment of elements
+	# to categories will be determined by the initial draw.
+	moves[1] = mvDPPValueBetaSimplex(x, weight=1)
+	
+	monitors[1] = mnScreen(x, printgen=1)
+	mymodel = model(x)
+	mymcmc = mcmc(mymodel, monitors, moves)
+	mymcmc.run(generations=50)
+## references

--- a/help/md/mvDPPValueScaling.md
+++ b/help/md/mvDPPValueScaling.md
@@ -1,9 +1,31 @@
 ## name
 mvDPPValueScaling
 ## title
+Scaling move applied to individual categories of a Dirichlet process mixture
 ## description
+Operates on draws from a Dirichlet process prior (DPP) on mixtures of [RealPos](https://revbayes.github.io/documentation/RealPos.html) distributions, i.e., distributions defined over non-negative real numbers.
 ## details
+In Dirichlet process mixtures, the number of categories (= clusters) is not specified beforehand but inferred from the data, and can range anywhere from 1 to the total number of elements (= observations). The move takes the current number of categories and simultaneously updates the value of every category using the scaling move with a scaling factor (lambda) of 1.
 ## authors
+Sebastian Hoehna
 ## see_also
+- dnDPP
+- mvScale
+- mvDPPValueBetaSimplex
+- mvDPPValueSliding
 ## example
+	# Here, we draw from a DP mixture for 3 elements, where every element
+	# is a non-negative real number drawn from an exponential distribution
+	x ~ dnDPP(1, dnExp(1), 3)
+	
+	# Next, we add the move. Note that without moves other than
+	# mvDPPValueScaling, only the values of the categories will be updated:
+        # the total number of categories and the assignment of elements to
+	# categories will be determined by the initial draw.
+	moves[1] = mvDPPValueScaling(x, weight=1)
+	
+	monitors[1] = mnScreen(x, printgen=1)
+	mymodel = model(x)
+	mymcmc = mcmc(mymodel, monitors, moves)
+	mymcmc.run(generations=50)
 ## references

--- a/help/md/mvDPPValueSliding.md
+++ b/help/md/mvDPPValueSliding.md
@@ -1,0 +1,31 @@
+## name
+mvDPPValueSliding
+## title
+Sliding move applied to individual categories of a Dirichlet process mixture
+## description
+Operates on draws from a Dirichlet process prior (DPP) on mixtures of [Real](https://revbayes.github.io/documentation/Real.html) distributions, i.e., distributions defined over all real numbers.
+## details
+In Dirichlet process mixtures, the number of categories (= clusters) is not specified beforehand but inferred from the data, and can range anywhere from 1 to the total number of elements (= observations). The move takes the current number of categories and simultaneously updates the value of every category using the sliding move with a window size (delta) of 1.
+## authors
+Sebastian Hoehna
+## see_also
+- dnDPP
+- mvSlide
+- mvDPPValueBetaSimplex
+- mvDPPValueScaling
+## example
+	# Here, we draw from a DP mixture for 3 elements, where every element
+	# is a real number drawn from the standard normal distribution
+	x ~ dnDPP(1, dnNormal(0, 1), 3)
+	
+	# Next, we add the move. Note that without moves other than
+	# mvDPPValueSliding, only the values of the categories will be updated:
+        # the total number of categories and the assignment of elements to
+	# categories will be determined by the initial draw.
+	moves[1] = mvDPPValueSliding(x, weight=1)
+	
+	monitors[1] = mnScreen(x, printgen=1)
+	mymodel = model(x)
+	mymcmc = mcmc(mymodel, monitors, moves)
+	mymcmc.run(generations=50)
+## references

--- a/src/core/help/RbHelpDatabase.cpp
+++ b/src/core/help/RbHelpDatabase.cpp
@@ -2502,7 +2502,75 @@ moves[1] = mvCorrelationMatrixSingleElementBeta(R, alpha=10.0))");
 	help_strings[string("mvCorrelationMatrixUpdate")][string("name")] = string(R"(mvCorrelationMatrixUpdate)");
 	help_strings[string("mvDPPAllocateAuxGibbs")][string("name")] = string(R"(mvDPPAllocateAuxGibbs)");
 	help_strings[string("mvDPPGibbsConcentration")][string("name")] = string(R"(mvDPPGibbsConcentration)");
+	help_arrays[string("mvDPPValueBetaSimplex")][string("authors")].push_back(string(R"(Sebastian Hoehna)"));
+	help_strings[string("mvDPPValueBetaSimplex")][string("description")] = string(R"(Operates on draws from a Dirichlet process prior (DPP) on mixtures of [Simplex](https://revbayes.github.io/documentation/Simplex.html) distributions, i.e., distributions defined over vectors whose elements are positive and sum to 1.)");
+	help_strings[string("mvDPPValueBetaSimplex")][string("details")] = string(R"(In Dirichlet process mixtures, the number of categories (= clusters) is not specified beforehand but inferred from the data, and can range anywhere from 1 to the total number of elements (= observations). The move takes the current number of categories and simultaneously updates the value of every category using the beta simplex move with a concentration parameter (alpha) of 10.)");
+	help_strings[string("mvDPPValueBetaSimplex")][string("example")] = string(R"(# Here, we draw from a DP mixture for 3 elements, where every element
+# is itself a 2-element simplex drawn from a flat Dirichlet distribution
+x ~ dnDPP(1, dnDirichlet( [1, 1] ), 3)
+
+# Next, we add the move. Note that without moves other than
+# mvDPPValueBetaSimplex, only the values of the categories will be
+# updated: the total number of categories and the assignment of elements
+# to categories will be determined by the initial draw.
+moves[1] = mvDPPValueBetaSimplex(x, weight=1)
+
+monitors[1] = mnScreen(x, printgen=1)
+mymodel = model(x)
+mymcmc = mcmc(mymodel, monitors, moves)
+mymcmc.run(generations=50))");
+	help_strings[string("mvDPPValueBetaSimplex")][string("name")] = string(R"(mvDPPValueBetaSimplex)");
+	help_arrays[string("mvDPPValueBetaSimplex")][string("see_also")].push_back(string(R"(- dnDPP)"));
+	help_arrays[string("mvDPPValueBetaSimplex")][string("see_also")].push_back(string(R"(- mvBetaSimplex)"));
+	help_arrays[string("mvDPPValueBetaSimplex")][string("see_also")].push_back(string(R"(- mvDPPValueScaling)"));
+	help_arrays[string("mvDPPValueBetaSimplex")][string("see_also")].push_back(string(R"(- mvDPPValueSliding)"));
+	help_strings[string("mvDPPValueBetaSimplex")][string("title")] = string(R"(Beta simplex move applied to individual categories of a Dirichlet process mixture)");
+	help_arrays[string("mvDPPValueScaling")][string("authors")].push_back(string(R"(Sebastian Hoehna)"));
+	help_strings[string("mvDPPValueScaling")][string("description")] = string(R"(Operates on draws from a Dirichlet process prior (DPP) on mixtures of [RealPos](https://revbayes.github.io/documentation/RealPos.html) distributions, i.e., distributions defined over non-negative real numbers.)");
+	help_strings[string("mvDPPValueScaling")][string("details")] = string(R"(In Dirichlet process mixtures, the number of categories (= clusters) is not specified beforehand but inferred from the data, and can range anywhere from 1 to the total number of elements (= observations). The move takes the current number of categories and simultaneously updates the value of every category using the scaling move with a scaling factor (lambda) of 1.)");
+	help_strings[string("mvDPPValueScaling")][string("example")] = string(R"(# Here, we draw from a DP mixture for 3 elements, where every element
+# is a non-negative real number drawn from an exponential distribution
+x ~ dnDPP(1, dnExp(1), 3)
+
+# Next, we add the move. Note that without moves other than
+# mvDPPValueScaling, only the values of the categories will be updated:
+# the total number of categories and the assignment of elements to
+# categories will be determined by the initial draw.
+moves[1] = mvDPPValueScaling(x, weight=1)
+
+monitors[1] = mnScreen(x, printgen=1)
+mymodel = model(x)
+mymcmc = mcmc(mymodel, monitors, moves)
+mymcmc.run(generations=50))");
 	help_strings[string("mvDPPValueScaling")][string("name")] = string(R"(mvDPPValueScaling)");
+	help_arrays[string("mvDPPValueScaling")][string("see_also")].push_back(string(R"(- dnDPP)"));
+	help_arrays[string("mvDPPValueScaling")][string("see_also")].push_back(string(R"(- mvScale)"));
+	help_arrays[string("mvDPPValueScaling")][string("see_also")].push_back(string(R"(- mvDPPValueBetaSimplex)"));
+	help_arrays[string("mvDPPValueScaling")][string("see_also")].push_back(string(R"(- mvDPPValueSliding)"));
+	help_strings[string("mvDPPValueScaling")][string("title")] = string(R"(Scaling move applied to individual categories of a Dirichlet process mixture)");
+	help_arrays[string("mvDPPValueSliding")][string("authors")].push_back(string(R"(Sebastian Hoehna)"));
+	help_strings[string("mvDPPValueSliding")][string("description")] = string(R"(Operates on draws from a Dirichlet process prior (DPP) on mixtures of [Real](https://revbayes.github.io/documentation/Real.html) distributions, i.e., distributions defined over all real numbers.)");
+	help_strings[string("mvDPPValueSliding")][string("details")] = string(R"(In Dirichlet process mixtures, the number of categories (= clusters) is not specified beforehand but inferred from the data, and can range anywhere from 1 to the total number of elements (= observations). The move takes the current number of categories and simultaneously updates the value of every category using the sliding move with a window size (delta) of 1.)");
+	help_strings[string("mvDPPValueSliding")][string("example")] = string(R"(# Here, we draw from a DP mixture for 3 elements, where every element
+# is a real number drawn from the standard normal distribution
+x ~ dnDPP(1, dnNormal(0, 1), 3)
+
+# Next, we add the move. Note that without moves other than
+# mvDPPValueSliding, only the values of the categories will be updated:
+# the total number of categories and the assignment of elements to
+# categories will be determined by the initial draw.
+moves[1] = mvDPPValueSliding(x, weight=1)
+
+monitors[1] = mnScreen(x, printgen=1)
+mymodel = model(x)
+mymcmc = mcmc(mymodel, monitors, moves)
+mymcmc.run(generations=50))");
+	help_strings[string("mvDPPValueSliding")][string("name")] = string(R"(mvDPPValueSliding)");
+	help_arrays[string("mvDPPValueSliding")][string("see_also")].push_back(string(R"(- dnDPP)"));
+	help_arrays[string("mvDPPValueSliding")][string("see_also")].push_back(string(R"(- mvSlide)"));
+	help_arrays[string("mvDPPValueSliding")][string("see_also")].push_back(string(R"(- mvDPPValueBetaSimplex)"));
+	help_arrays[string("mvDPPValueSliding")][string("see_also")].push_back(string(R"(- mvDPPValueScaling)"));
+	help_strings[string("mvDPPValueSliding")][string("title")] = string(R"(Sliding move applied to individual categories of a Dirichlet process mixture)");
 	help_strings[string("mvDirichletSimplex")][string("description")] = string(R"(A Dirichlet-simplex proposal randomly changes some values of a [Simplex](https://revbayes.github.io/documentation/Simplex.html)
 (a vector whose elements sum to 1). The other values change too because of renormalization.
  

--- a/src/revlanguage/workspace/RbRegister_Move.cpp
+++ b/src/revlanguage/workspace/RbRegister_Move.cpp
@@ -361,9 +361,9 @@ void RevLanguage::Workspace::initializeMoveGlobalWorkspace(void)
         addType( new Move_HomeologPhase() );
 
         /* Moves on mixtures (in folder "datatypes/inference/moves/mixture") */
-        addType( new Move_DPPTableValueUpdate<Real>(    new RevBayesCore::SlideProposal( NULL, 1.0 ) ) );
-        addType( new Move_DPPTableValueUpdate<RealPos>( new RevBayesCore::ScaleProposal( NULL, 1.0 ) ) );
-        addType( new Move_DPPTableValueUpdate<Simplex>( new RevBayesCore::BetaSimplexProposal( NULL, 10.0 ) ) );
+        addType( new Move_DPPTableValueUpdate<Real>(    new RevBayesCore::SlideProposal( NULL, 1.0 ) ) );        // mvDPPValueSliding
+        addType( new Move_DPPTableValueUpdate<RealPos>( new RevBayesCore::ScaleProposal( NULL, 1.0 ) ) );        // mvDPPValueScaling
+        addType( new Move_DPPTableValueUpdate<Simplex>( new RevBayesCore::BetaSimplexProposal( NULL, 10.0 ) ) ); // mvDPPValueBetaSimplex
 
 //        addType("mvDPPScaleCatVals",                new Move_DPPScaleCatValsMove() );
 //        addType("mvDPPScaleCatAllocateAux",         new Move_DPPScaleCatAllocateAux() );


### PR DESCRIPTION
At my request, PR #606 deleted the Markdown help file for `mvDPPValueBetaSimplex`, because neither @ms609 nor myself could find the source code for it. The help file was empty, so no great harm was caused by this, but the move does in fact exist. The reason why we couldn't find any occurrence of the string "DPPValueBetaSimplex" in the `src` directory is that it is derived from a template (`DPPTableValueUpdate.h`). This PR (1) adds a brief note to the move register to clarify this, and (2) provides help files for all three moves deriving from `DPPTableValueUpdate` (`mvDPPValueBetaSimplex`, `mvDPPValueScaling`, `mvDPPValueSliding`).