### PR TITLE
Update dlls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,7 +178,7 @@ jobs:
       env:
         USE_MPI: ${{ matrix.mpi }}
       run: |
-        ${GITHUB_WORKSPACE}/projects/meson/make_winroot.sh -ccache true -gtk true
+        ${GITHUB_WORKSPACE}/projects/make_winroot.sh -ccache true -gtk true
         ( cd ${GITHUB_WORKSPACE}/projects/meson/ ; ./generate.sh )
         
     - name: Configure and build

--- a/projects/make_winroot.sh
+++ b/projects/make_winroot.sh
@@ -96,8 +96,8 @@ cd ${SYSROOT}
 # libwinpthread-git-9.0.0.6090.ad98746a-1
 # We can use the libwinpthread-1 from the cross-compiler instead of download it.
 
-PKGS="boost-1.88.0-1
-boost-libs-1.88.0-1
+PKGS="boost-1.88.0-2
+boost-libs-1.88.0-2
 dlfcn-1.4.2-1
 "
 

--- a/projects/meson/make_winroot.sh
+++ b/projects/meson/make_winroot.sh
@@ -96,44 +96,47 @@ cd ${SYSROOT}
 # libwinpthread-git-9.0.0.6090.ad98746a-1
 # We can use the libwinpthread-1 from the cross-compiler instead of download it.
 
-PKGS="boost-1.83.0-2
-dlfcn-1.4.1-1
+PKGS="boost-1.88.0-1
+boost-libs-1.88.0-1
+dlfcn-1.4.2-1
 "
 
 if [ "${gtk}" = "true" ] ; then
     PKGS="$PKGS
-    atk-2.50.0-1
-    brotli-1.1.0-1
+    atk-2.56.2-1
+    brotli-1.1.0-4
     bzip2-1.0.8-3
-    cairo-1.18.0-1
-    expat-2.5.0-1
-    fontconfig-2.14.2-1
-    freetype-2.13.2-1
-    fribidi-1.0.13-1
-    gdk-pixbuf2-2.42.12-1
+    cairo-1.18.4-1
+    expat-2.7.1-2
+    fontconfig-2.16.2-1
+    freetype-2.13.3-1
+    fribidi-1.0.16-1
+    gdk-pixbuf2-2.42.12-4
     gettext-0.22.4-3
-    glib2-2.78.2-1
-    graphite2-1.3.14-2
+    glib2-2.84.1-2
+    graphite2-1.3.14-3
     gtk2-2.24.33-6
-    harfbuzz-8.3.0-1
-    iconv-1.17-4
-    libiconv-1.17-4
-    jasper-4.0.0-1
+    harfbuzz-11.2.0-1
+    iconv-1.18-1
+    libiconv-1.18-1
+    jasper-4.2.5-2
+    jbigkit-2.1-5
+    lerc-4.0.0-1
     libdatrie-0.2.13-3
-    libdeflate-1.19-1
-    libffi-3.4.4-1
-    libjpeg-turbo-3.0.1-1
-    libpng-1.6.40-1
+    libdeflate-1.23-1
+    libffi-3.4.8-1
+    libjpeg-turbo-3.1.0-1
+    libpng-1.6.48-1
     libthai-0.1.29-3
-    libtiff-4.6.0-1
-    libwebp-1.3.2-1
+    libtiff-4.7.0-1
+    libwebp-1.5.0-1
     lzo2-2.10-2
-    pango-1.50.14-4
-    pcre2-10.42-1
-    pixman-0.42.2-1
-    xz-5.4.5-1
-    zlib-1.3-1
-    zstd-1.5.5-1
+    pango-1.56.3-1
+    pcre2-10.45-1
+    pixman-0.46.0-1
+    xz-5.8.1-1
+    zlib-1.3.1-1
+    zstd-1.5.7-1
 "
 fi
 


### PR DESCRIPTION
Apparently the released version of RevStudio wouldn't start.  The problem was that the DLLs included weren't compatible with each other.  This PR solves this by updating the DLL versions.  We also need to avoid trying to find DLL files for libraries that are now header-only.

The TreeNode::resolveMultifurcation algorithm also suddenly started failing tests.  There was an issue with the coalescence algorithm for TimeTrees when not all children have the same age.  In this case a coalescent event could be scheduled for a time when there was only one active child, and the code would try and remove 2 children from a vector containing only 1 child.  This is solved by sorting the children and not generating a coalescence time for the youngest child.  We also generate only n-2 times now.  Sorting the children also makes it easier to determine which of the children are extant at a given time.  At each coalescent event we include any children that have become active before that coalescent event.

For BranchLengthTrees, the old code generated n-1 coalescent events so that the current node would have only 1 child.  The resulting "knuckle" was then removed later.  I have changed this so that we generate only n-2 coalescent events.  Now we don't generate any knuckles, so we don't have to remove them. 

Additional issues encountered and fixed along the way:
- the new coalescence tests are very slow and very numerous.  They come from a tutorial, so just run 1 iteration like we do with other tutorials.
- printing operator summaries made the *.errout differ if the code was run with assertions enabled, because one assertion computed a likelihood, and one of the operator summaries counted likelihood evaluations.  So I removed this printing.
- AutocorrelatedEventDistribution used `-1` to indicate lack of autocorrelation.  So we need to avoid subscripting by `-1`
- Elliptical slice sampling asserted that recomputing the likelihood should be exactly identical. I changed this to assert a log error of < 1.0e-9
