### PR TITLE
Bump version to v1.3.0 and add list of PRs as release notes.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,6 +263,18 @@ jobs:
            # There are some differences on the order of 1.0e-5 in the substitution likelihood between Linux/Intel and Mac/ARM
            rm -rf test_propose_bad_index/output_expected/
         fi
+        
+        if [ ${{ matrix.arch }} == "mac-arm64" ] ; then
+           rm -f test_coalescent/output_expected/horses_het_BSP*
+           rm -f test_coalescent/output_expected/horses_het_GMRF_treebased*
+           rm -f test_coalescent/output_expected/mcmc_heterochronous_BSP.errout
+           rm -f test_coalescent/output_expected/mcmc_heterochronous_GMRF_treebased.errout
+        fi
+
+        if [ ${{ matrix.arch }} == "win64" ] ; then
+           rm -f test_coalescent/output_expected/horses_iso_EBSP_*
+           rm -f test_coalescent/output_expected/mcmc_isochronous_EBSP.errout
+        fi
 
         ./run_integration_tests.sh -mpi ${USE_MPI} -windows ${IS_WINDOWS} rb
         cd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,10 +169,6 @@ jobs:
         ${GITHUB_WORKSPACE}/projects/meson/make_winroot.sh -ccache true -gtk true
         ( cd ${GITHUB_WORKSPACE}/projects/meson/ ; ./generate.sh )
         
-    - name: Update submodules
-      run: |
-        git submodule update --init --recursive
-        
     - name: Configure and build
       if: matrix.name != 'windows'
       env:
@@ -259,7 +255,8 @@ jobs:
            rm -f test_CBDSP/output_expected/mcmc_CBDSP.errout
         fi
 
