### PR TITLE
Ensuring integration tests can run tutorial checkpoint tests

### DIFF
--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -67,6 +67,7 @@ for t in revbayes.github.io/tutorials/*/tests.txt; do
         (
         cd scripts
         sed 's/generations=[0-9]*/generations=1/g' "$script" > "cp_$script"
+        sed -i '' 's/checkpointInterval=[0-9]*/checkpointInterval=1/g' "cp_$script"
         )
         ${rb_exec} -b scripts/cp_$script
         res="$?"

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -66,8 +66,7 @@ for t in revbayes.github.io/tutorials/*/tests.txt; do
     do
         (
         cd scripts
-        sed 's/generations=[0-9]*/generations=1/g' "$script" > "cp_$script"
-        sed -i '' 's/checkpointInterval=[0-9]*/checkpointInterval=1/g' "cp_$script"
+        sed 's/generations=[0-9]*/generations=1/g' "$script" | sed 's/checkpointInterval=[0-9]*/checkpointInterval=1/g'  > "cp_$script"
         )
         ${rb_exec} -b scripts/cp_$script
         res="$?"


### PR DESCRIPTION
Minor change to `tests/run_integration_tests.sh` to ensure that tutorial tests using checkpointing (e.g. `ctmc`) can be run without a hitch. It simply changes the `checkpointInterval` argument (if there is one) to 1 in the copy script used for the test run. Also updated git submodule.