### PR TITLE
Fix state space when subsetting by state space

### DIFF
--- a/src/core/datatypes/phylogenetics/character/DiscreteCharacterState.cpp
+++ b/src/core/datatypes/phylogenetics/character/DiscreteCharacterState.cpp
@@ -263,6 +263,12 @@ size_t DiscreteCharacterState::getNumberOfStates(void) const
 }
 
 
+void DiscreteCharacterState::setStateLabels(const std::string &l)
+{
+    
+}
+
+
 const std::vector<double>& DiscreteCharacterState::getWeights() const
 {
     // PoMo has weights.

--- a/src/core/datatypes/phylogenetics/character/DiscreteCharacterState.h
+++ b/src/core/datatypes/phylogenetics/character/DiscreteCharacterState.h
@@ -24,35 +24,36 @@ namespace RevBayesCore {
         virtual bool                            operator==(const CharacterState& x) const;
         bool                                    operator!=(const CharacterState& x) const;
         virtual bool                            operator<(const CharacterState& x) const;
-        void                                    operator++();  //!< Increment
-        void                                    operator++(int i);  //!< Increment
-        virtual void                            operator+=(int i);  //!< Increment
-        void                                    operator--();  //!< Decrement
-        void                                    operator--(int i);  //!< Decrement
-        virtual void                            operator-=(int i);  //!< Decrement
+        void                                    operator++();                                   //!< Increment
+        void                                    operator++(int i);                              //!< Increment
+        virtual void                            operator+=(int i);                              //!< Increment
+        void                                    operator--();                                   //!< Decrement
+        void                                    operator--(int i);                              //!< Decrement
+        virtual void                            operator-=(int i);                              //!< Decrement
 
         virtual bool                            isAmbiguous(void) const;
         virtual std::string                     getStringValue(void) const;
-        virtual std::string                     getStateDescription(void) const;  //!< Get a description of the current state
-        virtual std::vector<std::string>        getStateDescriptions(void) const;  //!< Get all possible state labels as a vector
-        virtual size_t                          getNumberObservedStates(void) const;  //!< How many states are in the set of current states
+        virtual std::string                     getStateDescription(void) const;                //!< Get a description of the current state
+        virtual std::vector<std::string>        getStateDescriptions(void) const;               //!< Get all possible state labels as a vector
+        virtual size_t                          getNumberObservedStates(void) const;            //!< How many states are in the set of current states
         virtual size_t                          getNumberOfStates(void) const;
-        virtual size_t                          getStateIndex(void) const;  //!< Get the index of the current state
-        virtual bool                            isStateSet(size_t index) const;  //!< Is this state part of the current set?
+        virtual size_t                          getStateIndex(void) const;                      //!< Get the index of the current state
+        virtual bool                            isStateSet(size_t index) const;                 //!< Is this state part of the current set?
 
         virtual DiscreteCharacterState*         clone(void) const = 0;
 
-        virtual void                            addState(const std::string &symbol) = 0;  //!< Add a state to the set of current states
-        virtual RbBitSet                        getState(void) const = 0;  //!< Get the current state (as a bitset)
-        virtual void                            setToFirstState(void) = 0;  //!< Set the state to the first (lowest) possible state
-        virtual void                            setStateByIndex(size_t index) = 0;  //!< Set the current state (by index)
-        virtual void                            setState(const std::string &symbol) = 0;  //!< Set the current state (by state)
+        virtual void                            addState(const std::string &symbol) = 0;        //!< Add a state to the set of current states
+        virtual RbBitSet                        getState(void) const = 0;                       //!< Get the current state (as a bitset)
+        virtual void                            setToFirstState(void) = 0;                      //!< Set the state to the first (lowest) possible state
+        virtual void                            setStateByIndex(size_t index) = 0;              //!< Set the current state (by index)
+        virtual void                            setState(const std::string &symbol) = 0;        //!< Set the current state (by state)
 
         // Discrete character observation functions
-        virtual std::string                     getStateLabels(void) const = 0;  //!< Get labels for all possible states
-        const std::vector<double>&              getWeights() const;  //!< Get the weights of each state
-        bool                                    isWeighted() const;  //!< Is the state weighted?
-        void                                    setWeighted( bool tf );   //!< Sets whether the state is weighted or not
+        virtual std::string                     getStateLabels(void) const = 0;                 //!< Get labels for all possible states
+        const std::vector<double>&              getWeights() const;                             //!< Get the weights of each state
+        bool                                    isWeighted() const;                             //!< Is the state weighted?
+        virtual void                            setStateLabels(const std::string& l);           //!< Set the state labels
+        void                                    setWeighted( bool tf );                         //!< Sets whether the state is weighted or not
 
     protected:
                                                 DiscreteCharacterState(size_t n);   //!< Constructor

--- a/src/core/datatypes/phylogenetics/character/StandardState.cpp
+++ b/src/core/datatypes/phylogenetics/character/StandardState.cpp
@@ -156,3 +156,9 @@ void StandardState::setStateByIndex(size_t index)
     state.set( index );
 }
 
+
+void StandardState::setStateLabels(const std::string& l)
+{
+    labels = l;
+}
+

--- a/src/core/datatypes/phylogenetics/character/StandardState.h
+++ b/src/core/datatypes/phylogenetics/character/StandardState.h
@@ -34,19 +34,20 @@ namespace RevBayesCore {
         StandardState*                  clone(void) const;                                          //!< Get a copy of this object
     
         // Discrete character observation functions
-        void                            addState(const std::string &symbol);                //!< Add a character state to the set of character states
-        RbBitSet                        getState(void) const;                               //!< Get the state (as the bitset)
-        void                            setToFirstState(void);                              //!< Set this character state to the first (lowest) possible state
-        void                            setState(const std::string &symbol);                //!< Compute the internal state value for this character.
-        void                            setStateByIndex(size_t index);                      //!< Set the discrete observation
+        void                            addState(const std::string &symbol);                        //!< Add a character state to the set of character states
+        RbBitSet                        getState(void) const;                                       //!< Get the state (as the bitset)
+        void                            setToFirstState(void);                                      //!< Set this character state to the first (lowest) possible state
+        void                            setState(const std::string &symbol);                        //!< Compute the internal state value for this character.
+        void                            setStateByIndex(size_t index);                              //!< Set the discrete observation
 
         std::string                     getDataType(void) const;                                    //!< Get the datatype as a common string.
         std::string                     getStateLabels(void) const;                                 //!< Get valid state labels
-        bool                            isGapState(void) const;                             //!< Get whether this is a gapped character state
-        bool                            isMissingState(void) const;                         //!< Get whether this is a missing character state
-        void                            setGapState(bool tf);                               //!< set whether this is a gapped character
-        void                            setMissingState(bool tf);                           //!< set whether this is a missing character
-        
+        bool                            isGapState(void) const;                                     //!< Get whether this is a gapped character state
+        bool                            isMissingState(void) const;                                 //!< Get whether this is a missing character state
+        void                            setGapState(bool tf);                                       //!< set whether this is a gapped character
+        void                            setMissingState(bool tf);                                   //!< set whether this is a missing character
+        void                            setStateLabels(const std::string& l);                       //!< set the state labels
+
     private:
         
         bool                            is_gap;

--- a/src/core/datatypes/phylogenetics/characterdata/AbstractCharacterData.cpp
+++ b/src/core/datatypes/phylogenetics/characterdata/AbstractCharacterData.cpp
@@ -433,14 +433,16 @@ size_t AbstractCharacterData::getNumberOfIncludedTaxa(void) const
  *
  * \return    The percentage of missing characters.
  */
-double AbstractCharacterData::getPercentageMissing( const std::string &n ) const {
+double AbstractCharacterData::getPercentageMissing( const std::string &n ) const 
+{
     
     const AbstractTaxonData &td = getTaxonData(n);
     return td.getPercentageMissing();
 }
 
 
-std::string AbstractCharacterData::getStateLabels(void) {
+std::string AbstractCharacterData::getStateLabels(void) 
+{
 
     if (taxonMap.size() == 0)
     {
@@ -450,7 +452,8 @@ std::string AbstractCharacterData::getStateLabels(void) {
     return i->second->getStateLabels();
 }
 
-std::string AbstractCharacterData::getStateLabels(void) const {
+std::string AbstractCharacterData::getStateLabels(void) const 
+{
 
     if (taxonMap.size() == 0)
     {
@@ -468,7 +471,8 @@ std::string AbstractCharacterData::getStateLabels(void) const {
  *
  * \return              The taxon.
  */
-const Taxon& AbstractCharacterData::getTaxon(size_t idx) const {
+const Taxon& AbstractCharacterData::getTaxon(size_t idx) const 
+{
     
     return taxa[idx];
 }

--- a/src/revlanguage/datatypes/phylogenetics/characterdata/RlAbstractHomologousDiscreteCharacterData.cpp
+++ b/src/revlanguage/datatypes/phylogenetics/characterdata/RlAbstractHomologousDiscreteCharacterData.cpp
@@ -596,6 +596,13 @@ RevPtr<RevVariable> AbstractHomologousDiscreteCharacterData::executeMethod(std::
                 if (max + 1 == n)
                 {
                     v.includeCharacter(i);
+                    for (size_t j = 0; j < nTaxa; j++)
+                    {
+                        RevBayesCore::AbstractDiscreteTaxonData& td = v.getTaxonData(j);
+                        std::string labels = td.getCharacter(i).getStateLabels();
+                        labels = labels.substr(0,n);
+                        td.getCharacter(i).setStateLabels(labels);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
This should be resetting state labels when setting partition by state size. Thus, it fixes the issue that the state space still looks larger.