### PR TITLE
Mark overridden virtual functions as such in tree event moves

### DIFF
--- a/src/core/moves/characterhistory/ContinuousEventBirthDeathProposal.h
+++ b/src/core/moves/characterhistory/ContinuousEventBirthDeathProposal.h
@@ -24,18 +24,18 @@ namespace RevBayesCore {
     class ContinuousEventBirthDeathProposal : public EventBirthDeathProposal {
         
     public:
-        ContinuousEventBirthDeathProposal( StochasticNode<Tree> *n);                                                                //!<  constructor
+        ContinuousEventBirthDeathProposal( StochasticNode<Tree> *n);                                                                //!< Constructor
         
         // Basic utility functions
         bool                                    allowClamped() const override { return true; }                                      //!< Proposal doesn't change the tree, but changes parameters describing the process that generates the tree. See #600
-        ContinuousEventBirthDeathProposal*      clone(void) const;                                                                  //!< Clone object
-        const std::string&                      getProposalName(void) const;                                                        //!< Get the name of the proposal for summary printing
+        ContinuousEventBirthDeathProposal*      clone(void) const override;                                                         //!< Clone object
+        const std::string&                      getProposalName(void) const override;                                               //!< Get the name of the proposal for summary printing
         
     protected:
         
         // pure virtual methods
-        CharacterEvent*                         drawNewEvent(double event_time);
-        double                                  computeEventProposalProbability( CharacterEvent* event );
+        CharacterEvent*                         drawNewEvent(double event_time) override;
+        double                                  computeEventProposalProbability( CharacterEvent* event ) override;
         
     };
     

--- a/src/core/moves/characterhistory/ContinuousEventScaleProposal.h
+++ b/src/core/moves/characterhistory/ContinuousEventScaleProposal.h
@@ -22,36 +22,36 @@ namespace RevBayesCore {
     class ContinuousEventScaleProposal : public Proposal {
         
     public:
-        ContinuousEventScaleProposal( StochasticNode<Tree> *n, double l );                                                                //!<  constructor
+        ContinuousEventScaleProposal( StochasticNode<Tree> *n, double l );                                                                //!< Constructor
         
         // Basic utility functions
-        bool                                            allowClamped() const override { return true; }                                                 //!< Proposal doesn't change the tree, but changes parameters describing the process that generates the tree. See #600
-        void                                            cleanProposal(void);                                                                //!< Clean up proposal
-        ContinuousEventScaleProposal*                   clone(void) const;                                                                  //!< Clone object
-        double                                          doProposal(void);                                                                   //!< Perform proposal
-        const std::string&                              getProposalName(void) const;                                                        //!< Get the name of the proposal for summary printing
-        double                                          getProposalTuningParameter(void) const;
-        void                                            printParameterSummary(std::ostream &o, bool name_only) const;                                       //!< Print the parameter summary
-        void                                            prepareProposal(void);                                                              //!< Prepare the proposal
-        void                                            setProposalTuningParameter(double tp);
-        void                                            tune(double r);                                                                     //!< Tune the proposal to achieve a better acceptance/rejection ratio
-        void                                            undoProposal(void);                                                                 //!< Reject the proposal
+        bool                                            allowClamped() const override { return true; }                                    //!< Proposal doesn't change the tree, but changes parameters describing the process that generates the tree. See #600
+        void                                            cleanProposal(void) override;                                                     //!< Clean up proposal
+        ContinuousEventScaleProposal*                   clone(void) const override;                                                       //!< Clone object
+        double                                          doProposal(void) override;                                                        //!< Perform proposal
+        const std::string&                              getProposalName(void) const override;                                             //!< Get the name of the proposal for summary printing
+        double                                          getProposalTuningParameter(void) const override;
+        void                                            printParameterSummary(std::ostream &o, bool name_only) const override;            //!< Print the parameter summary
+        void                                            prepareProposal(void) override;                                                   //!< Prepare the proposal
+        void                                            setProposalTuningParameter(double tp) override;
+        void                                            tune(double r) override;                                                          //!< Tune the proposal to achieve a better acceptance/rejection ratio
+        void                                            undoProposal(void) override;                                                      //!< Reject the proposal
         
     protected:
         
-        void                                            swapNodeInternal(DagNode *oldN, DagNode *newN);                                     //!< Swap the DAG nodes on which the Proposal is working on
+        void                                            swapNodeInternal(DagNode *oldN, DagNode *newN) override;                          //!< Swap the DAG nodes on which the Proposal is working on
         
     private:
         // parameters
         
-        StochasticNode<Tree>*                           variable;                                                                           //!< The variable the Proposal is working on
+        StochasticNode<Tree>*                           variable;                                                                         //!< The variable the Proposal is working on
         ConditionedBirthDeathShiftProcessContinuous*    distribution;
 
         double                                          lambda;
         
-        CharacterEventContinuous*                       stored_value;                                                                        //!< The stored value of the Proposal used for rejections.
-        double                                          stored_rate;                                                                              //!< The value we propose.
-        size_t                                          stored_index;                                                                              //!< The value we propose.
+        CharacterEventContinuous*                       stored_value;                                                                     //!< The stored value of the Proposal used for rejections.
+        double                                          stored_rate;                                                                      //!< The value we propose.
+        size_t                                          stored_index;                                                                     //!< The value we propose.
         bool                                            failed;
 
 };

--- a/src/core/moves/characterhistory/DiscreteEventBirthDeathProposal.h
+++ b/src/core/moves/characterhistory/DiscreteEventBirthDeathProposal.h
@@ -24,18 +24,18 @@ namespace RevBayesCore {
     class DiscreteEventBirthDeathProposal : public EventBirthDeathProposal {
         
     public:
-        DiscreteEventBirthDeathProposal( StochasticNode<Tree> *n);                                                                  //!<  constructor
+        DiscreteEventBirthDeathProposal( StochasticNode<Tree> *n);                                                                  //!< Constructor
         
         // Basic utility functions
-        bool                                    allowClamped() const override { return true; }                                                    //!< Proposal doesn't change the tree, but changes parameters describing the process that generates the tree. See #600
-        DiscreteEventBirthDeathProposal*        clone(void) const;                                                                  //!< Clone object
-        const std::string&                      getProposalName(void) const;                                                        //!< Get the name of the proposal for summary printing
+        bool                                    allowClamped() const override { return true; }                                      //!< Proposal doesn't change the tree, but changes parameters describing the process that generates the tree. See #600
+        DiscreteEventBirthDeathProposal*        clone(void) const override;                                                         //!< Clone object
+        const std::string&                      getProposalName(void) const override;                                               //!< Get the name of the proposal for summary printing
         
     protected:
         
         // pure virtual methods
-        CharacterEvent*                         drawNewEvent(double event_time);
-        double                                  computeEventProposalProbability( CharacterEvent* event );
+        CharacterEvent*                         drawNewEvent(double event_time) override;
+        double                                  computeEventProposalProbability( CharacterEvent* event ) override;
         
     };
     

--- a/src/core/moves/characterhistory/DiscreteEventCategoryRandomWalkProposal.h
+++ b/src/core/moves/characterhistory/DiscreteEventCategoryRandomWalkProposal.h
@@ -22,33 +22,33 @@ namespace RevBayesCore {
     class DiscreteEventCategoryRandomWalkProposal : public Proposal {
         
     public:
-        DiscreteEventCategoryRandomWalkProposal( StochasticNode<Tree> *n);                                                                //!<  constructor
+        DiscreteEventCategoryRandomWalkProposal( StochasticNode<Tree> *n);                                                                //!< Constructor
         
         // Basic utility functions
-        bool                                            allowClamped() const override { return true; }                                      //!< Proposal doesn't change the tree, but changes parameters describing the process that generates the tree. See #600
-        void                                            cleanProposal(void);                                                                //!< Clean up proposal
-        DiscreteEventCategoryRandomWalkProposal*        clone(void) const;                                                                  //!< Clone object
-        double                                          doProposal(void);                                                                   //!< Perform proposal
-        const std::string&                              getProposalName(void) const;                                                        //!< Get the name of the proposal for summary printing
-        double                                          getProposalTuningParameter(void) const;
-        void                                            printParameterSummary(std::ostream &o, bool name_only) const;                                       //!< Print the parameter summary
-        void                                            prepareProposal(void);                                                              //!< Prepare the proposal
-        void                                            setProposalTuningParameter(double tp);
-        void                                            tune(double r);                                                                     //!< Tune the proposal to achieve a better acceptance/rejection ratio
-        void                                            undoProposal(void);                                                                 //!< Reject the proposal
+        bool                                            allowClamped() const override { return true; }                                    //!< Proposal doesn't change the tree, but changes parameters describing the process that generates the tree. See #600
+        void                                            cleanProposal(void) override;                                                     //!< Clean up proposal
+        DiscreteEventCategoryRandomWalkProposal*        clone(void) const override;                                                       //!< Clone object
+        double                                          doProposal(void) override;                                                        //!< Perform proposal
+        const std::string&                              getProposalName(void) const override;                                             //!< Get the name of the proposal for summary printing
+        double                                          getProposalTuningParameter(void) const override;
+        void                                            printParameterSummary(std::ostream &o, bool name_only) const override;            //!< Print the parameter summary
+        void                                            prepareProposal(void) override;                                                   //!< Prepare the proposal
+        void                                            setProposalTuningParameter(double tp) override;
+        void                                            tune(double r) override;                                                          //!< Tune the proposal to achieve a better acceptance/rejection ratio
+        void                                            undoProposal(void) override;                                                      //!< Reject the proposal
         
     protected:
         
-        void                                            swapNodeInternal(DagNode *oldN, DagNode *newN);                                     //!< Swap the DAG nodes on which the Proposal is working on
+        void                                            swapNodeInternal(DagNode *oldN, DagNode *newN) override;                          //!< Swap the DAG nodes on which the Proposal is working on
         
     private:
         // parameters
         
-        StochasticNode<Tree>*                           variable;                                                                           //!< The variable the Proposal is working on
+        StochasticNode<Tree>*                           variable;                                                                         //!< The variable the Proposal is working on
         HeterogeneousRateBirthDeath*                    distribution;
         
-        CharacterEventDiscrete*                         stored_value;                                                                        //!< The stored value of the Proposal used for rejections.
-        size_t                                          stored_category;                                                                              //!< The value we propose.
+        CharacterEventDiscrete*                         stored_value;                                                                     //!< The stored value of the Proposal used for rejections.
+        size_t                                          stored_category;                                                                  //!< The value we propose.
         bool                                            failed;
     };
     

--- a/src/core/moves/characterhistory/EventBirthDeathProposal.h
+++ b/src/core/moves/characterhistory/EventBirthDeathProposal.h
@@ -23,24 +23,24 @@ namespace RevBayesCore {
     class EventBirthDeathProposal : public Proposal {
         
     public:
-        virtual EventBirthDeathProposal*        clone(void) const = 0;                                                              //!< Clone object
-        virtual const std::string&              getProposalName(void) const = 0;                                                    //!< Get the name of the proposal for summary printing
+        virtual EventBirthDeathProposal*        clone(void) const override = 0;                                                     //!< Clone object
+        virtual const std::string&              getProposalName(void) const override = 0;                                           //!< Get the name of the proposal for summary printing
         
         
         // Basic utility functions
-        bool                                    allowClamped() const override { return true; }                                            //!< Proposal doesn't change the tree, but changes parameters describing the process that generates the tree. See #600
-        void                                    cleanProposal(void);                                                                //!< Clean up proposal
-        double                                  doProposal(void);                                                                   //!< Perform proposal
+        bool                                    allowClamped() const override { return true; }                                      //!< Proposal doesn't change the tree, but changes parameters describing the process that generates the tree. See #600
+        void                                    cleanProposal(void) override;                                                       //!< Clean up proposal
+        double                                  doProposal(void) override;                                                          //!< Perform proposal
         virtual void                            initialize();                                                                       //!< Initialize the proposal
-        double                                  getProposalTuningParameter(void) const;
-        void                                    printParameterSummary(std::ostream &o, bool name_only) const;                       //!< Print the parameter summary
-        void                                    prepareProposal(void);                                                              //!< Prepare the proposal
-        void                                    setProposalTuningParameter(double tp);
-        void                                    tune(double r);                                                                     //!< Tune the proposal to achieve a better acceptance/rejection ratio
-        void                                    undoProposal(void);                                                                 //!< Reject the proposal
+        double                                  getProposalTuningParameter(void) const override;
+        void                                    printParameterSummary(std::ostream &o, bool name_only) const override;              //!< Print the parameter summary
+        void                                    prepareProposal(void) override;                                                     //!< Prepare the proposal
+        void                                    setProposalTuningParameter(double tp) override;
+        void                                    tune(double r) override;                                                            //!< Tune the proposal to achieve a better acceptance/rejection ratio
+        void                                    undoProposal(void) override;                                                        //!< Reject the proposal
         
     protected:
-        EventBirthDeathProposal( StochasticNode<Tree> *n);                                                                          //!<  constructor
+        EventBirthDeathProposal( StochasticNode<Tree> *n);                                                                          //!< Constructor
 
         // pure virtual methods
         virtual CharacterEvent*                 drawNewEvent(double event_time) = 0;
@@ -48,7 +48,7 @@ namespace RevBayesCore {
 
         double                                  doBirthProposal(void);
         double                                  doDeathProposal(void);
-        void                                    swapNodeInternal(DagNode *oldN, DagNode *newN);                                     //!< Swap the DAG nodes on which the Proposal is working on
+        void                                    swapNodeInternal(DagNode *oldN, DagNode *newN) override;                            //!< Swap the DAG nodes on which the Proposal is working on
         
         // parameters
         AbstractCharacterHistoryBirthDeathProcess* distribution;
@@ -63,9 +63,9 @@ namespace RevBayesCore {
         size_t accepted_death;
         size_t trie_death;
 
-        CharacterEvent*                         stored_value;                                                                        //!< The stored value of the Proposal used for rejections.
+        CharacterEvent*                         stored_value;                                                                       //!< The stored value of the Proposal used for rejections.
         size_t                                  stored_branch_index;
-        bool                                    was_birth_proposal;                                                                              //!< The value we propose.
+        bool                                    was_birth_proposal;                                                                 //!< The value we propose.
     };
     
 }

--- a/src/core/moves/characterhistory/EventBranchTimeBetaProposal.h
+++ b/src/core/moves/characterhistory/EventBranchTimeBetaProposal.h
@@ -23,24 +23,24 @@ namespace RevBayesCore {
     class EventBranchTimeBetaProposal : public Proposal {
         
     public:
-        EventBranchTimeBetaProposal( StochasticNode<Tree> *n, double d, double o);                                                                //!<  constructor
+        EventBranchTimeBetaProposal( StochasticNode<Tree> *n, double d, double o);                                                          //!< Constructor
         
         // Basic utility functions
         bool                                            allowClamped() const override { return true; }                                      //!< Proposal doesn't change the tree, but changes parameters describing the process that generates the tree. See #600
-        void                                            cleanProposal(void);                                                                //!< Clean up proposal
-        EventBranchTimeBetaProposal*                    clone(void) const;                                                                  //!< Clone object
-        double                                          doProposal(void);                                                                   //!< Perform proposal
-        const std::string&                              getProposalName(void) const;                                                        //!< Get the name of the proposal for summary printing
-        double                                          getProposalTuningParameter(void) const;
-        void                                            printParameterSummary(std::ostream &o, bool name_only) const;                                       //!< Print the parameter summary
-        void                                            prepareProposal(void);                                                              //!< Prepare the proposal
-        void                                            setProposalTuningParameter(double tp);
-        void                                            tune(double r);                                                                     //!< Tune the proposal to achieve a better acceptance/rejection ratio
-        void                                            undoProposal(void);                                                                 //!< Reject the proposal
+        void                                            cleanProposal(void) override;                                                       //!< Clean up proposal
+        EventBranchTimeBetaProposal*                    clone(void) const override;                                                         //!< Clone object
+        double                                          doProposal(void) override;                                                          //!< Perform proposal
+        const std::string&                              getProposalName(void) const override;                                               //!< Get the name of the proposal for summary printing
+        double                                          getProposalTuningParameter(void) const override;
+        void                                            printParameterSummary(std::ostream &o, bool name_only) const override;              //!< Print the parameter summary
+        void                                            prepareProposal(void) override;                                                     //!< Prepare the proposal
+        void                                            setProposalTuningParameter(double tp) override;
+        void                                            tune(double r) override;                                                            //!< Tune the proposal to achieve a better acceptance/rejection ratio
+        void                                            undoProposal(void) override;                                                        //!< Reject the proposal
         
     protected:
         
-        void                                            swapNodeInternal(DagNode *oldN, DagNode *newN);                                     //!< Swap the DAG nodes on which the Proposal is working on
+        void                                            swapNodeInternal(DagNode *oldN, DagNode *newN) override;                            //!< Swap the DAG nodes on which the Proposal is working on
         
     private:
         // parameters
@@ -50,9 +50,9 @@ namespace RevBayesCore {
         double                                          delta;
         double                                          offset;
 
-        CharacterEvent*                                 stored_value;                                                                        //!< The stored value of the Proposal used for rejections.
-        double                                          stored_age;                                                                              //!< The value we propose.
-        size_t                                          stored_branch_index;                                                                              //!< The value we propose.
+        CharacterEvent*                                 stored_value;                                                                       //!< The stored value of the Proposal used for rejections.
+        double                                          stored_age;                                                                         //!< The value we propose.
+        size_t                                          stored_branch_index;                                                                //!< The value we propose.
         bool                                            failed;
     };
     

--- a/src/core/moves/characterhistory/EventTimeSlideProposal.h
+++ b/src/core/moves/characterhistory/EventTimeSlideProposal.h
@@ -23,24 +23,24 @@ namespace RevBayesCore {
     class EventTimeSlideProposal : public Proposal {
         
     public:
-        EventTimeSlideProposal( StochasticNode<Tree> *n, double d);                                                                         //!<  constructor
+        EventTimeSlideProposal( StochasticNode<Tree> *n, double d);                                                                         //!< Constructor
         
         // Basic utility functions
         bool                                            allowClamped() const override { return true; }                                      //!< Proposal doesn't change the tree, but changes parameters describing the process that generates the tree. See #600
-        void                                            cleanProposal(void);                                                                //!< Clean up proposal
-        EventTimeSlideProposal*                         clone(void) const;                                                                  //!< Clone object
-        double                                          doProposal(void);                                                                   //!< Perform proposal
-        const std::string&                              getProposalName(void) const;                                                        //!< Get the name of the proposal for summary printing
-        double                                          getProposalTuningParameter(void) const;
-        void                                            printParameterSummary(std::ostream &o, bool name_only) const;                                       //!< Print the parameter summary
-        void                                            prepareProposal(void);                                                              //!< Prepare the proposal
-        void                                            setProposalTuningParameter(double tp);
-        void                                            tune(double r);                                                                     //!< Tune the proposal to achieve a better acceptance/rejection ratio
-        void                                            undoProposal(void);                                                                 //!< Reject the proposal
+        void                                            cleanProposal(void) override;                                                       //!< Clean up proposal
+        EventTimeSlideProposal*                         clone(void) const override;                                                         //!< Clone object
+        double                                          doProposal(void) override;                                                          //!< Perform proposal
+        const std::string&                              getProposalName(void) const override;                                               //!< Get the name of the proposal for summary printing
+        double                                          getProposalTuningParameter(void) const override;
+        void                                            printParameterSummary(std::ostream &o, bool name_only) const override;                                       //!< Print the parameter summary
+        void                                            prepareProposal(void) override;                                                     //!< Prepare the proposal
+        void                                            setProposalTuningParameter(double tp) override;
+        void                                            tune(double r) override;                                                            //!< Tune the proposal to achieve a better acceptance/rejection ratio
+        void                                            undoProposal(void) override;                                                        //!< Reject the proposal
         
     protected:
         
-        void                                            swapNodeInternal(DagNode *oldN, DagNode *newN);                                     //!< Swap the DAG nodes on which the Proposal is working on
+        void                                            swapNodeInternal(DagNode *oldN, DagNode *newN) override;                            //!< Swap the DAG nodes on which the Proposal is working on
         
     private:
         // parameters
@@ -49,8 +49,8 @@ namespace RevBayesCore {
         AbstractCharacterHistoryBirthDeathProcess*      distribution;
         double                                          delta;
         
-        CharacterEvent*                                 stored_value;                                                                        //!< The stored value of the Proposal used for rejections.
-        double                                          stored_age;                                                                          //!< The value we propose.
+        CharacterEvent*                                 stored_value;                                                                       //!< The stored value of the Proposal used for rejections.
+        double                                          stored_age;                                                                         //!< The value we propose.
         size_t                                          stored_branch_index;
         size_t                                          proposed_branch_index;
         bool                                            failed;

--- a/src/core/moves/mixture/MultiValueEventScaleProposal.h
+++ b/src/core/moves/mixture/MultiValueEventScaleProposal.h
@@ -30,32 +30,32 @@ template <class variableType> class StochasticNode;
         MultiValueEventScaleProposal( StochasticNode<MultiValueEvent> *n, const std::string &vn, double l );                                                       //!<  constructor
         
         // Basic utility functions
-        bool                                    allowClamped() const override { return true; }              //!< Proposal doesn't change the tree, but changes parameters describing the process that generates the tree. See #600
-        void                                    cleanProposal(void);                                        //!< Clean up proposal
-        MultiValueEventScaleProposal*           clone(void) const;                                          //!< Clone object
-        double                                  doProposal(void);                                           //!< Perform proposal
-        const std::string&                      getProposalName(void) const;                                //!< Get the name of the proposal for summary printing
-        double                                  getProposalTuningParameter(void) const;
-        void                                    prepareProposal(void);                                      //!< Prepare the proposal
-        void                                    printParameterSummary(std::ostream &o, bool name_only) const;               //!< Print the parameter summary
-        void                                    setProposalTuningParameter(double tp);
-        void                                    tune(double r);                                             //!< Tune the proposal to achieve a better acceptance/rejection ratio
-        void                                    undoProposal(void);                                         //!< Reject the proposal
+        bool                                    allowClamped() const override { return true; }                         //!< Proposal doesn't change the tree, but changes parameters describing the process that generates the tree. See #600
+        void                                    cleanProposal(void) override;                                          //!< Clean up proposal
+        MultiValueEventScaleProposal*           clone(void) const override;                                            //!< Clone object
+        double                                  doProposal(void) override;                                             //!< Perform proposal
+        const std::string&                      getProposalName(void) const override;                                  //!< Get the name of the proposal for summary printing
+        double                                  getProposalTuningParameter(void) const override;
+        void                                    prepareProposal(void) override;                                        //!< Prepare the proposal
+        void                                    printParameterSummary(std::ostream &o, bool name_only) const override; //!< Print the parameter summary
+        void                                    setProposalTuningParameter(double tp) override;
+        void                                    tune(double r) override;                                               //!< Tune the proposal to achieve a better acceptance/rejection ratio
+        void                                    undoProposal(void) override;                                           //!< Reject the proposal
         
     protected:
         
-        void                                    swapNodeInternal(DagNode *oldN, DagNode *newN);             //!< Swap the DAG nodes on which the Proposal is working on
+        void                                    swapNodeInternal(DagNode *oldN, DagNode *newN) override;               //!< Swap the DAG nodes on which the Proposal is working on
         
     private:
         
         // parameters
-        StochasticNode<MultiValueEvent>*        event_var;                                                   //!< The variable the Proposal is working on
+        StochasticNode<MultiValueEvent>*        event_var;                                                             //!< The variable the proposal is working on
         
         // stored objects to undo proposal
         bool                                    failed;
         std::string                             value_name;
 //        std::vector<double>                     stored_values;
-        double                                  lambda;                                                                             //!< The scale parameter of the move (larger lambda -> larger proposals).
+        double                                  lambda;                                                                //!< The scale parameter of the move (larger lambda -> larger proposals).
         double                                  stored_value;
         size_t                                  stored_index;
         

--- a/src/core/moves/mixture/MultiValueEventSlideProposal.h
+++ b/src/core/moves/mixture/MultiValueEventSlideProposal.h
@@ -30,32 +30,32 @@ template <class variableType> class StochasticNode;
         MultiValueEventSlideProposal( StochasticNode<MultiValueEvent> *n, const std::string &vn, double l );                                                       //!<  constructor
         
         // Basic utility functions
-        bool                                    allowClamped() const override { return true; }              //!< Proposal doesn't change the tree, but changes parameters describing the process that generates the tree. See #600
-        void                                    cleanProposal(void);                                        //!< Clean up proposal
-        MultiValueEventSlideProposal*           clone(void) const;                                          //!< Clone object
-        double                                  doProposal(void);                                           //!< Perform proposal
-        const std::string&                      getProposalName(void) const;                                //!< Get the name of the proposal for summary printing
-        double                                  getProposalTuningParameter(void) const;
-        void                                    prepareProposal(void);                                      //!< Prepare the proposal
-        void                                    printParameterSummary(std::ostream &o, bool name_only) const;               //!< Print the parameter summary
-        void                                    setProposalTuningParameter(double tp);
-        void                                    tune(double r);                                             //!< Tune the proposal to achieve a better acceptance/rejection ratio
-        void                                    undoProposal(void);                                         //!< Reject the proposal
+        bool                                    allowClamped() const override { return true; }                         //!< Proposal doesn't change the tree, but changes parameters describing the process that generates the tree. See #600
+        void                                    cleanProposal(void) override;                                          //!< Clean up proposal
+        MultiValueEventSlideProposal*           clone(void) const override;                                            //!< Clone object
+        double                                  doProposal(void) override;                                             //!< Perform proposal
+        const std::string&                      getProposalName(void) const override;                                  //!< Get the name of the proposal for summary printing
+        double                                  getProposalTuningParameter(void) const override;
+        void                                    prepareProposal(void) override;                                        //!< Prepare the proposal
+        void                                    printParameterSummary(std::ostream &o, bool name_only) const override; //!< Print the parameter summary
+        void                                    setProposalTuningParameter(double tp) override;
+        void                                    tune(double r) override;                                               //!< Tune the proposal to achieve a better acceptance/rejection ratio
+        void                                    undoProposal(void) override;                                           //!< Reject the proposal
         
     protected:
         
-        void                                    swapNodeInternal(DagNode *oldN, DagNode *newN);             //!< Swap the DAG nodes on which the Proposal is working on
+        void                                    swapNodeInternal(DagNode *oldN, DagNode *newN) override;               //!< Swap the DAG nodes on which the Proposal is working on
         
     private:
         
         // parameters
-        StochasticNode<MultiValueEvent>*        event_var;                                                   //!< The variable the Proposal is working on
+        StochasticNode<MultiValueEvent>*        event_var;                                                             //!< The variable the proposal is working on
         
         // stored objects to undo proposal
         bool                                    failed;
         std::string                             value_name;
         //        std::vector<double>                     stored_values;
-        double                                  lambda;                                                                             //!< The Slide parameter of the move (larger lambda -> larger proposals).
+        double                                  lambda;                                                                //!< The slide parameter of the move (larger lambda -> larger proposals).
         double                                  stored_value;
         size_t                                  stored_index;
         


### PR DESCRIPTION
This is just a cosmetic follow-up to the recently merged PR #600 – it adds the `override` keyword to the virtual functions of several tree event moves in order to get rid of compiler warnings.