-        if [ ${{ matrix.arch }} == "mac-arm64" ] || [ ${{ matrix.arch }} = "mac-intel64" ] || [ ${{ matrix.arch }} == "win64" ] ; then
+        if [ ${{ matrix.arch }} = "mac-arm64" ] || [ ${{ matrix.arch }} = "mac-intel64" ] || [ ${{ matrix.arch }} = "win64" ] ; then
+           rm -f test_MC3/output_expected/*tuning_and_checkpointing*
            rm -rf test_FBD/output_expected/
            rm -rf test_BDSTP/output_expected/
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,73 @@
-# RevBayes 1.2.6 (unreleased)
+# RevBayes 1.3.0 (unreleased)
+## What's Changed
+* simmap bugfix for when some characters are excluded by @kopperud in https://github.com/revbayes/revbayes/pull/636
+* Bump version after v1.2.5 release by @bredelings in https://github.com/revbayes/revbayes/pull/637
+* Fix `.dropTip()` behavior for multifurcations by @davidcerny in https://github.com/revbayes/revbayes/pull/640
+* Fix CI builds by dropping openlibm by @bredelings in https://github.com/revbayes/revbayes/pull/644
+* Print convergence statistics during MCMC runs with stopping rules by @davidcerny in https://github.com/revbayes/revbayes/pull/645
+* Random resolution of multifurcations and MBL time-scaling by @davidcerny in https://github.com/revbayes/revbayes/pull/641
+* Add cosine function by @bredelings in https://github.com/revbayes/revbayes/pull/647
+* MPI checkpointing fix by @davidcerny in https://github.com/revbayes/revbayes/pull/646
+* Prevent loss of integer precision in MC^3 by @davidcerny in https://github.com/revbayes/revbayes/pull/652
+* Filled out help file for exp function. by @brpetrucci in https://github.com/revbayes/revbayes/pull/653
+* Revert accidentally committed-by-unreview patch by @bredelings in https://github.com/revbayes/revbayes/pull/654
+* Document simplex moves by @ms609 in https://github.com/revbayes/revbayes/pull/606
+* Changes to rate matrix model help files by @brpetrucci in https://github.com/revbayes/revbayes/pull/656
+* Remove empty touch( ), keep( ), and  restore( ) specializations. by @bredelings in https://github.com/revbayes/revbayes/pull/658
+* Changes to build files to streamline help infrastructure by @brpetrucci in https://github.com/revbayes/revbayes/pull/659
+* Improvements to stopping rule messages by @davidcerny in https://github.com/revbayes/revbayes/pull/657
+* Use different seeds for replicates in MPI run by @bjoelle in https://github.com/revbayes/revbayes/pull/662
+* Completing and standardizing stats distributions help files, part 1 by @brpetrucci in https://github.com/revbayes/revbayes/pull/663
+* Document DPP moves by @davidcerny in https://github.com/revbayes/revbayes/pull/666
+* Prevent modification of clamped value by @ms609 in https://github.com/revbayes/revbayes/pull/600
+* Prevent NaN heats in MC^3 by @davidcerny in https://github.com/revbayes/revbayes/pull/661
+* add help for jukes cantor by @raymondcast18 in https://github.com/revbayes/revbayes/pull/649
+* Mark overridden virtual functions as such in tree event moves by @davidcerny in https://github.com/revbayes/revbayes/pull/669
+* Revamped tutorial testing by @brpetrucci in https://github.com/revbayes/revbayes/pull/674
+* Ensuring integration tests can run tutorial checkpoint tests by @brpetrucci in https://github.com/revbayes/revbayes/pull/676
+* Dev hoehna lab by @hoehna in https://github.com/revbayes/revbayes/pull/682
+* Additional coalescent development by @hoehna in https://github.com/revbayes/revbayes/pull/473
+* Update nlohmann::json to avoid tons of compilation warnings with GCC 15. by @bredelings in https://github.com/revbayes/revbayes/pull/685
+* Don't throw exception to perform a simple check. by @bredelings in https://github.com/revbayes/revbayes/pull/677
+* Fix broken overrides part1 by @bredelings in https://github.com/revbayes/revbayes/pull/684
+* Created matrix.md and var.md files for review by @raymondcast18 in https://github.com/revbayes/revbayes/pull/681
+* Don't treat deterministic nodes as constants by @bredelings in https://github.com/revbayes/revbayes/pull/678
+* Use std::shared_ptr<Environment> to hold Environments. by @bredelings in https://github.com/revbayes/revbayes/pull/687
+* Fix state space when subsetting by state space by @hoehna in https://github.com/revbayes/revbayes/pull/696
+* Better documentation and progress monitoring for power posterior analyses by @davidcerny in https://github.com/revbayes/revbayes/pull/673
+* Added sine function by @sigibrock in https://github.com/revbayes/revbayes/pull/648
+* Fix mvRateAgeBetaShift by @bredelings in https://github.com/revbayes/revbayes/pull/688
+* Added function covarion documentation by @basanta33 in https://github.com/revbayes/revbayes/pull/704
+* Adding documentation to 'fnDiscretizeDistribution' and 'fnDiscretizeG… by @basanta33 in https://github.com/revbayes/revbayes/pull/707
+* updated fnFreeBinary help file by @sigibrock in https://github.com/revbayes/revbayes/pull/706
+* Wrote help files for power and write function by @raymondcast18 in https://github.com/revbayes/revbayes/pull/690
+* vectorFlatten.md fnFreeK.md, fnReadVCF.md, dnUniformInteger.md help files by @raymondcast18 in https://github.com/revbayes/revbayes/pull/667
+* Updating documentation for readTreeTrace by @ixchelgzlzr in https://github.com/revbayes/revbayes/pull/703
+* Fix windows long by @bredelings in https://github.com/revbayes/revbayes/pull/708
+* BUG #668 dnUniformTopology ignores neg clade const by @Levi-Raskin in https://github.com/revbayes/revbayes/pull/711
+* Changed website submodule to pull from source rather than master. by @brpetrucci in https://github.com/revbayes/revbayes/pull/692
+* Editing WAG help file  by @PhyloevoTi in https://github.com/revbayes/revbayes/pull/655
+* Update readTrace.md by @bredelings in https://github.com/revbayes/revbayes/pull/702
+* Fix out of range proposal by @bredelings in https://github.com/revbayes/revbayes/pull/709
+* Fix deterministic index by @bredelings in https://github.com/revbayes/revbayes/pull/719
+* Document TreeTrace methods by @ms609 in https://github.com/revbayes/revbayes/pull/722
+* Only type-convert variables based on value if they are constant by @bredelings in https://github.com/revbayes/revbayes/pull/721
+* Document readTrace methods by @ms609 in https://github.com/revbayes/revbayes/pull/723
+* Fix logging when running Mcmcmc twice. by @bredelings in https://github.com/revbayes/revbayes/pull/727
+* MC^3 checkpointing fix by @davidcerny in https://github.com/revbayes/revbayes/pull/670
+* Fix `readTrees(text = ...)` by @davidcerny in https://github.com/revbayes/revbayes/pull/735
+* Add an `nruns` argument to `readTrace()` by @davidcerny in https://github.com/revbayes/revbayes/pull/736
+* Fix caching bugs in phyloCTMC by @bredelings in https://github.com/revbayes/revbayes/pull/729
+* Allow MCMC moves with low prob ratio and high Jacobian/Hastings ratio by @bredelings in https://github.com/revbayes/revbayes/pull/728
+* Display current stopping rule values when resuming from a checkpoint by @davidcerny in https://github.com/revbayes/revbayes/pull/739
 
+## New Contributors
+* @raymondcast18 made their first contribution in https://github.com/revbayes/revbayes/pull/649
+* @sigibrock made their first contribution in https://github.com/revbayes/revbayes/pull/648
+* @basanta33 made their first contribution in https://github.com/revbayes/revbayes/pull/704
+* @ixchelgzlzr made their first contribution in https://github.com/revbayes/revbayes/pull/703
+* @Levi-Raskin made their first contribution in https://github.com/revbayes/revbayes/pull/711
+* @PhyloevoTi made their first contribution in https://github.com/revbayes/revbayes/pull/655
 
 # RevBayes 1.2.5 (Dec 19, 2025)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 
 ## Features
   * Interface
-      - Print convergence statistics during MCMC runs with stopping rules (#645, #657, #739).
+      - Print convergence statistics during MCMC runs with stopping rules if `verbose=2` (#645, #657, #739).
       - Better progress monitoring for power posterior analyses (#673).
   * Methods / arguments
       - Add member procedure for randomly resolving multifurcations (#641).
@@ -47,24 +47,31 @@
       - Prevent some instances of clamped values from being modified (#600).
 
 ## Documentation improvements
-  * Document simplex moves [#606](https://github.com/revbayes/revbayes/pull/606))
-  * Add help for jukes cantor [#649](https://github.com/revbayes/revbayes/pull/649)
-  * Fill out help file for exp function [#653](https://github.com/revbayes/revbayes/pull/653))
-  * Edit WAG help file  [#655](https://github.com/revbayes/revbayes/pull/655)
-  * Change rate matrix model help files [#656](https://github.com/revbayes/revbayes/pull/656)
-  * Complete and standardize stats distributions help files, part 1 [#663](https://github.com/revbayes/revbayes/pull/663)
-  * Document DPP moves [#666](https://github.com/revbayes/revbayes/pull/666)
-  * vectorFlatten.md fnFreeK.md, fnReadVCF.md, dnUniformInteger.md help files [#667](https://github.com/revbayes/revbayes/pull/667)
-  * Create matrix.md and var.md files for review [#681](https://github.com/revbayes/revbayes/pull/681)
-  * More move help files [#683](https://github.com/revbayes/revbayes/pull/683)
-  * Write help files for power and write function [#690](https://github.com/revbayes/revbayes/pull/690)
-  * Update readTrace.md [#702](https://github.com/revbayes/revbayes/pull/702)
-  * Update documentation for readTreeTrace [#703](https://github.com/revbayes/revbayes/pull/703)
-  * Add function covarion documentation [#704](https://github.com/revbayes/revbayes/pull/704)
-  * Update fnFreeBinary help file [#706](https://github.com/revbayes/revbayes/pull/706)
-  * Add documentation to 'fnDiscretizeDistribution' and 'fnDiscretizeG… [#707](https://github.com/revbayes/revbayes/pull/707)
-  * Document TreeTrace methods [#722](https://github.com/revbayes/revbayes/pull/722)
-  * Document readTrace methods [#723](https://github.com/revbayes/revbayes/pull/723)
+  * `Simplex` (#606).
+  * Moves
+      - `mvBetaSimplex`, `mvDirichletSimplex`, `mvElementSwapSimplex` (#606).
+      - `mvDPPValueBetaSimplex`, `mvDPPValueScaling`, `mvDPPValueSliding` (#666).
+      - `mvNNI`, `mvSPR`, `mvScale`, `mvScaleBactrian`, `mvSlide`, `mvSlideBactrian`, `mvTreeScale`, `mvUpDownScale`, `mvUpDownSlide` (#683).
+  * `sin` (#648, #683).
+  * Substitution models
+      - `fnJC` (#649).
+      - `fnF81`, `fnGTR`, `fnHKY`, `fnK80`, `fnK81`, `fnT92`, `fnTrN` (#653, #656).
+      - `fnLG`, `fnWAG` (#655).
+      - `fnFreeK` (#667).
+      - `fnCovarion` (#704).
+      - `fnFreeBinary` (#706).
+  * `exp` (#653).
+  * Complete and standardize documentation for `dnBernoulli`, `dnBeta`, `dnBimodalLognormal`, `dnBimodalNormal`, `dnBinomial`, `dnCategorical`, `dnCauchy`, `dnChisq`, `dnDirichlet`, `dnExponential`, `dnGamma` (#663).
+  * `dnUniformInteger`, `fnReadVCF`, `vectorFlatten` (#667).
+  * Expand documentation for `powerPosterior` (#673).
+  * `matrix`, `var` (#681).
+  * `floor`, `mnModel`, `reverse`, `sinh` (#683).
+  * `power`, `write` (#690).
+  * Analysis output types and I/O functions
+      - `readTrace` (#702, #723, #736).
+      - `readTreeTrace` (#703, #722, #723, #736).
+      - `Trace`, `TraceTree` (#723).
+  * Discretization functions: `fnDiscretizeDistribution`, `fnDiscretizeGamma` (#707).
 
 ## Infrastructure
   * Update validation tests [#473](https://github.com/revbayes/revbayes/pull/473)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,36 +1,46 @@
 # RevBayes 1.3.0 (unreleased)
 ## What's Changed
-* simmap bugfix for when some characters are excluded by @kopperud in https://github.com/revbayes/revbayes/pull/636
-* Fix `.dropTip()` behavior for multifurcations by @davidcerny in https://github.com/revbayes/revbayes/pull/640
 * Print convergence statistics during MCMC runs with stopping rules by @davidcerny in https://github.com/revbayes/revbayes/pull/645
-* Random resolution of multifurcations and MBL time-scaling by @davidcerny in https://github.com/revbayes/revbayes/pull/641
-* Add cosine function by @bredelings in https://github.com/revbayes/revbayes/pull/647
-* MPI checkpointing fix by @davidcerny in https://github.com/revbayes/revbayes/pull/646
-* Prevent loss of integer precision in MC^3 by @davidcerny in https://github.com/revbayes/revbayes/pull/652
+* Display current stopping rule values when resuming from a checkpoint by @davidcerny in https://github.com/revbayes/revbayes/pull/739
 * Improvements to stopping rule messages by @davidcerny in https://github.com/revbayes/revbayes/pull/657
-* Use different seeds for replicates in MPI run by @bjoelle in https://github.com/revbayes/revbayes/pull/662
+* Better documentation and progress monitoring for power posterior analyses by @davidcerny in https://github.com/revbayes/revbayes/pull/673
+
+* Add an `nruns` argument to `readTrace()` by @davidcerny in https://github.com/revbayes/revbayes/pull/736
 * Prevent modification of clamped value by @ms609 in https://github.com/revbayes/revbayes/pull/600
-* Prevent NaN heats in MC^3 by @davidcerny in https://github.com/revbayes/revbayes/pull/661
+* Random resolution of multifurcations and MBL time-scaling by @davidcerny in https://github.com/revbayes/revbayes/pull/641
+
 * Dev hoehna lab by @hoehna in https://github.com/revbayes/revbayes/pull/682
 * Additional coalescent development by @hoehna in https://github.com/revbayes/revbayes/pull/473
-* Don't treat deterministic nodes as constants by @bredelings in https://github.com/revbayes/revbayes/pull/678
-* Use std::shared_ptr<Environment> to hold Environments. by @bredelings in https://github.com/revbayes/revbayes/pull/687
-* Fix state space when subsetting by state space by @hoehna in https://github.com/revbayes/revbayes/pull/696
-* Better documentation and progress monitoring for power posterior analyses by @davidcerny in https://github.com/revbayes/revbayes/pull/673
+
 * Added sine function by @sigibrock in https://github.com/revbayes/revbayes/pull/648
-* Fix mvRateAgeBetaShift by @bredelings in https://github.com/revbayes/revbayes/pull/688
-* Fix windows long by @bredelings in https://github.com/revbayes/revbayes/pull/708
-* BUG #668 dnUniformTopology ignores neg clade const by @Levi-Raskin in https://github.com/revbayes/revbayes/pull/711
-* Fix out of range proposal by @bredelings in https://github.com/revbayes/revbayes/pull/709
-* Fix deterministic index by @bredelings in https://github.com/revbayes/revbayes/pull/719
-* Only type-convert variables based on value if they are constant by @bredelings in https://github.com/revbayes/revbayes/pull/721
+* Add cosine function by @bredelings in https://github.com/revbayes/revbayes/pull/647
+
+
+## Fixes
+* MPI checkpointing fix by @davidcerny in https://github.com/revbayes/revbayes/pull/646
+* Prevent loss of integer precision in MC^3 by @davidcerny in https://github.com/revbayes/revbayes/pull/652
+* Use different seeds for replicates in MPI run by @bjoelle in https://github.com/revbayes/revbayes/pull/662
+* Prevent NaN heats in MC^3 by @davidcerny in https://github.com/revbayes/revbayes/pull/661
 * Fix logging when running Mcmcmc twice. by @bredelings in https://github.com/revbayes/revbayes/pull/727
 * MC^3 checkpointing fix by @davidcerny in https://github.com/revbayes/revbayes/pull/670
-* Fix `readTrees(text = ...)` by @davidcerny in https://github.com/revbayes/revbayes/pull/735
-* Add an `nruns` argument to `readTrace()` by @davidcerny in https://github.com/revbayes/revbayes/pull/736
+
+* Don't treat deterministic nodes as constants by @bredelings in https://github.com/revbayes/revbayes/pull/678
+* Only type-convert variables based on value if they are constant by @bredelings in https://github.com/revbayes/revbayes/pull/721
+* Fix out of range proposal by @bredelings in https://github.com/revbayes/revbayes/pull/709
+* Fix deterministic index by @bredelings in https://github.com/revbayes/revbayes/pull/719
+
+* Fix mvRateAgeBetaShift by @bredelings in https://github.com/revbayes/revbayes/pull/688
 * Fix caching bugs in phyloCTMC by @bredelings in https://github.com/revbayes/revbayes/pull/729
 * Allow MCMC moves with low prob ratio and high Jacobian/Hastings ratio by @bredelings in https://github.com/revbayes/revbayes/pull/728
-* Display current stopping rule values when resuming from a checkpoint by @davidcerny in https://github.com/revbayes/revbayes/pull/739
+
+* Fix state space when subsetting by state space by @hoehna in https://github.com/revbayes/revbayes/pull/696
+* BUG #668 dnUniformTopology ignores neg clade const by @Levi-Raskin in https://github.com/revbayes/revbayes/pull/711
+* Fix `readTrees(text = ...)` by @davidcerny in https://github.com/revbayes/revbayes/pull/735
+* simmap bugfix for when some characters are excluded by @kopperud in https://github.com/revbayes/revbayes/pull/636
+* Fix `.dropTip()` behavior for multifurcations by @davidcerny in https://github.com/revbayes/revbayes/pull/640
+
+* Fix windows long by @bredelings in https://github.com/revbayes/revbayes/pull/708
+* Use std::shared_ptr<Environment> to hold Environments. by @bredelings in https://github.com/revbayes/revbayes/pull/687
 
 ## Documentation
 * Filled out help file for exp function. by @brpetrucci in https://github.com/revbayes/revbayes/pull/653

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,88 +1,98 @@
 # RevBayes 1.3.0 (unreleased)
-## What's Changed
-* Print convergence statistics during MCMC runs with stopping rules [#645](https://github.com/revbayes/revbayes/pull/645)
-* Display current stopping rule values when resuming from a checkpoint [#739](https://github.com/revbayes/revbayes/pull/739)
-* Improvements to stopping rule messages [#657](https://github.com/revbayes/revbayes/pull/657)
-* Better documentation and progress monitoring for power posterior analyses [#673](https://github.com/revbayes/revbayes/pull/673)
 
-* Add an `nruns` argument to `readTrace()` [#736](https://github.com/revbayes/revbayes/pull/736)
-* Prevent modification of clamped value [#600](https://github.com/revbayes/revbayes/pull/600)
-* Random resolution of multifurcations and MBL time-scaling [#641](https://github.com/revbayes/revbayes/pull/641)
+## Backwards-incompatible changes
+  * Change the name of the tuning argument of `mvUpDownSlide` from `lambda` to `delta`.
+  * Change the name of the first argument of `Tree.reroot( )` from `clade` to `outgroup`.
+  * In `powerPosterior( )`, specifying `ncats=N` sets up N analyses numbered 1--N, rather than N+1 analyses numbered 0--N.
 
-* Dev hoehna lab [#682](https://github.com/revbayes/revbayes/pull/682)
-* Additional coalescent development [#473](https://github.com/revbayes/revbayes/pull/473)
+## Features
+  * Interface
+      - Print convergence statistics during MCMC runs with stopping rules (#645, #657, #739).
+      - Better progress monitoring for power posterior analyses (#673).
+  * Methods / arguments
+      - Add member procedure for randomly resolving multifurcations (#641).
+      - Add an `nruns` argument to `readTrace( )` (#736).
+  * Functions
+      - Add function for minimum branch length time-scaling (#641).
+      - Add trigonometric functions (#647, #648).
 
-* Added sine function [#648](https://github.com/revbayes/revbayes/pull/648)
-* Add cosine function [#647](https://github.com/revbayes/revbayes/pull/647)
+## Bug fixes
+  * Checkpointing
+      - Fix segfault when attempting to resume an MPI analysis (#646).
+      - Fix mismatch of chain states and chain heats when resuming an MC^3 analysis (#670).
+      - Don't skip iterations when logging a resumed MC^3 analysis (#727).
+  * MPI / MC^3
+      - Fix NaN heats in MC^3 (#661).
+      - Make sure MPI runs the specified number of independent replicates (#662).
+  * Model graph
+      - Only convert deterministic nodes to constant nodes if they really are constant (#678).
+      - Fix crash in user functions (#687).
+      - Make sure indexing by a deterministic variable creates a deterministic node (#719).
+      - Only type-convert variables based on value if they are constant (#721).
+  * Moves
+      - Fix `mvRateAgeBetaShift` (#688).
+      - Allow moves to propose out-of-range indices (#709).
+      - Allow moves with low probability ratio and high Jacobian/Hastings ratio (#728).
+  * Member procedures
+      - Fix `.dropTip( )` behavior for multifurcations (#640).
+      - Fix `.getStateDescriptions( )` behavior when subsetting by state space (#696).
+      - Fix `.reroot( )` behavior when specifying an outgroup by its name string (#742).
+  * Misc
+      - Fix stochastic character mapping when there are excluded characters (#636).
+      - Fix handling of large integers on Windows (#708).
+      - Don't ignore negative clade constraints (#711).
+      - Fix partial likelihood caching in `dnPhyloCTMC` (#729).
+      - Allow reading multiple trees from a string (`readTrees(text = ...)`) (#735).
+  * Partial
+      - Prevent some instances of clamped values from being modified (#600).
 
-
-## Fixes
-* MPI checkpointing fix [#646](https://github.com/revbayes/revbayes/pull/646)
-* Prevent loss of integer precision in MC^3 [#652](https://github.com/revbayes/revbayes/pull/652)
-* Use different seeds for replicates in MPI run [#662](https://github.com/revbayes/revbayes/pull/662)
-* Prevent NaN heats in MC^3 [#661](https://github.com/revbayes/revbayes/pull/661)
-* Fix logging when running Mcmcmc twice. [#727](https://github.com/revbayes/revbayes/pull/727)
-* MC^3 checkpointing fix [#670](https://github.com/revbayes/revbayes/pull/670)
-
-* Only convert deterministic nodes to constant nodes if they really are constant [#678](https://github.com/revbayes/revbayes/pull/678)
-* Only type-convert variables based on value if they are constant [#721](https://github.com/revbayes/revbayes/pull/721)
-* Allow MCMC proposals to propose out-of-range indices [#709](https://github.com/revbayes/revbayes/pull/709)
-* Indexing by a deterministic index should create a deterministic node [#719](https://github.com/revbayes/revbayes/pull/719)
-
-* Fix mvRateAgeBetaShift [#688](https://github.com/revbayes/revbayes/pull/688)
-* Fix caching bugs in phyloCTMC [#729](https://github.com/revbayes/revbayes/pull/729)
-* Allow MCMC moves with low prob ratio and high Jacobian/Hastings ratio [#728](https://github.com/revbayes/revbayes/pull/728)
-
-* Fix state space when subsetting by state space [#696](https://github.com/revbayes/revbayes/pull/696)
-* Don't ignore negative clade const [#711](https://github.com/revbayes/revbayes/pull/711)
-* Fix `readTrees(text = ...)` [#735](https://github.com/revbayes/revbayes/pull/735)
-* Fix simmap when there are excluded characters [#636](https://github.com/revbayes/revbayes/pull/636)
-* Fix `.dropTip()` behavior for multifurcations [#640](https://github.com/revbayes/revbayes/pull/640)
-* Fix handling of large integers on windows [#708](https://github.com/revbayes/revbayes/pull/708)
-* Fix crash in user functions [#687](https://github.com/revbayes/revbayes/pull/687)
-
-## Documentation
-* Filled out help file for exp function. [#653]([#653](https://github.com/revbayes/revbayes/pull/653))
-* Document simplex moves [#606]([#606](https://github.com/revbayes/revbayes/pull/606))
-* Changes to rate matrix model help files [#656](https://github.com/revbayes/revbayes/pull/656)
-* Completing and standardizing stats distributions help files, part 1 [#663](https://github.com/revbayes/revbayes/pull/663)
-* Document DPP moves [#666](https://github.com/revbayes/revbayes/pull/666)
-* add help for jukes cantor [#649](https://github.com/revbayes/revbayes/pull/649)
-* Created matrix.md and var.md files for review [#681](https://github.com/revbayes/revbayes/pull/681)
-* Added function covarion documentation [#704](https://github.com/revbayes/revbayes/pull/704)
-* Adding documentation to 'fnDiscretizeDistribution' and 'fnDiscretizeG… [#707](https://github.com/revbayes/revbayes/pull/707)
-* updated fnFreeBinary help file [#706](https://github.com/revbayes/revbayes/pull/706)
-* Wrote help files for power and write function [#690](https://github.com/revbayes/revbayes/pull/690)
-* vectorFlatten.md fnFreeK.md, fnReadVCF.md, dnUniformInteger.md help files [#667](https://github.com/revbayes/revbayes/pull/667)
-* Updating documentation for readTreeTrace [#703](https://github.com/revbayes/revbayes/pull/703)
-* Editing WAG help file  [#655](https://github.com/revbayes/revbayes/pull/655)
-* Update readTrace.md [#702](https://github.com/revbayes/revbayes/pull/702)
-* Document TreeTrace methods [#722](https://github.com/revbayes/revbayes/pull/722)
-* Document readTrace methods [#723](https://github.com/revbayes/revbayes/pull/723)
+## Documentation improvements
+  * Document simplex moves [#606](https://github.com/revbayes/revbayes/pull/606))
+  * Add help for jukes cantor [#649](https://github.com/revbayes/revbayes/pull/649)
+  * Fill out help file for exp function [#653](https://github.com/revbayes/revbayes/pull/653))
+  * Edit WAG help file  [#655](https://github.com/revbayes/revbayes/pull/655)
+  * Change rate matrix model help files [#656](https://github.com/revbayes/revbayes/pull/656)
+  * Complete and standardize stats distributions help files, part 1 [#663](https://github.com/revbayes/revbayes/pull/663)
+  * Document DPP moves [#666](https://github.com/revbayes/revbayes/pull/666)
+  * vectorFlatten.md fnFreeK.md, fnReadVCF.md, dnUniformInteger.md help files [#667](https://github.com/revbayes/revbayes/pull/667)
+  * Create matrix.md and var.md files for review [#681](https://github.com/revbayes/revbayes/pull/681)
+  * More move help files [#683](https://github.com/revbayes/revbayes/pull/683)
+  * Write help files for power and write function [#690](https://github.com/revbayes/revbayes/pull/690)
+  * Update readTrace.md [#702](https://github.com/revbayes/revbayes/pull/702)
+  * Update documentation for readTreeTrace [#703](https://github.com/revbayes/revbayes/pull/703)
+  * Add function covarion documentation [#704](https://github.com/revbayes/revbayes/pull/704)
+  * Update fnFreeBinary help file [#706](https://github.com/revbayes/revbayes/pull/706)
+  * Add documentation to 'fnDiscretizeDistribution' and 'fnDiscretizeG… [#707](https://github.com/revbayes/revbayes/pull/707)
+  * Document TreeTrace methods [#722](https://github.com/revbayes/revbayes/pull/722)
+  * Document readTrace methods [#723](https://github.com/revbayes/revbayes/pull/723)
 
 ## Infrastructure
-* Fix CI builds by dropping openlibm [#644](https://github.com/revbayes/revbayes/pull/644)
-* Changes to build files to streamline help infrastructure [#659](https://github.com/revbayes/revbayes/pull/659)
-* Revamped tutorial testing [#674](https://github.com/revbayes/revbayes/pull/674)
-* Ensuring integration tests can run tutorial checkpoint tests [#676](https://github.com/revbayes/revbayes/pull/676)
-* Changed website submodule to pull from source rather than master. [#692](https://github.com/revbayes/revbayes/pull/692)
+  * Update validation tests [#473](https://github.com/revbayes/revbayes/pull/473)
+  * Fix CI builds by dropping openlibm [#644](https://github.com/revbayes/revbayes/pull/644)
+  * Changes to build files to streamline help infrastructure [#659](https://github.com/revbayes/revbayes/pull/659)
+  * Revamped tutorial testing [#674](https://github.com/revbayes/revbayes/pull/674)
+  * Ensuring integration tests can run tutorial checkpoint tests [#676](https://github.com/revbayes/revbayes/pull/676)
+  * Add integration tests for revised coalescent classes [#689](https://github.com/revbayes/revbayes/pull/689)
+  * Changed website submodule to pull from source rather than master. [#692](https://github.com/revbayes/revbayes/pull/692)
 
 ## Ignore
-* Bump version after v1.2.5 release [#637](https://github.com/revbayes/revbayes/pull/637)
-* Revert accidentally committed-by-unreview patch [#654](https://github.com/revbayes/revbayes/pull/654)
-* Remove empty touch( ), keep( ), and  restore( ) specializations. [#658](https://github.com/revbayes/revbayes/pull/658)
-* Update nlohmann::json to avoid tons of compilation warnings with GCC 15. [#685](https://github.com/revbayes/revbayes/pull/685)
-* Fix broken overrides part1 [#684](https://github.com/revbayes/revbayes/pull/684)
-* Mark overridden virtual functions as such in tree event moves [#669](https://github.com/revbayes/revbayes/pull/669)
-* Don't throw exception to perform a simple check. [#677](https://github.com/revbayes/revbayes/pull/677)
+  * Bump version after v1.2.5 release [#637](https://github.com/revbayes/revbayes/pull/637)
+  * Prevent loss of integer precision in MC^3 [#652](https://github.com/revbayes/revbayes/pull/652)
+  * Revert accidentally committed-by-unreview patch [#654](https://github.com/revbayes/revbayes/pull/654)
+  * Remove empty touch( ), keep( ), and  restore( ) specializations. [#658](https://github.com/revbayes/revbayes/pull/658)
+  * Mark overridden virtual functions as such in tree event moves [#669](https://github.com/revbayes/revbayes/pull/669)
+  * Don't throw exception to perform a simple check. [#677](https://github.com/revbayes/revbayes/pull/677)
+  * Dev hoehna lab [#682](https://github.com/revbayes/revbayes/pull/682)
+  * Fix broken overrides part1 [#684](https://github.com/revbayes/revbayes/pull/684)
+  * Update nlohmann::json to avoid tons of compilation warnings with GCC 15. [#685](https://github.com/revbayes/revbayes/pull/685)
 
 ## New Contributors
-* @raymondcast18 made their first contribution in [#649](https://github.com/revbayes/revbayes/pull/649)
-* @sigibrock made their first contribution in [#648](https://github.com/revbayes/revbayes/pull/648)
-* @basanta33 made their first contribution in [#704](https://github.com/revbayes/revbayes/pull/704)
-* @ixchelgzlzr made their first contribution in [#703](https://github.com/revbayes/revbayes/pull/703)
-* @Levi-Raskin made their first contribution in [#711](https://github.com/revbayes/revbayes/pull/711)
-* @PhyloevoTi made their first contribution in [#655](https://github.com/revbayes/revbayes/pull/655)
+  * @sigibrock made their first contribution in [#648](https://github.com/revbayes/revbayes/pull/648)
+  * @raymondcast18 made their first contribution in [#649](https://github.com/revbayes/revbayes/pull/649)
+  * @PhyloevoTi made their first contribution in [#655](https://github.com/revbayes/revbayes/pull/655)
+  * @ixchelgzlzr made their first contribution in [#703](https://github.com/revbayes/revbayes/pull/703)
+  * @basanta33 made their first contribution in [#704](https://github.com/revbayes/revbayes/pull/704)
+  * @Levi-Raskin made their first contribution in [#711](https://github.com/revbayes/revbayes/pull/711)
 
 # RevBayes 1.2.5 (Dec 19, 2025)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,89 +1,88 @@
 # RevBayes 1.3.0 (unreleased)
 ## What's Changed
-* Print convergence statistics during MCMC runs with stopping rules by @davidcerny in https://github.com/revbayes/revbayes/pull/645
-* Display current stopping rule values when resuming from a checkpoint by @davidcerny in https://github.com/revbayes/revbayes/pull/739
-* Improvements to stopping rule messages by @davidcerny in https://github.com/revbayes/revbayes/pull/657
-* Better documentation and progress monitoring for power posterior analyses by @davidcerny in https://github.com/revbayes/revbayes/pull/673
+* Print convergence statistics during MCMC runs with stopping rules [#645](https://github.com/revbayes/revbayes/pull/645)
+* Display current stopping rule values when resuming from a checkpoint [#739](https://github.com/revbayes/revbayes/pull/739)
+* Improvements to stopping rule messages [#657](https://github.com/revbayes/revbayes/pull/657)
+* Better documentation and progress monitoring for power posterior analyses [#673](https://github.com/revbayes/revbayes/pull/673)
 
-* Add an `nruns` argument to `readTrace()` by @davidcerny in https://github.com/revbayes/revbayes/pull/736
-* Prevent modification of clamped value by @ms609 in https://github.com/revbayes/revbayes/pull/600
-* Random resolution of multifurcations and MBL time-scaling by @davidcerny in https://github.com/revbayes/revbayes/pull/641
+* Add an `nruns` argument to `readTrace()` [#736](https://github.com/revbayes/revbayes/pull/736)
+* Prevent modification of clamped value [#600](https://github.com/revbayes/revbayes/pull/600)
+* Random resolution of multifurcations and MBL time-scaling [#641](https://github.com/revbayes/revbayes/pull/641)
 
-* Dev hoehna lab by @hoehna in https://github.com/revbayes/revbayes/pull/682
-* Additional coalescent development by @hoehna in https://github.com/revbayes/revbayes/pull/473
+* Dev hoehna lab [#682](https://github.com/revbayes/revbayes/pull/682)
+* Additional coalescent development [#473](https://github.com/revbayes/revbayes/pull/473)
 
-* Added sine function by @sigibrock in https://github.com/revbayes/revbayes/pull/648
-* Add cosine function by @bredelings in https://github.com/revbayes/revbayes/pull/647
+* Added sine function [#648](https://github.com/revbayes/revbayes/pull/648)
+* Add cosine function [#647](https://github.com/revbayes/revbayes/pull/647)
 
 
 ## Fixes
-* MPI checkpointing fix by @davidcerny in https://github.com/revbayes/revbayes/pull/646
-* Prevent loss of integer precision in MC^3 by @davidcerny in https://github.com/revbayes/revbayes/pull/652
-* Use different seeds for replicates in MPI run by @bjoelle in https://github.com/revbayes/revbayes/pull/662
-* Prevent NaN heats in MC^3 by @davidcerny in https://github.com/revbayes/revbayes/pull/661
-* Fix logging when running Mcmcmc twice. by @bredelings in https://github.com/revbayes/revbayes/pull/727
-* MC^3 checkpointing fix by @davidcerny in https://github.com/revbayes/revbayes/pull/670
+* MPI checkpointing fix [#646](https://github.com/revbayes/revbayes/pull/646)
+* Prevent loss of integer precision in MC^3 [#652](https://github.com/revbayes/revbayes/pull/652)
+* Use different seeds for replicates in MPI run [#662](https://github.com/revbayes/revbayes/pull/662)
+* Prevent NaN heats in MC^3 [#661](https://github.com/revbayes/revbayes/pull/661)
+* Fix logging when running Mcmcmc twice. [#727](https://github.com/revbayes/revbayes/pull/727)
+* MC^3 checkpointing fix [#670](https://github.com/revbayes/revbayes/pull/670)
 
-* Don't treat deterministic nodes as constants by @bredelings in https://github.com/revbayes/revbayes/pull/678
-* Only type-convert variables based on value if they are constant by @bredelings in https://github.com/revbayes/revbayes/pull/721
-* Fix out of range proposal by @bredelings in https://github.com/revbayes/revbayes/pull/709
-* Fix deterministic index by @bredelings in https://github.com/revbayes/revbayes/pull/719
+* Only convert deterministic nodes to constant nodes if they really are constant [#678](https://github.com/revbayes/revbayes/pull/678)
+* Only type-convert variables based on value if they are constant [#721](https://github.com/revbayes/revbayes/pull/721)
+* Allow MCMC proposals to propose out-of-range indices [#709](https://github.com/revbayes/revbayes/pull/709)
+* Indexing by a deterministic index should create a deterministic node [#719](https://github.com/revbayes/revbayes/pull/719)
 
-* Fix mvRateAgeBetaShift by @bredelings in https://github.com/revbayes/revbayes/pull/688
-* Fix caching bugs in phyloCTMC by @bredelings in https://github.com/revbayes/revbayes/pull/729
-* Allow MCMC moves with low prob ratio and high Jacobian/Hastings ratio by @bredelings in https://github.com/revbayes/revbayes/pull/728
+* Fix mvRateAgeBetaShift [#688](https://github.com/revbayes/revbayes/pull/688)
+* Fix caching bugs in phyloCTMC [#729](https://github.com/revbayes/revbayes/pull/729)
+* Allow MCMC moves with low prob ratio and high Jacobian/Hastings ratio [#728](https://github.com/revbayes/revbayes/pull/728)
 
-* Fix state space when subsetting by state space by @hoehna in https://github.com/revbayes/revbayes/pull/696
-* BUG #668 dnUniformTopology ignores neg clade const by @Levi-Raskin in https://github.com/revbayes/revbayes/pull/711
-* Fix `readTrees(text = ...)` by @davidcerny in https://github.com/revbayes/revbayes/pull/735
-* simmap bugfix for when some characters are excluded by @kopperud in https://github.com/revbayes/revbayes/pull/636
-* Fix `.dropTip()` behavior for multifurcations by @davidcerny in https://github.com/revbayes/revbayes/pull/640
-
-* Fix windows long by @bredelings in https://github.com/revbayes/revbayes/pull/708
-* Use std::shared_ptr<Environment> to hold Environments. by @bredelings in https://github.com/revbayes/revbayes/pull/687
+* Fix state space when subsetting by state space [#696](https://github.com/revbayes/revbayes/pull/696)
+* Don't ignore negative clade const [#711](https://github.com/revbayes/revbayes/pull/711)
+* Fix `readTrees(text = ...)` [#735](https://github.com/revbayes/revbayes/pull/735)
+* Fix simmap when there are excluded characters [#636](https://github.com/revbayes/revbayes/pull/636)
+* Fix `.dropTip()` behavior for multifurcations [#640](https://github.com/revbayes/revbayes/pull/640)
+* Fix handling of large integers on windows [#708](https://github.com/revbayes/revbayes/pull/708)
+* Fix crash in user functions [#687](https://github.com/revbayes/revbayes/pull/687)
 
 ## Documentation
-* Filled out help file for exp function. by @brpetrucci in https://github.com/revbayes/revbayes/pull/653
-* Document simplex moves by @ms609 in https://github.com/revbayes/revbayes/pull/606
-* Changes to rate matrix model help files by @brpetrucci in https://github.com/revbayes/revbayes/pull/656
-* Completing and standardizing stats distributions help files, part 1 by @brpetrucci in https://github.com/revbayes/revbayes/pull/663
-* Document DPP moves by @davidcerny in https://github.com/revbayes/revbayes/pull/666
-* add help for jukes cantor by @raymondcast18 in https://github.com/revbayes/revbayes/pull/649
-* Created matrix.md and var.md files for review by @raymondcast18 in https://github.com/revbayes/revbayes/pull/681
-* Added function covarion documentation by @basanta33 in https://github.com/revbayes/revbayes/pull/704
-* Adding documentation to 'fnDiscretizeDistribution' and 'fnDiscretizeG… by @basanta33 in https://github.com/revbayes/revbayes/pull/707
-* updated fnFreeBinary help file by @sigibrock in https://github.com/revbayes/revbayes/pull/706
-* Wrote help files for power and write function by @raymondcast18 in https://github.com/revbayes/revbayes/pull/690
-* vectorFlatten.md fnFreeK.md, fnReadVCF.md, dnUniformInteger.md help files by @raymondcast18 in https://github.com/revbayes/revbayes/pull/667
-* Updating documentation for readTreeTrace by @ixchelgzlzr in https://github.com/revbayes/revbayes/pull/703
-* Editing WAG help file  by @PhyloevoTi in https://github.com/revbayes/revbayes/pull/655
-* Update readTrace.md by @bredelings in https://github.com/revbayes/revbayes/pull/702
-* Document TreeTrace methods by @ms609 in https://github.com/revbayes/revbayes/pull/722
-* Document readTrace methods by @ms609 in https://github.com/revbayes/revbayes/pull/723
+* Filled out help file for exp function. [#653]([#653](https://github.com/revbayes/revbayes/pull/653))
+* Document simplex moves [#606]([#606](https://github.com/revbayes/revbayes/pull/606))
+* Changes to rate matrix model help files [#656](https://github.com/revbayes/revbayes/pull/656)
+* Completing and standardizing stats distributions help files, part 1 [#663](https://github.com/revbayes/revbayes/pull/663)
+* Document DPP moves [#666](https://github.com/revbayes/revbayes/pull/666)
+* add help for jukes cantor [#649](https://github.com/revbayes/revbayes/pull/649)
+* Created matrix.md and var.md files for review [#681](https://github.com/revbayes/revbayes/pull/681)
+* Added function covarion documentation [#704](https://github.com/revbayes/revbayes/pull/704)
+* Adding documentation to 'fnDiscretizeDistribution' and 'fnDiscretizeG… [#707](https://github.com/revbayes/revbayes/pull/707)
+* updated fnFreeBinary help file [#706](https://github.com/revbayes/revbayes/pull/706)
+* Wrote help files for power and write function [#690](https://github.com/revbayes/revbayes/pull/690)
+* vectorFlatten.md fnFreeK.md, fnReadVCF.md, dnUniformInteger.md help files [#667](https://github.com/revbayes/revbayes/pull/667)
+* Updating documentation for readTreeTrace [#703](https://github.com/revbayes/revbayes/pull/703)
+* Editing WAG help file  [#655](https://github.com/revbayes/revbayes/pull/655)
+* Update readTrace.md [#702](https://github.com/revbayes/revbayes/pull/702)
+* Document TreeTrace methods [#722](https://github.com/revbayes/revbayes/pull/722)
+* Document readTrace methods [#723](https://github.com/revbayes/revbayes/pull/723)
 
 ## Infrastructure
-* Fix CI builds by dropping openlibm by @bredelings in https://github.com/revbayes/revbayes/pull/644
-* Changes to build files to streamline help infrastructure by @brpetrucci in https://github.com/revbayes/revbayes/pull/659
-* Revamped tutorial testing by @brpetrucci in https://github.com/revbayes/revbayes/pull/674
-* Ensuring integration tests can run tutorial checkpoint tests by @brpetrucci in https://github.com/revbayes/revbayes/pull/676
-* Changed website submodule to pull from source rather than master. by @brpetrucci in https://github.com/revbayes/revbayes/pull/692
+* Fix CI builds by dropping openlibm [#644](https://github.com/revbayes/revbayes/pull/644)
+* Changes to build files to streamline help infrastructure [#659](https://github.com/revbayes/revbayes/pull/659)
+* Revamped tutorial testing [#674](https://github.com/revbayes/revbayes/pull/674)
+* Ensuring integration tests can run tutorial checkpoint tests [#676](https://github.com/revbayes/revbayes/pull/676)
+* Changed website submodule to pull from source rather than master. [#692](https://github.com/revbayes/revbayes/pull/692)
 
 ## Ignore
-* Bump version after v1.2.5 release by @bredelings in https://github.com/revbayes/revbayes/pull/637
-* Revert accidentally committed-by-unreview patch by @bredelings in https://github.com/revbayes/revbayes/pull/654
-* Remove empty touch( ), keep( ), and  restore( ) specializations. by @bredelings in https://github.com/revbayes/revbayes/pull/658
-* Update nlohmann::json to avoid tons of compilation warnings with GCC 15. by @bredelings in https://github.com/revbayes/revbayes/pull/685
-* Fix broken overrides part1 by @bredelings in https://github.com/revbayes/revbayes/pull/684
-* Mark overridden virtual functions as such in tree event moves by @davidcerny in https://github.com/revbayes/revbayes/pull/669
-* Don't throw exception to perform a simple check. by @bredelings in https://github.com/revbayes/revbayes/pull/677
+* Bump version after v1.2.5 release [#637](https://github.com/revbayes/revbayes/pull/637)
+* Revert accidentally committed-by-unreview patch [#654](https://github.com/revbayes/revbayes/pull/654)
+* Remove empty touch( ), keep( ), and  restore( ) specializations. [#658](https://github.com/revbayes/revbayes/pull/658)
+* Update nlohmann::json to avoid tons of compilation warnings with GCC 15. [#685](https://github.com/revbayes/revbayes/pull/685)
+* Fix broken overrides part1 [#684](https://github.com/revbayes/revbayes/pull/684)
+* Mark overridden virtual functions as such in tree event moves [#669](https://github.com/revbayes/revbayes/pull/669)
+* Don't throw exception to perform a simple check. [#677](https://github.com/revbayes/revbayes/pull/677)
 
 ## New Contributors
-* @raymondcast18 made their first contribution in https://github.com/revbayes/revbayes/pull/649
-* @sigibrock made their first contribution in https://github.com/revbayes/revbayes/pull/648
-* @basanta33 made their first contribution in https://github.com/revbayes/revbayes/pull/704
-* @ixchelgzlzr made their first contribution in https://github.com/revbayes/revbayes/pull/703
-* @Levi-Raskin made their first contribution in https://github.com/revbayes/revbayes/pull/711
-* @PhyloevoTi made their first contribution in https://github.com/revbayes/revbayes/pull/655
+* @raymondcast18 made their first contribution in [#649](https://github.com/revbayes/revbayes/pull/649)
+* @sigibrock made their first contribution in [#648](https://github.com/revbayes/revbayes/pull/648)
+* @basanta33 made their first contribution in [#704](https://github.com/revbayes/revbayes/pull/704)
+* @ixchelgzlzr made their first contribution in [#703](https://github.com/revbayes/revbayes/pull/703)
+* @Levi-Raskin made their first contribution in [#711](https://github.com/revbayes/revbayes/pull/711)
+* @PhyloevoTi made their first contribution in [#655](https://github.com/revbayes/revbayes/pull/655)
 
 # RevBayes 1.2.5 (Dec 19, 2025)
 
@@ -134,7 +133,7 @@
   * Misc
       - Allow reading non-square matrices (#564).
       - Allow checking `args.size()` when no arguments are given. (#479).
-      - Balance braces when printing Matrix<Real> (#615).
+      - Balance braces when printing `Matrix<Real>` (#615).
 
 ## Documentation improvements
   * `dnPhyloCTMC( )` (#487).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,58 +1,29 @@
 # RevBayes 1.3.0 (unreleased)
 ## What's Changed
 * simmap bugfix for when some characters are excluded by @kopperud in https://github.com/revbayes/revbayes/pull/636
-* Bump version after v1.2.5 release by @bredelings in https://github.com/revbayes/revbayes/pull/637
 * Fix `.dropTip()` behavior for multifurcations by @davidcerny in https://github.com/revbayes/revbayes/pull/640
-* Fix CI builds by dropping openlibm by @bredelings in https://github.com/revbayes/revbayes/pull/644
 * Print convergence statistics during MCMC runs with stopping rules by @davidcerny in https://github.com/revbayes/revbayes/pull/645
 * Random resolution of multifurcations and MBL time-scaling by @davidcerny in https://github.com/revbayes/revbayes/pull/641
 * Add cosine function by @bredelings in https://github.com/revbayes/revbayes/pull/647
 * MPI checkpointing fix by @davidcerny in https://github.com/revbayes/revbayes/pull/646
 * Prevent loss of integer precision in MC^3 by @davidcerny in https://github.com/revbayes/revbayes/pull/652
-* Filled out help file for exp function. by @brpetrucci in https://github.com/revbayes/revbayes/pull/653
-* Revert accidentally committed-by-unreview patch by @bredelings in https://github.com/revbayes/revbayes/pull/654
-* Document simplex moves by @ms609 in https://github.com/revbayes/revbayes/pull/606
-* Changes to rate matrix model help files by @brpetrucci in https://github.com/revbayes/revbayes/pull/656
-* Remove empty touch( ), keep( ), and  restore( ) specializations. by @bredelings in https://github.com/revbayes/revbayes/pull/658
-* Changes to build files to streamline help infrastructure by @brpetrucci in https://github.com/revbayes/revbayes/pull/659
 * Improvements to stopping rule messages by @davidcerny in https://github.com/revbayes/revbayes/pull/657
 * Use different seeds for replicates in MPI run by @bjoelle in https://github.com/revbayes/revbayes/pull/662
-* Completing and standardizing stats distributions help files, part 1 by @brpetrucci in https://github.com/revbayes/revbayes/pull/663
-* Document DPP moves by @davidcerny in https://github.com/revbayes/revbayes/pull/666
 * Prevent modification of clamped value by @ms609 in https://github.com/revbayes/revbayes/pull/600
 * Prevent NaN heats in MC^3 by @davidcerny in https://github.com/revbayes/revbayes/pull/661
-* add help for jukes cantor by @raymondcast18 in https://github.com/revbayes/revbayes/pull/649
-* Mark overridden virtual functions as such in tree event moves by @davidcerny in https://github.com/revbayes/revbayes/pull/669
-* Revamped tutorial testing by @brpetrucci in https://github.com/revbayes/revbayes/pull/674
-* Ensuring integration tests can run tutorial checkpoint tests by @brpetrucci in https://github.com/revbayes/revbayes/pull/676
 * Dev hoehna lab by @hoehna in https://github.com/revbayes/revbayes/pull/682
 * Additional coalescent development by @hoehna in https://github.com/revbayes/revbayes/pull/473
-* Update nlohmann::json to avoid tons of compilation warnings with GCC 15. by @bredelings in https://github.com/revbayes/revbayes/pull/685
-* Don't throw exception to perform a simple check. by @bredelings in https://github.com/revbayes/revbayes/pull/677
-* Fix broken overrides part1 by @bredelings in https://github.com/revbayes/revbayes/pull/684
-* Created matrix.md and var.md files for review by @raymondcast18 in https://github.com/revbayes/revbayes/pull/681
 * Don't treat deterministic nodes as constants by @bredelings in https://github.com/revbayes/revbayes/pull/678
 * Use std::shared_ptr<Environment> to hold Environments. by @bredelings in https://github.com/revbayes/revbayes/pull/687
 * Fix state space when subsetting by state space by @hoehna in https://github.com/revbayes/revbayes/pull/696
 * Better documentation and progress monitoring for power posterior analyses by @davidcerny in https://github.com/revbayes/revbayes/pull/673
 * Added sine function by @sigibrock in https://github.com/revbayes/revbayes/pull/648
 * Fix mvRateAgeBetaShift by @bredelings in https://github.com/revbayes/revbayes/pull/688
-* Added function covarion documentation by @basanta33 in https://github.com/revbayes/revbayes/pull/704
-* Adding documentation to 'fnDiscretizeDistribution' and 'fnDiscretizeG… by @basanta33 in https://github.com/revbayes/revbayes/pull/707
-* updated fnFreeBinary help file by @sigibrock in https://github.com/revbayes/revbayes/pull/706
-* Wrote help files for power and write function by @raymondcast18 in https://github.com/revbayes/revbayes/pull/690
-* vectorFlatten.md fnFreeK.md, fnReadVCF.md, dnUniformInteger.md help files by @raymondcast18 in https://github.com/revbayes/revbayes/pull/667
-* Updating documentation for readTreeTrace by @ixchelgzlzr in https://github.com/revbayes/revbayes/pull/703
 * Fix windows long by @bredelings in https://github.com/revbayes/revbayes/pull/708
 * BUG #668 dnUniformTopology ignores neg clade const by @Levi-Raskin in https://github.com/revbayes/revbayes/pull/711
-* Changed website submodule to pull from source rather than master. by @brpetrucci in https://github.com/revbayes/revbayes/pull/692
-* Editing WAG help file  by @PhyloevoTi in https://github.com/revbayes/revbayes/pull/655
-* Update readTrace.md by @bredelings in https://github.com/revbayes/revbayes/pull/702
 * Fix out of range proposal by @bredelings in https://github.com/revbayes/revbayes/pull/709
 * Fix deterministic index by @bredelings in https://github.com/revbayes/revbayes/pull/719
-* Document TreeTrace methods by @ms609 in https://github.com/revbayes/revbayes/pull/722
 * Only type-convert variables based on value if they are constant by @bredelings in https://github.com/revbayes/revbayes/pull/721
-* Document readTrace methods by @ms609 in https://github.com/revbayes/revbayes/pull/723
 * Fix logging when running Mcmcmc twice. by @bredelings in https://github.com/revbayes/revbayes/pull/727
 * MC^3 checkpointing fix by @davidcerny in https://github.com/revbayes/revbayes/pull/670
 * Fix `readTrees(text = ...)` by @davidcerny in https://github.com/revbayes/revbayes/pull/735
@@ -60,6 +31,41 @@
 * Fix caching bugs in phyloCTMC by @bredelings in https://github.com/revbayes/revbayes/pull/729
 * Allow MCMC moves with low prob ratio and high Jacobian/Hastings ratio by @bredelings in https://github.com/revbayes/revbayes/pull/728
 * Display current stopping rule values when resuming from a checkpoint by @davidcerny in https://github.com/revbayes/revbayes/pull/739
+
+## Documentation
+* Filled out help file for exp function. by @brpetrucci in https://github.com/revbayes/revbayes/pull/653
+* Document simplex moves by @ms609 in https://github.com/revbayes/revbayes/pull/606
+* Changes to rate matrix model help files by @brpetrucci in https://github.com/revbayes/revbayes/pull/656
+* Completing and standardizing stats distributions help files, part 1 by @brpetrucci in https://github.com/revbayes/revbayes/pull/663
+* Document DPP moves by @davidcerny in https://github.com/revbayes/revbayes/pull/666
+* add help for jukes cantor by @raymondcast18 in https://github.com/revbayes/revbayes/pull/649
+* Created matrix.md and var.md files for review by @raymondcast18 in https://github.com/revbayes/revbayes/pull/681
+* Added function covarion documentation by @basanta33 in https://github.com/revbayes/revbayes/pull/704
+* Adding documentation to 'fnDiscretizeDistribution' and 'fnDiscretizeG… by @basanta33 in https://github.com/revbayes/revbayes/pull/707
+* updated fnFreeBinary help file by @sigibrock in https://github.com/revbayes/revbayes/pull/706
+* Wrote help files for power and write function by @raymondcast18 in https://github.com/revbayes/revbayes/pull/690
+* vectorFlatten.md fnFreeK.md, fnReadVCF.md, dnUniformInteger.md help files by @raymondcast18 in https://github.com/revbayes/revbayes/pull/667
+* Updating documentation for readTreeTrace by @ixchelgzlzr in https://github.com/revbayes/revbayes/pull/703
+* Editing WAG help file  by @PhyloevoTi in https://github.com/revbayes/revbayes/pull/655
+* Update readTrace.md by @bredelings in https://github.com/revbayes/revbayes/pull/702
+* Document TreeTrace methods by @ms609 in https://github.com/revbayes/revbayes/pull/722
+* Document readTrace methods by @ms609 in https://github.com/revbayes/revbayes/pull/723
+
+## Infrastructure
+* Fix CI builds by dropping openlibm by @bredelings in https://github.com/revbayes/revbayes/pull/644
+* Changes to build files to streamline help infrastructure by @brpetrucci in https://github.com/revbayes/revbayes/pull/659
+* Revamped tutorial testing by @brpetrucci in https://github.com/revbayes/revbayes/pull/674
+* Ensuring integration tests can run tutorial checkpoint tests by @brpetrucci in https://github.com/revbayes/revbayes/pull/676
+* Changed website submodule to pull from source rather than master. by @brpetrucci in https://github.com/revbayes/revbayes/pull/692
+
+## Ignore
+* Bump version after v1.2.5 release by @bredelings in https://github.com/revbayes/revbayes/pull/637
+* Revert accidentally committed-by-unreview patch by @bredelings in https://github.com/revbayes/revbayes/pull/654
+* Remove empty touch( ), keep( ), and  restore( ) specializations. by @bredelings in https://github.com/revbayes/revbayes/pull/658
+* Update nlohmann::json to avoid tons of compilation warnings with GCC 15. by @bredelings in https://github.com/revbayes/revbayes/pull/685
+* Fix broken overrides part1 by @bredelings in https://github.com/revbayes/revbayes/pull/684
+* Mark overridden virtual functions as such in tree event moves by @davidcerny in https://github.com/revbayes/revbayes/pull/669
+* Don't throw exception to perform a simple check. by @bredelings in https://github.com/revbayes/revbayes/pull/677
 
 ## New Contributors
 * @raymondcast18 made their first contribution in https://github.com/revbayes/revbayes/pull/649

--- a/NEWS.md
+++ b/NEWS.md
@@ -101,7 +101,7 @@
   * @basanta33 made their first contribution in [#704](https://github.com/revbayes/revbayes/pull/704)
   * @Levi-Raskin made their first contribution in [#711](https://github.com/revbayes/revbayes/pull/711)
 
-# RevBayes 1.2.5 (Dec 19, 2025)
+# RevBayes 1.2.5 (Dec 19, 2024)
 
 ## Backwards-incompatible changes
   * Remove `underPrior` argument to `mcmc.run( )` and `mcmcmc.run( )`.  You can use `model.ignoreAllData()` instead.
@@ -161,9 +161,9 @@
   * Clarify differences between `.clamp()` and `.setValue()` (#599).
   * Stopping and convergence rules (#488).
   * `mcmc` and `mcmcmc`
-    - `.run( )` (#485, #488).
-    - `.initializeFromCheckpoint( )` (#505).
-    - `moveschedule` parameter and the `weight` parameter of moves (#506).
+      - `.run( )` (#485, #488).
+      - `.initializeFromCheckpoint( )` (#505).
+      - `moveschedule` parameter and the `weight` parameter of moves (#506).
   * Corrections to `dnBivariatePoisson` (#539) and `mcmcmc` (#541).
 
 # RevBayes 1.2.4 (May 29, 2024)

--- a/NEWS.md
+++ b/NEWS.md
@@ -41,6 +41,7 @@
       - Fix stochastic character mapping when there are excluded characters (#636).
       - Fix handling of large integers on Windows (#708).
       - Don't ignore negative clade constraints (#711).
+      - Allow for machine uncertainty in `dnEpisodicBirthDeath` with empirical sampling (#713).
       - Fix partial likelihood caching in `dnPhyloCTMC` (#729).
       - Allow reading multiple trees from a string (`readTrees(text = ...)`) (#735).
   * Partial
@@ -74,32 +75,21 @@
   * Discretization functions: `fnDiscretizeDistribution`, `fnDiscretizeGamma` (#707).
 
 ## Infrastructure
-  * Update validation tests [#473](https://github.com/revbayes/revbayes/pull/473)
-  * Fix CI builds by dropping openlibm [#644](https://github.com/revbayes/revbayes/pull/644)
-  * Changes to build files to streamline help infrastructure [#659](https://github.com/revbayes/revbayes/pull/659)
-  * Revamped tutorial testing [#674](https://github.com/revbayes/revbayes/pull/674)
-  * Ensuring integration tests can run tutorial checkpoint tests [#676](https://github.com/revbayes/revbayes/pull/676)
-  * Add integration tests for revised coalescent classes [#689](https://github.com/revbayes/revbayes/pull/689)
-  * Changed website submodule to pull from source rather than master. [#692](https://github.com/revbayes/revbayes/pull/692)
+  * Update validation tests (#473).
+  * Fix continuous-integration builds by dropping openlibm (#644).
+  * Change build files to streamline updates to the help database (#659).
+  * Make tutorial tests more flexible (#674).
+  * Make sure the test runner can handle tutorial checkpoint tests (#676).
+  * Add integration tests for revised coalescent classes (#689).
+  * Change website submodule to pull from source rather than master (#692).
 
-## Ignore
-  * Bump version after v1.2.5 release [#637](https://github.com/revbayes/revbayes/pull/637)
-  * Prevent loss of integer precision in MC^3 [#652](https://github.com/revbayes/revbayes/pull/652)
-  * Revert accidentally committed-by-unreview patch [#654](https://github.com/revbayes/revbayes/pull/654)
-  * Remove empty touch( ), keep( ), and  restore( ) specializations. [#658](https://github.com/revbayes/revbayes/pull/658)
-  * Mark overridden virtual functions as such in tree event moves [#669](https://github.com/revbayes/revbayes/pull/669)
-  * Don't throw exception to perform a simple check. [#677](https://github.com/revbayes/revbayes/pull/677)
-  * Dev hoehna lab [#682](https://github.com/revbayes/revbayes/pull/682)
-  * Fix broken overrides part1 [#684](https://github.com/revbayes/revbayes/pull/684)
-  * Update nlohmann::json to avoid tons of compilation warnings with GCC 15. [#685](https://github.com/revbayes/revbayes/pull/685)
-
-## New Contributors
-  * @sigibrock made their first contribution in [#648](https://github.com/revbayes/revbayes/pull/648)
-  * @raymondcast18 made their first contribution in [#649](https://github.com/revbayes/revbayes/pull/649)
-  * @PhyloevoTi made their first contribution in [#655](https://github.com/revbayes/revbayes/pull/655)
-  * @ixchelgzlzr made their first contribution in [#703](https://github.com/revbayes/revbayes/pull/703)
-  * @basanta33 made their first contribution in [#704](https://github.com/revbayes/revbayes/pull/704)
-  * @Levi-Raskin made their first contribution in [#711](https://github.com/revbayes/revbayes/pull/711)
+## New contributors
+  * @sigibrock made their first contribution in #648.
+  * @raymondcast18 made their first contribution in #649.
+  * @PhyloevoTi made their first contribution in #655.
+  * @ixchelgzlzr made their first contribution in #703.
+  * @basanta33 made their first contribution in #704.
+  * @Levi-Raskin made their first contribution in #711.
 
 # RevBayes 1.2.5 (Dec 19, 2024)
 

--- a/meson.build
+++ b/meson.build
@@ -1,11 +1,11 @@
 project('RevBayes', ['cpp', 'c'],
-        version: '1.2.6-preview',
+        version: '1.3.0',
         default_options: [
           'buildtype=release',
           'cpp_std=c++17',
           'b_ndebug=if-release'
         ],
-        meson_version: '>= 0.57',
+        meson_version: '>= 1.0',
         license: 'GPLv2')
 
 cpp = meson.get_compiler('cpp')

--- a/src/revlanguage/utils/RbVersion.cpp
+++ b/src/revlanguage/utils/RbVersion.cpp
@@ -34,7 +34,7 @@ std::string RbVersion::getGitCommit( void ) const
 
 std::string RbVersion::getVersion( void ) const
 {
-    return "1.2.6-preview";
+    return "1.3.0";
 }
 
 


### PR DESCRIPTION
Here's a PR to bump the version numbers.
Before release, we need to:
- check that the release scripts work by making a tag like `test-3.0` and pushing it, and checking github actions jobs successfully generate the release artifacts.  Its possible to delete the tag afterwards.
- the NEWS file just contains the list of PRs and new contributors.  We need to summarize and organize this so that its helpful to end users.  Many PRs have a description that is understandable only to developers. Sometimes multiple PRs are needed to fix the same issue, and they should be combined.  And somethings are invisible to end users and should probably not be listed.  Probably we can put documentation PRs in their own category.