### PR TITLE
Pseudodata

### DIFF
--- a/src/core/datatypes/PseudoData.h
+++ b/src/core/datatypes/PseudoData.h
@@ -32,7 +32,7 @@ namespace RevBayesCore
     template <typename T>
     struct PseudoData: public Cloneable
     {
-        virtual double operator()(const T&) = 0;
+        virtual double operator()(const T&) const = 0;
         virtual ~PseudoData() {};
 
         PseudoData* clone() const = 0;
@@ -50,7 +50,7 @@ namespace RevBayesCore
     struct PseudoDataNothing: public PseudoData<T>
     {
         PseudoDataNothing* clone() const {return new PseudoDataNothing(*this);}
-        double operator()(const T&) {return 0;}
+        double operator()(const T&) const {return 0;}
     };
 
     // Whatever we observed, the data has decreasing probability outside [a,b]
@@ -59,7 +59,7 @@ namespace RevBayesCore
         double a;
         double b;
         double lambda;
-        double operator()(const double& x)
+        double operator()(const double& x) const
         {
             if (x > a and x < b)
                 return 0;

--- a/src/core/datatypes/PseudoData.h
+++ b/src/core/datatypes/PseudoData.h
@@ -30,49 +30,31 @@ namespace RevBayesCore
 {
 
     template <typename T>
-    struct PseudoData: public Cloneable
+    class PseudoData: public Cloneable
     {
-        virtual double operator()(const T&) const = 0;
-        virtual ~PseudoData() {};
+    public:
+        typedef std::function<double (const T&)> func_t;
 
-        PseudoData* clone() const = 0;
+    private:
+        func_t log_likelihood;
+
+    public:
+        PseudoData(const PseudoData<T>&) = default;
+        PseudoData(func_t f):log_likelihood(f) {}
+        PseudoData(): PseudoData( [](const T&) { return 0.0; }) {}
+
+        virtual ~PseudoData() override {};
+
+        PseudoData<T>* clone() const override { return new PseudoData<T>(*this);}
+
+        // Call this on the parameter to get the log-likelihood of the unspecified data.
+        double operator()(const T& x) const { return log_likelihood(x); }
 
         // ModelVector< > somehow requires this.
         bool operator==(const PseudoData&) const { return false; }
         bool operator!=(const PseudoData&) const { return true; }
         bool operator<(const PseudoData&) const { return false; }
         bool operator<=(const PseudoData&) const { return false; }
-    };
-
-
-    // We observed nothing.
-    template <typename T>
-    struct PseudoDataNothing: public PseudoData<T>
-    {
-        PseudoDataNothing* clone() const {return new PseudoDataNothing(*this);}
-        double operator()(const T&) const {return 0;}
-    };
-
-    // Whatever we observed, the data has decreasing probability outside [a,b]
-    struct PseudoDataInterval: public PseudoData<double>
-    {
-        double a;
-        double b;
-        double lambda;
-        double operator()(const double& x) const
-        {
-            if (x > a and x < b)
-                return 0;
-            else
-            {
-                double d = std::min(std::abs(x-a), std::abs(x-b));
-                return -lambda * d;
-            }
-        }
-
-        PseudoDataInterval* clone() const {return new PseudoDataInterval(*this);}
-
-        PseudoDataInterval(double A, double B, double L):a(A), b(B), lambda(L) {assert(lambda >= 0);}
     };
 
     // We need this for TypedDagNode<SiteMixtureModel> for some reason...

--- a/src/core/datatypes/PseudoData.h
+++ b/src/core/datatypes/PseudoData.h
@@ -1,0 +1,86 @@
+#ifndef PseudoData_H
+#define PseudoData_H
+
+#include <limits>
+#include <cassert>
+#include "Cloneable.h"
+
+
+/*
+ * The PseudoData object is used to handle situations where:
+ * - the data is unspecified
+ * - the distribution is unspecified
+ * - the likelihood function Pr(data|parameter) is specified as a function f(parameter).
+ *
+ * In RevBayes this would look like:
+ *
+ *   x ~ dnPseudo(parameter)
+ *   x.clamp(f)
+ *
+ * The likelihood Pr(x|parameter) is then specified to be f(parameter).
+ *
+ * This only makes sense if x is clamped, so if the user just writes:
+ *
+ *   x ~ dnPseudo(parameter)
+ *
+ * then we set x=E where E is the empty pseudodata.  Then Pr(x) = E(x) = 1.
+ */
+
+namespace RevBayesCore
+{
+
+    template <typename T>
+    struct PseudoData: public Cloneable
+    {
+        virtual double operator()(const T&) = 0;
+        virtual ~PseudoData() {};
+
+        PseudoData* clone() const = 0;
+
+        // ModelVector< > somehow requires this.
+        bool operator==(const PseudoData&) const { return false; }
+        bool operator!=(const PseudoData&) const { return true; }
+        bool operator<(const PseudoData&) const { return false; }
+        bool operator<=(const PseudoData&) const { return false; }
+    };
+
+
+    // We observed nothing.
+    template <typename T>
+    struct PseudoDataNothing: public PseudoData<T>
+    {
+        PseudoDataNothing* clone() const {return new PseudoDataNothing(*this);}
+        double operator()(const T&) {return 0;}
+    };
+
+    // Whatever we observed, the data has decreasing probability outside [a,b]
+    struct PseudoDataInterval: public PseudoData<double>
+    {
+        double a;
+        double b;
+        double lambda;
+        double operator()(const double& x)
+        {
+            if (x > a and x < b)
+                return 0;
+            else
+            {
+                double d = std::min(std::abs(x-a), std::abs(x-b));
+                return -lambda * d;
+            }
+        }
+
+        PseudoDataInterval* clone() const {return new PseudoDataInterval(*this);}
+
+        PseudoDataInterval(double A, double B, double L):a(A), b(B), lambda(L) {assert(lambda >= 0);}
+    };
+
+    // We need this for TypedDagNode<SiteMixtureModel> for some reason...
+    template <typename T>
+    std::ostream&                                       operator<<(std::ostream& o, const PseudoData<T>& x)
+    {
+        o<<"PseudoData<"<<typeid(T).name()<<">";
+        return o;
+    }}
+
+#endif

--- a/src/core/distributions/PseudoDist.h
+++ b/src/core/distributions/PseudoDist.h
@@ -25,12 +25,17 @@
 
 namespace RevBayesCore
 {
+    struct PseudoDistBase
+    {
+        virtual void setPseudoData(const DagNode*) = 0;
+    };
 
     template <typename T>
-    class PseudoDist : public TypedDistribution< PseudoData<T>>
+    class PseudoDist : public TypedDistribution< PseudoData<T>>, public PseudoDistBase
     {
         // the base distribution
         const TypedDagNode<T>*                              parameter = nullptr;
+        const TypedDagNode<PseudoData<T>>*                  pseudo_data = nullptr;
 
     protected:
         // Parameter management functions
@@ -39,6 +44,10 @@ namespace RevBayesCore
             if (oldP == parameter)
             {
                 this->parameter = static_cast<const TypedDagNode<T>*>(newP);
+            }
+            else if (oldP == pseudo_data)
+            {
+                this->pseudo_data = static_cast<const TypedDagNode<PseudoData<T>>*>(newP);
             }
         }
 
@@ -56,12 +65,32 @@ namespace RevBayesCore
 
         PseudoDist*                                         clone(void) const override {return new PseudoDist(*this);}
 
+        void setPseudoData(const DagNode* node) override
+        {
+            auto pd = dynamic_cast<const TypedDagNode<PseudoData<T>>*>(node);
+            if (not pd)
+                throw RbException()<<"setPseudoData: node isn't of type TypedDagNode<PseudoData<T>>!";
+
+            if (pseudo_data) this->removeParameter(pseudo_data);
+
+            pseudo_data = pd;
+            this->addParameter(pd);
+        }
+
         double                                              computeLnProbability(void) override
         {
-            // We return the likelihood Pr(unspecified data | x)
-            auto& pseudo_data = this->getValue();
-            auto& x = parameter->getValue();
-            return pseudo_data(x);
+            if (pseudo_data)
+            {
+                // We return the likelihood Pr(unspecified data | x)
+                auto& f = pseudo_data->getValue();
+                auto& x = parameter->getValue();
+                return f(x);
+            }
+            else
+            {
+                // Not yet clamped to pseudodata.
+                return 0.0;
+            }
         }
 
         void                                                redrawValue(void) override

--- a/src/core/distributions/PseudoDist.h
+++ b/src/core/distributions/PseudoDist.h
@@ -1,0 +1,82 @@
+#ifndef PseudoDist_H
+#define PseudoDist_H
+
+#include "PseudoData.h"
+
+/*
+ * This distribution handle situations where:
+ * - the data is unspecified
+ * - the distribution is unspecified
+ * - the likelihood function Pr(data|parameter) is specified as a function f(parameter).
+ *
+ * In RevBayes this would look like:
+ *
+ *   x ~ dnPseudo(parameter)
+ *   x.clamp(f)
+ *
+ * The likelihood Pr(x|parameter) is then specified to be f(parameter).
+ *
+ * This only makes sense if x is clamped, so if the user just writes:
+ *
+ *   x ~ dnPseudo(parameter)
+ *
+ * then we set x=E where E is the empty pseudodata.  Then Pr(x) = E(x) = 1.
+ */
+
+namespace RevBayesCore
+{
+
+    template <typename T>
+    class PseudoDist : public TypedDistribution< PseudoData<T>>
+    {
+        // the base distribution
+        const TypedDagNode<T>*                              parameter = nullptr;
+
+    protected:
+        // Parameter management functions
+        void                                                swapParameterInternal(const DagNode *oldP, const DagNode *newP) override
+        {
+            if (oldP == parameter)
+            {
+                this->parameter = static_cast<const TypedDagNode<T>*>(newP);
+            }
+        }
+
+    public:
+        PseudoDist(const TypedDagNode<T>* d)
+            :TypedDistribution<PseudoData<T>>(nullptr),
+             parameter(d)
+        {
+            this->addParameter(d);
+
+            redrawValue();
+        }
+
+        PseudoDist(const PseudoDist<T>& d) = default;
+
+        PseudoDist*                                         clone(void) const override {return new PseudoDist(*this);}
+
+        double                                              computeLnProbability(void) override
+        {
+            // We return the likelihood Pr(unspecified data | x)
+            auto& pseudo_data = this->getValue();
+            auto& x = parameter->getValue();
+            return pseudo_data(x);
+        }
+
+        void                                                redrawValue(void) override
+        {
+            delete this->value;
+
+            // Supply a PseudoData object with no observations, leading to Pr(unspecified data|parameter) = 1.
+            // This will be overridden only if the variable simulated from this distribution is clamped.
+            this->value = new PseudoDataNothing<T>();
+        }
+
+    };
+}
+
+
+
+
+#endif

--- a/src/core/distributions/PseudoDist.h
+++ b/src/core/distributions/PseudoDist.h
@@ -99,7 +99,7 @@ namespace RevBayesCore
 
             // Supply a PseudoData object with no observations, leading to Pr(unspecified data|parameter) = 1.
             // This will be overridden only if the variable simulated from this distribution is clamped.
-            this->value = new PseudoDataNothing<T>();
+            this->value = new PseudoData<T>();
         }
 
     };

--- a/src/revlanguage/dag/RlStochasticNode.h
+++ b/src/revlanguage/dag/RlStochasticNode.h
@@ -4,6 +4,7 @@
 #include "StochasticNode.h"
 #include "RevMemberObject.h"
 #include "RlDistribution.h"
+#include "PseudoDist.h"
 
 namespace RevLanguage {
     
@@ -177,6 +178,16 @@ RevLanguage::RevPtr<RevLanguage::RevVariable> RevLanguage::StochasticNode<valueT
         // we found the corresponding member method
         found = true;
         
+        // Handle the special case of clamping pseudoData objects, which
+        //   need to be set as parameters of the PseudoDist distribution.
+        if (auto pseudo_dist = dynamic_cast<RevBayesCore::PseudoDistBase*>(this->distribution))
+        {
+            if (auto pseudo_data = args[0].getVariable()->getRevObject().getDagNode())
+                pseudo_dist->setPseudoData(pseudo_data);
+            else
+                throw RbException()<<"clamp: no dag node, so no effect!";
+        }
+
         // get the observation
 //        const RevObject &tmp_obj = args[0].getVariable()->getRevObject();
 //        const ModelObject<valueType> *tmp_ptr = dynamic_cast<const ModelObject<valueType> *>( &tmp_obj );

--- a/src/revlanguage/datatypes/math/RlPseudoData.h
+++ b/src/revlanguage/datatypes/math/RlPseudoData.h
@@ -1,0 +1,58 @@
+#ifndef RlPseudoData_H
+#define RlPseudoData_H
+
+#include "ModelObject.h"
+#include "PseudoData.h"
+
+#include <iostream>
+#include <vector>
+
+namespace RevLanguage {
+
+    /**
+     * @brief PseudoData: specifying data in terms of information it gives about a parameter via a likelihood function.
+     */
+    template <typename rlType>
+    class PseudoData : public ModelObject<RevBayesCore::PseudoData<typename rlType::valueType> > {
+
+    public:
+        typedef typename RevBayesCore::PseudoData<typename rlType::valueType> valueType;
+
+        PseudoData() {}
+        PseudoData(const valueType& v): ModelObject<valueType>(v.clone()) {}
+        PseudoData(valueType* v): ModelObject<valueType>(v) {}
+        PseudoData(RevBayesCore::TypedDagNode<valueType>* n): ModelObject<valueType>(n) {}
+
+        PseudoData<rlType>*         clone(void) const override
+        {
+            return new PseudoData<rlType>(*this);
+        }
+
+        static const std::string&   getClassType()
+        {
+            static std::string rev_type = "PseudoData<" + rlType::getClassType() + ">";
+
+            return rev_type;
+        }
+
+        static const TypeSpec&      getClassTypeSpec(void)
+        {
+            static TypeSpec rev_type_spec = TypeSpec( getClassType(), &ModelObject<RevBayesCore::PseudoData<typename rlType::valueType> >::getClassTypeSpec(), &rlType::getClassTypeSpec() );
+
+            return rev_type_spec;
+        }
+
+        const TypeSpec&             getTypeSpec(void) const override
+        {
+            return getClassTypeSpec();
+        }
+
+
+        // Member object functions
+        std::string                 getGuiName(void) override { return "PseudoData"; }
+        std::string                 getGuiUnicodeSymbol(void) override { return "PseudoData"; }
+        std::string                 getGuiInfo(void) override { return ""; }
+    };
+}
+
+#endif

--- a/src/revlanguage/distributions/Dist_Pseudo.h
+++ b/src/revlanguage/distributions/Dist_Pseudo.h
@@ -1,0 +1,135 @@
+#ifndef Dist_PseudoData_h
+#define Dist_PseudoData_h
+
+#include "PseudoDist.h"
+#include "RlTypedDistribution.h"
+#include "RlPseudoData.h"
+
+namespace RevLanguage
+{
+
+    template <typename T>
+    class Dist_Pseudo: public TypedDistribution<PseudoData<T>>
+    {
+    public:
+        Dist_Pseudo() {}
+
+        Dist_Pseudo<T>* clone() const
+        {
+            return new Dist_Pseudo<T>(*this);
+        }
+
+        //!< Get Rev type
+        static const std::string&                       getClassType(void)
+        {
+            static std::string rev_type = "PseudoDist";
+
+            return rev_type;
+        }
+
+        //!< Get class type spec
+        static const TypeSpec&                          getClassTypeSpec(void)
+        {
+            static TypeSpec rev_type_spec ( TypedDistribution<PseudoData<T>>::getClassTypeSpec() );
+
+            return rev_type_spec;
+        }
+
+        //!< Get the type spec of the instance
+        const TypeSpec&                                 getTypeSpec(void) const
+        {
+            static TypeSpec ts = getClassTypeSpec();
+
+            return ts;
+        }
+
+        /**
+         * Get the Rev name for the distribution.
+         * This name is used for the constructor and the distribution functions,
+         * such as the density and random value function
+         *
+         * \return Rev name of constructor function.
+         */
+        //!< Get the Rev-name for this distribution.
+        std::string                                     getDistributionFunctionName(void) const
+        {
+            return "Pseudo";
+        }
+
+        const MemberRules&                              getParameterRules(void) const;
+
+
+        // Distribution functions you have to override
+        RevBayesCore::PseudoDist<typename T::valueType>*                    createDistribution() const override;
+
+    protected:
+
+        void                                            setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var);       //!< Set member variable
+
+    private:
+        RevPtr<const RevVariable> parameter;
+    };
+
+
+
+    template <typename T>
+    RevBayesCore::PseudoDist<typename T::valueType>* Dist_Pseudo<T>::createDistribution( void ) const
+    {
+        // get the parameters
+        auto param  = static_cast<const T&>( parameter->getRevObject() ).getDagNode();
+
+        return new RevBayesCore::PseudoDist<typename T::valueType>(param);
+    }
+
+    template <typename T>
+    const MemberRules&   Dist_Pseudo<T>::getParameterRules(void) const
+    {
+        static MemberRules dist_member_rules;
+        static bool rules_set = false;
+
+        if ( rules_set == false )
+        {
+            /* This should be simple but is a bit complicated because
+             * the subtype relationships for T don't work on Distribution<T>
+             *
+             * That is:  RevBayes knows that RealPos < Real.
+             *           RevBayes does NOT know that Distribution__RealPos < Distribution__Real.
+             *
+             * Therefore, depending on T, we need to list the types of the distributions that are allowed.
+             * - for T=Real, the distribution can be on Real, RealPos, or Probability.
+             * - for T=RealPos, the distribution can be on RealPos or Probability.
+             * This encodes the fact that a RealPos plus a RealPos yields a RealPos.
+             */
+             
+            std::vector<TypeSpec> distTypes;
+
+            distTypes.push_back(T::getClassTypeSpec());
+
+            dist_member_rules.push_back( new ArgumentRule( "parameter", distTypes, "The parameter of the unspecified distribution.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+
+            rules_set = true;
+        }
+
+        return dist_member_rules;
+    }
+
+
+    template <typename T>
+    void Dist_Pseudo<T>::setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var)
+    {
+        if ( name == "parameter" )
+        {
+            parameter = var;
+        }
+        else
+        {
+            TypedDistribution< PseudoData<T> >::setConstParameter(name, var);
+        }
+    }
+
+
+
+}
+
+
+#endif

--- a/src/revlanguage/functions/pseudodata/Func_PseudoDataInterval.cpp
+++ b/src/revlanguage/functions/pseudodata/Func_PseudoDataInterval.cpp
@@ -1,0 +1,116 @@
+#include "Func_PseudoDataInterval.h"
+
+#include "RealPos.h"
+#include "RlDeterministicNode.h"
+#include "RlPseudoData.h"
+#include "GenericFunction.h"
+#include "TypedDagNode.h"
+#include "Argument.h"
+#include "ArgumentRule.h"
+#include "ArgumentRules.h"
+#include "RbException.h"
+#include "RevVariable.h"
+#include "RlFunction.h"
+#include "RlBoolean.h"
+#include "Integer.h"
+#include "Simplex.h"
+#include "TypeSpec.h"
+
+using std::vector;
+using std::unique_ptr;
+
+namespace Core = RevBayesCore;
+
+Core::PseudoData<double>* PseudoDataIntervalFunc(double lower, double upper, double decayRate)
+{
+    return new Core::PseudoDataInterval(lower, upper, decayRate);
+}
+
+using namespace RevLanguage;
+
+
+/** default constructor */
+Func_PseudoDataInterval::Func_PseudoDataInterval( void ) : TypedFunction<PseudoData<Real>>( )
+{
+}
+
+
+/**
+ * The clone function is a convenience function to create proper copies of inherited objected.
+ * E.g. a.clone() will create a clone of the correct type even if 'a' is of derived type 'b'.
+ *
+ * \return A new copy of the process.
+ */
+Func_PseudoDataInterval* Func_PseudoDataInterval::clone( void ) const
+{
+    return new Func_PseudoDataInterval( *this );
+}
+
+
+Core::TypedFunction< Core::PseudoData<double> >* Func_PseudoDataInterval::createFunction( void ) const
+{
+    Core::TypedDagNode< double >* lower = dynamic_cast<const Real &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
+    Core::TypedDagNode< double >* upper = dynamic_cast<const Real &>( this->args[1].getVariable()->getRevObject() ).getDagNode();
+    Core::TypedDagNode< double >* decayRate = dynamic_cast<const RealPos &>( this->args[2].getVariable()->getRevObject() ).getDagNode();
+
+    return Core::generic_function_ptr< Core::PseudoData<double> >( PseudoDataIntervalFunc, lower, upper, decayRate );
+}
+
+
+/* Get argument rules */
+const ArgumentRules& Func_PseudoDataInterval::getArgumentRules( void ) const
+{
+    static ArgumentRules argumentRules = ArgumentRules();
+    static bool          rules_set = false;
+
+    if ( !rules_set )
+    {
+        argumentRules.push_back( new ArgumentRule( "lower", Real::getClassTypeSpec(), "The lower bound.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        argumentRules.push_back( new ArgumentRule( "upper", Real::getClassTypeSpec(), "The upper bound.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        argumentRules.push_back( new ArgumentRule( "decayRate", RealPos::getClassTypeSpec(), "The rate of decay outside the interval.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY, new RealPos(std::numeric_limits<double>::infinity() ) ) );
+
+        rules_set = true;
+    }
+
+    return argumentRules;
+}
+
+
+const std::string& Func_PseudoDataInterval::getClassType(void)
+{
+
+    static std::string rev_type = "Func_PseudoDataInterval";
+
+    return rev_type;
+}
+
+
+/* Get class type spec describing type of object */
+const TypeSpec& Func_PseudoDataInterval::getClassTypeSpec(void)
+{
+
+    static TypeSpec rev_type_spec = TypeSpec( getClassType(), new TypeSpec( Function::getClassTypeSpec() ) );
+
+    return rev_type_spec;
+}
+
+
+/**
+ * Get the primary Rev name for this function.
+ */
+std::string Func_PseudoDataInterval::getFunctionName( void ) const
+{
+    // create a name variable that is the same for all instance of this class
+    std::string f_name = "pdInterval";
+
+    return f_name;
+}
+
+
+const TypeSpec& Func_PseudoDataInterval::getTypeSpec( void ) const
+{
+
+    static TypeSpec type_spec = getClassTypeSpec();
+
+    return type_spec;
+}

--- a/src/revlanguage/functions/pseudodata/Func_PseudoDataInterval.cpp
+++ b/src/revlanguage/functions/pseudodata/Func_PseudoDataInterval.cpp
@@ -21,9 +21,19 @@ using std::unique_ptr;
 
 namespace Core = RevBayesCore;
 
-Core::PseudoData<double>* PseudoDataIntervalFunc(double lower, double upper, double decayRate)
+Core::PseudoData<double>* PseudoDataIntervalFunc(double a, double b, double lambda)
 {
-    return new Core::PseudoDataInterval(lower, upper, decayRate);
+    Core::PseudoData<double>::func_t interval_func = [a,b,lambda](const double& x)
+        {
+            if (x > a and x < b)
+                return 0.0;
+            else
+            {
+                double d = std::min(std::abs(x-a), std::abs(x-b));
+                return -lambda * d;
+            }
+        };
+    return new Core::PseudoData<double>(interval_func);
 }
 
 using namespace RevLanguage;

--- a/src/revlanguage/functions/pseudodata/Func_PseudoDataInterval.h
+++ b/src/revlanguage/functions/pseudodata/Func_PseudoDataInterval.h
@@ -1,0 +1,52 @@
+#ifndef Func_PseudoDataInterval_H
+#define Func_PseudoDataInterval_H
+
+#include <string>
+#include <iosfwd>
+#include <vector>
+
+#include "Real.h"
+#include "RlPseudoData.h"
+#include "RlTypedFunction.h"
+#include "DeterministicNode.h"
+#include "DynamicNode.h"
+#include "RevPtr.h"
+#include "RlDeterministicNode.h"
+#include "TypedDagNode.h"
+#include "TypedFunction.h"
+
+namespace RevLanguage {
+class ArgumentRules;
+class TypeSpec;
+
+    /**
+     * The RevLanguage wrapper of Interval pseudo-data.
+     *
+     * @copyright Copyright 2025-
+     * @author Benjamin D. Redelings
+     * @since 2025-01-17, version 1.0
+     *
+     */
+    class Func_PseudoDataInterval: public TypedFunction<PseudoData<Real>> {
+
+    public:
+        Func_PseudoDataInterval( void );
+
+        // Basic utility functions
+        Func_PseudoDataInterval*                                            clone(void) const;                                          //!< Clone the object
+        static const std::string&                                           getClassType(void);                                         //!< Get Rev type
+        static const TypeSpec&                                              getClassTypeSpec(void);                                     //!< Get class type spec
+        std::string                                                         getFunctionName(void) const;                                //!< Get the primary name of the function in Rev
+        const TypeSpec&                                                     getTypeSpec(void) const;                                    //!< Get the type spec of the instance
+
+        // Function functions you have to override
+        RevBayesCore::TypedFunction< RevBayesCore::PseudoData<double>>*     createFunction(void) const;                                 //!< Create a function object
+        const ArgumentRules&                                                getArgumentRules(void) const;                               //!< Get argument rules
+
+    };
+
+}
+
+#endif
+
+

--- a/src/revlanguage/workspace/RbRegister_Dist.cpp
+++ b/src/revlanguage/workspace/RbRegister_Dist.cpp
@@ -286,6 +286,8 @@
 #include "Transform_Vector_Logit.h"
 #include "Transform_Vector_Invlogit.h"
 
+#include "Dist_Pseudo.h"
+
 /// Functions ///
 
 /* Helper functions for creating functions (in folder "functions") */
@@ -631,6 +633,8 @@ void RevLanguage::Workspace::initializeDistGlobalWorkspace(void)
         AddDistribution< ModelVector<Real>          >( new Transform_Vector_Log()   );
         AddDistribution< ModelVector<Real>          >( new Transform_Vector_Logit() );
         AddDistribution< ModelVector<Probability>   >( new Transform_Vector_InvLogit() );
+
+        AddDistribution< PseudoData<Real>           >( new Dist_Pseudo<Real>()      );
 
         // uniform partitions prior
         AddDistribution< ModelVector<RealPos>       >( new Dist_upp<RealPos>() );

--- a/src/revlanguage/workspace/RbRegister_Func.cpp
+++ b/src/revlanguage/workspace/RbRegister_Func.cpp
@@ -314,6 +314,9 @@
 #include "Func_decomposedVarianceCovarianceMatrix.h"
 #include "Func_partialToCorrelationMatrix.h"
 
+/* PseudoData */
+#include "Func_PseudoDataInterval.h"
+
 /* Type conversions */
 #include "Proc_StringToInt.h"
 
@@ -660,6 +663,8 @@ void RevLanguage::Workspace::initializeFuncGlobalWorkspace(void)
         addFunction( new Func_decomposedVarianceCovarianceMatrix( ) );
         addFunction( new Func_partialToCorrelationMatrix( )         );
 
+        // Pseudo-data
+        addFunction( new Func_PseudoDataInterval()                  );
 
         // Type conversion
         addFunction( new Proc_StringToInt( )                         );

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -63,25 +63,23 @@ for t in revbayes.github.io/tutorials/*/tests.txt; do
     cd $dirname
     tests+=($testname)
 
-    printf "\n\n#### Running test: $testname\n\n"
+    printf "\n#### Running test: $testname\n\n"
 
     for script in $(cat tests.txt);
     do
+        printf "  $script\n"
         (
-        cd scripts
-        sed 's/generations=[0-9]*/generations=1/g' "$script" | sed 's/checkpointInterval=[0-9]*/checkpointInterval=1/g'  > "cp_$script"
+            cd scripts
+            sed 's/generations=[0-9]*/generations=1/g' "$script" | sed 's/checkpointInterval=[0-9]*/checkpointInterval=1/g'  > "cp_$script"
         )
         ${rb_exec} -b scripts/cp_$script
         res="$?"
         if [ $res = 1 ]; then
             res="error: $f"
-            break
         elif [ $res = 139 ]; then
             res="segfault: $f"
-            break
         elif [ $res != 0 ]; then
             res="error $res: $f"
-            break
         fi
         if [ $res != 0 ] ; then
             echo "${dirname}/test.sh ==> error $res"
@@ -113,6 +111,7 @@ for t in test_*; do
     res=0
     # run the test scripts
     for f in scripts/*.[Rr]ev ; do
+        printf "  $f\n"
         mkdir -p output
         tmp0=${f#scripts/}
         tmp1=${tmp0%.[Rr]ev}

--- a/tests/test_pseudo/scripts/interval.Rev
+++ b/tests/test_pseudo/scripts/interval.Rev
@@ -1,0 +1,10 @@
+t ~ dnNormal(0,10)
+fossil ~ dnPseudo(t)
+fossil.clamp(pdInterval(-1,3))
+
+mymodel = model(t)
+mymodel.graph("output/interval.dot")
+
+mymcmc = mcmc(mymodel,moves=[mvSlice(t)],monitors=[mnModel(filename="output/ignore.log")])
+mymcmc.run(1000)
+q()

--- a/tests/test_pseudo/scripts/interval.Rev
+++ b/tests/test_pseudo/scripts/interval.Rev
@@ -5,6 +5,6 @@ fossil.clamp(pdInterval(-1,3))
 mymodel = model(t)
 mymodel.graph("output/interval.dot")
 
-mymcmc = mcmc(mymodel,moves=[mvSlice(t)],monitors=[mnModel(filename="output/ignore.log")])
+mymcmc = mcmc(mymodel,moves=[mvSlice(t)],monitors=[mnModel(filename="output/interval.log")])
 mymcmc.run(1000)
 q()

--- a/tests/test_pseudo/scripts/interval2.Rev
+++ b/tests/test_pseudo/scripts/interval2.Rev
@@ -1,0 +1,14 @@
+t ~ dnNormal(0,10)
+
+a ~ dnNormal(-1,1)
+b ~ dnExponential(3) + a
+
+fossil ~ dnPseudo(t)
+fossil.clamp( pdInterval(a,b) )
+
+mymodel = model(t,a,b)
+mymodel.graph("output/interval2.dot")
+
+mymcmc = mcmc(mymodel,moves=[mvSlice(t),mvSlice(a), mvSlice(b)],monitors=[mnModel(filename="output/interval2.log")])
+mymcmc.run(1000)
+q()


### PR DESCRIPTION
RevBayes currently needs hacky and unreadable ways to add uniform bounds on fossils:
```
    F[i] ~ dnUniform(t[i] - b_i, t[i] - a_i)
    F[i].clamp( 0 )
```
By enforcing `0 \in (t[i]-b[i], t[i]-a[i])`, we end up enforcing that `t[i] \in (a[i],b[i])`.

It might seem simpler to simply write
```
   t[i] ~ dnUniform(a[i],b[i])
```
but that isn't write either, because `t[i]` already has a prior -- we can't add a second prior~

What's really happening here is that we have some unspecific fossil data (represented) by `F[i]`.  We don't know what the distribution of `F[i]` is -- nor do we know exactly what `F[i]` is either.  But we know that function `Pr(F[i] | t[i])` is 1 if `t[i]` is in `(a[i],b[i])` and 0 otherwise.  

We propose to express this kind of thing by writing:
```
   F[i] ~ dnPseudo(t[i])                         # there's some fossil data that gives information at t[i]
   F[i].clamp( pdUniform(a[i], b[i]) )   # this fossil data imposes a likelihood function that is 1 between a[i] and b[i] and 0 otherwise
```
