### PR TITLE
Remove more cases of getBranchLength()

### DIFF
--- a/src/core/distributions/AnalyticalMixtureDistribution.h
+++ b/src/core/distributions/AnalyticalMixtureDistribution.h
@@ -37,12 +37,6 @@ namespace RevBayesCore {
         void                                                    redrawValue(void);
         //        void                                                    setValue(RbAnalytical<mixtureType> *v, bool f=false);
         
-        // special handling of state changes
-        void                                                    getAffected(RbOrderedSet<DagNode *>& affected, const DagNode* affecter);                          //!< get affected nodes
-        void                                                    keepSpecialization(const DagNode* affecter);
-        void                                                    restoreSpecialization(const DagNode *restorer);
-        void                                                    touchSpecialization(const DagNode *toucher, bool touchAll);
-        
     protected:
         // Parameter management functions
         void                                                    swapParameterInternal(const DagNode *oldP, const DagNode *newP);                        //!< Swap a parameter
@@ -217,26 +211,6 @@ void RevBayesCore::AnalyticalMixtureDistribution<mixtureType>::executeMethod(con
 
 
 template <class mixtureType>
-void RevBayesCore::AnalyticalMixtureDistribution<mixtureType>::getAffected(RbOrderedSet<DagNode *> &affected, const DagNode* affecter)
-{
-    
-    
-}
-
-
-template <class mixtureType>
-void RevBayesCore::AnalyticalMixtureDistribution<mixtureType>::keepSpecialization( const DagNode* affecter )
-{
-    // only do this when the toucher was our parameters
-    //    if ( affecter == parameterValues && this->dag_node != NULL )
-    //    {
-    //        this->dag_node->keepAffected();
-    //    }
-    
-}
-
-
-template <class mixtureType>
 void RevBayesCore::AnalyticalMixtureDistribution<mixtureType>::redrawValue( void )
 {
     
@@ -298,26 +272,6 @@ void RevBayesCore::AnalyticalMixtureDistribution<mixtureType>::swapParameterInte
     {
         throw RbException() << "Could not find the distribution parameter to be swapped: " << old_p->getName() << " to " << new_p->getName(); 
     }
-}
-
-
-template <class mixtureType>
-void RevBayesCore::AnalyticalMixtureDistribution<mixtureType>::restoreSpecialization( const DagNode *restorer )
-{
-    
-    // only do this when the toucher was our parameters
-    dirty = true;
-    
-    
-}
-
-
-template <class mixtureType>
-void RevBayesCore::AnalyticalMixtureDistribution<mixtureType>::touchSpecialization( const DagNode *toucher, bool touchAll )
-{
-    // only do this when the toucher was our parameters
-    dirty = true;
-    
 }
 
 #endif

--- a/src/core/distributions/phylogenetics/substitution/CTMCProcess.h
+++ b/src/core/distributions/phylogenetics/substitution/CTMCProcess.h
@@ -54,10 +54,7 @@ namespace RevBayesCore {
         virtual std::vector<double>                                         getMixtureProbs( void ) const;
         virtual std::vector<double>                                         getRootFrequencies( size_t mixture = 0 ) const;
         virtual void                                                        getRootFrequencies( std::vector<std::vector<double> >& ) const;
-        virtual void                                                        keepSpecialization(const DagNode* affecter);
-        virtual void                                                        restoreSpecialization(const DagNode *restorer);
         virtual void                                                        setActivePIDSpecialized(size_t i, size_t n);                                                 //!< Set the number of processes for this distribution.
-        virtual void                                                        touchSpecialization(const DagNode *toucher, bool touchAll);
         virtual void                                                        updateTransitionProbabilities( void ) const;
 
 
@@ -915,14 +912,6 @@ std::vector<double> RevBayesCore::CTMCProcess<charType>::getMixtureProbs( void )
 
 
 template<class charType>
-void RevBayesCore::CTMCProcess<charType>::keepSpecialization( const DagNode* affecter )
-{
-
-}
-
-
-
-template<class charType>
 void RevBayesCore::CTMCProcess<charType>::redrawValue( void )
 {
     
@@ -1064,15 +1053,6 @@ void RevBayesCore::CTMCProcess<charType>::reInitialized( void )
 
     // we need to recompress because the tree may have changed
     compress();
-}
-
-
-template<class charType>
-void RevBayesCore::CTMCProcess<charType>::restoreSpecialization( const DagNode* affecter )
-{
-
-
-
 }
 
 
@@ -1353,17 +1333,6 @@ void RevBayesCore::CTMCProcess<charType>::swapParameterInternal(const DagNode *o
     }
 
 }
-
-template<class charType>
-void RevBayesCore::CTMCProcess<charType>::touchSpecialization( const DagNode* affecter, bool touch_all )
-{
-
-
-}
-
-
-
-
 
 
 /*

--- a/src/core/distributions/phylogenetics/substitution/PhyloDistanceGamma.cpp
+++ b/src/core/distributions/phylogenetics/substitution/PhyloDistanceGamma.cpp
@@ -71,29 +71,6 @@ PhyloDistanceGamma* PhyloDistanceGamma::clone( void ) const
 }
 
 
-void PhyloDistanceGamma::keepSpecialization(const DagNode* affecter)
-{
-    
-    
-}
-
-
-void PhyloDistanceGamma::touchSpecialization(const DagNode *toucher, bool touchAll)
-{
-    
-    
-}
-
-
-void PhyloDistanceGamma::reInitialized(void)
-{
-    
-    
-}
-
-
-
-
 double PhyloDistanceGamma::computeLogLikelihood( void )
 {
     

--- a/src/core/distributions/phylogenetics/substitution/PhyloDistanceGamma.h
+++ b/src/core/distributions/phylogenetics/substitution/PhyloDistanceGamma.h
@@ -18,11 +18,10 @@ namespace RevBayesCore {
         virtual                                            ~PhyloDistanceGamma(void);                                                                   //!< Virtual destructor
         
         // public member functions
-        PhyloDistanceGamma*                                                 clone(void) const;                                                                          //!< Create an independent clone
+                PhyloDistanceGamma*                                                 clone(void) const;                                                                          //!< Create an independent clone
 		double                                                              computeLnProbability(void);
 		//void                                                                fireTreeChangeEvent(const TopologyNode &n);                                                 //!< The tree has changed and we want to know which part.
 		void                                                                redrawValue(void);
-		void                                                                reInitialized(void);
 		void                                                                setDistanceMatrix(const TypedDagNode< DistanceMatrix > *dm);
 		void                                                                setVarianceMatrix(const TypedDagNode< DistanceMatrix > *dm);
 		void                                                                setNames(const std::vector< std::string >& n);
@@ -35,11 +34,6 @@ namespace RevBayesCore {
 		
 		// Parameter management functions.
 		virtual void                                                        swapParameterInternal(const DagNode *oldP, const DagNode *newP);                                    //!< Swap a parameter
-		
-		
-		// virtual methods that may be overwritten, but then the derived class should call this methods
-		virtual void                                                        keepSpecialization(const DagNode* affecter);
-		virtual void                                                        touchSpecialization(const DagNode *toucher, bool touchAll);
 		
 		void 																updateAlphaAndBetaMatrices();
 		


### PR DESCRIPTION
This removes empty cases of `touchSpecialization( )`, `keepSpecialization( )`, `restoreSpecialization( )`. 