### PR TITLE
Fix logging when running Mcmcmc twice.

### DIFF
--- a/src/core/analysis/mcmc/Mcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmc.cpp
@@ -330,34 +330,6 @@ void Mcmc::disableScreenMonitor( bool all, size_t rep )
 
 
 /**
- * Finish the monitors which will close the output streams.
- */
-void Mcmc::finishMonitors( size_t n_reps, MonteCarloAnalysisOptions::TraceCombinationTypes tc )
-{
-    
-    // iterate over all monitors
-    for (size_t i=0; i<monitors.size(); ++i)
-    {
-        
-        // if this chain is active, then close the stream
-        if ( chain_active == true && process_active == true )
-        {
-            monitors[i].closeStream();
-            
-            // combine results if we used more than one replicate
-            if ( n_reps > 1 && tc != MonteCarloAnalysisOptions::NONE )
-            {
-                monitors[i].combineReplicates( n_reps, tc );
-            }
-            
-        }
-        
-    }
-    
-}
-
-
-/**
  * Get the heat of the likelihood of this chain.
  */
 double Mcmc::getChainLikelihoodHeat(void) const
@@ -1382,6 +1354,28 @@ void Mcmc::startMonitors( size_t num_cycles, bool reopen )
     }
     
 }
+
+/**
+ * Finish the monitors which will close the output streams.
+ */
+void Mcmc::finishMonitors( size_t n_reps, MonteCarloAnalysisOptions::TraceCombinationTypes tc )
+{
+    
+    // iterate over all monitors
+    for (size_t i=0; i<monitors.size(); ++i)
+    {
+        // close filestream for each monitor
+        monitors[i].closeStream();
+            
+        // combine results if we used more than one replicate
+        if ( n_reps > 1 && tc != MonteCarloAnalysisOptions::NONE )
+        {
+            monitors[i].combineReplicates( n_reps, tc );
+        }
+    }
+    
+}
+
 
 /**
  * Write the header for each of the monitors.


### PR DESCRIPTION
It looks like current practice is to call `monitors[i].openStream()` on the monitors for every chain -- including hot chains.  However, we only call `monitors[i].closeStream()` on the monitors for the active chain.

Currently all chains in an Mcmcmc analysis have their own duplicate version of each monitor.  For an analysis with 4 chains, we thus open the log file 4 times. The log file is open from 4 different fstream objects, and we write to the file sometimes through one fstream object, and sometimes through another object, as different chains become active.  The fact that this works at all boggles the mind.  Perhaps this explains why we seek to the end of the file before writing?

But apparently it seems to work.  However, after we stop the MCMCMC and restart it, writing to the file sometimes sends the bits directly into the ether (see #525). They just vanish, and the file is unchanged even though I can watch the write (and the flush()) happening in the debugger.  So probably something is corrupting the fstream objects.

SOLUTION: Apparently if we close all the streams after the analysis ends, then the second analysis logs things correctly.