### PR TITLE
Revamped tutorial testing

### DIFF
--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -52,30 +52,40 @@ fi
 tests=()
 status=()
 
-for t in revbayes.github.io/tutorials/*/test.sh; do
-    testname=`echo $t | cut -d '/' -f 2-3`
-    dirname=`echo $t | cut -d '/' -f 1-3`
-    
-    cd $dirname
+for t in revbayes.github.io/tutorials/*/tests.txt; do
+    testname=`echo $t | cut -d '/' -f 2-3`;
+    dirname=`echo $t | cut -d '/' -f 1-3`; 
+	
 
+    cd $dirname
     tests+=($testname)
 
     printf "\n\n#### Running test: $testname\n\n"
-    sh test.sh
-    res="$?"
-    if [ $res = 1 ]; then
-        res="error: $f"
-        break
-    elif [ $res = 139 ]; then
-        res="segfault: $f"
-        break
-    elif [ $res != 0 ]; then
-        res="error $res: $f"
-        break
-    fi
-    if [ $res != 0 ] ; then
-        echo "${dirname}/test.sh ==> error $res"
-    fi
+    
+	for script in $(cat tests.txt); 
+	do
+		(
+		cd scripts
+		sed 's/generations=[0-9]*/generations=1/g' "$script" > "cp_$script"
+		)
+        ${rb_exec} -b scripts/cp_$script
+    	res="$?"
+    	if [ $res = 1 ]; then
+        	res="error: $f"
+        	break
+    	elif [ $res = 139 ]; then
+        	res="segfault: $f"
+        	break
+    	elif [ $res != 0 ]; then
+        	res="error $res: $f"
+        	break
+    	fi
+    	if [ $res != 0 ] ; then
+        	echo "${dirname}/test.sh ==> error $res"
+    	fi
+		rm scripts/cp_$script
+		rm -rf output
+	done
 
     status+=("$res")
 

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -62,30 +62,30 @@ for t in revbayes.github.io/tutorials/*/tests.txt; do
 
     printf "\n\n#### Running test: $testname\n\n"
     
-	for script in $(cat tests.txt); 
-	do
-		(
-		cd scripts
-		sed 's/generations=[0-9]*/generations=1/g' "$script" > "cp_$script"
-		)
+    for script in $(cat tests.txt); 
+    do
+        (
+        cd scripts
+        sed 's/generations=[0-9]*/generations=1/g' "$script" > "cp_$script"
+        )
         ${rb_exec} -b scripts/cp_$script
-    	res="$?"
-    	if [ $res = 1 ]; then
-        	res="error: $f"
-        	break
-    	elif [ $res = 139 ]; then
-        	res="segfault: $f"
-        	break
-    	elif [ $res != 0 ]; then
-        	res="error $res: $f"
-        	break
-    	fi
-    	if [ $res != 0 ] ; then
-        	echo "${dirname}/test.sh ==> error $res"
-    	fi
-		rm scripts/cp_$script
-		rm -rf output
-	done
+        res="$?"
+        if [ $res = 1 ]; then
+            res="error: $f"
+            break
+        elif [ $res = 139 ]; then
+            res="segfault: $f"
+            break
+        elif [ $res != 0 ]; then
+            res="error $res: $f"
+            break
+        fi
+        if [ $res != 0 ] ; then
+            echo "${dirname}/test.sh ==> error $res"
+        fi
+        rm scripts/cp_$script
+        rm -rf output
+    done
 
     status+=("$res")
 


### PR DESCRIPTION
Changed `tests/run_integration_tests.sh` to make tutorial tests more flexible. Originally, one had to write a `test.sh` script for each tutorial (and there were scripts written for the fbd, dating, and ctmc tutorial only), which only allowed for one script per test as it was written. To make this more flexible, we changed the integration tests script so that it runs each script in a file `tests.txt` in a tutorial directory. In this way, we can ensure tutorial developers can specify which scripts must be tested, so that scripts that should not be run (e.g. when they are just written to set up variables for a master script) will not be accidentally added to the tests. To test this, I also reviewed the fbd, dating and ctmc tutorials to make sure the html and scripts matched, deleted `test.sh`, and added `tests.txt` (all on the website side, see the website repo). I updated the `revbayes.github.io` submodule in the `tests` directory to make sure this was working.