### PR TITLE
Fix parsing of the `STATELABELS` block in Nexus files

### DIFF
--- a/src/libs/ncl/nxscharactersblock.cpp
+++ b/src/libs/ncl/nxscharactersblock.cpp
@@ -4549,9 +4549,11 @@ void NxsCharactersBlock::HandleStatelabels(
 	charStates.clear();
 	for (;;)
 		{
-		token.GetNextToken();
-		if (token.Equals(";"))
-			break;
+        if (token.Equals(";"))
+            break;
+        token.GetNextToken();
+        if (token.Equals(";"))
+            break;
         int n = -1;
         try {
             n = token.GetToken().ConvertToInt();

--- a/tests/data/statelabels_end_comma.nex
+++ b/tests/data/statelabels_end_comma.nex
@@ -1,0 +1,42 @@
+#NEXUS
+BEGIN TAXA;
+  DIMENSIONS NTAX=5;
+  TAXLABELS
+    'A'
+    'B'
+    'C'
+    'D'
+    'E'
+  ;
+ENDBLOCK;
+
+BEGIN CHARACTERS;
+  DIMENSIONS NCHAR=3;
+  FORMAT DATATYPE=STANDARD GAP=- MISSING=? SYMBOLS="0123456789";
+  CHARLABELS
+    [1] 'Cephalization'
+    [2] 'Proboscis invaginable'
+    [3] 'Degree to which the introvert can be invaginated'
+  ;
+  STATELABELS
+    1
+    'Proboscis'
+    'Distinct head'
+    ,
+    2
+    'Absent'
+    'Present'
+    ,
+    3
+    'Minimal'
+    'Extensive'
+    ,
+  ;
+  MATRIX
+    'A'	00-
+    'B'	0??
+    'C'	010
+    'D'	011
+    'E'	010
+  ;
+ENDBLOCK;

--- a/tests/data/statelabels_no_end_comma.nex
+++ b/tests/data/statelabels_no_end_comma.nex
@@ -1,0 +1,42 @@
+#NEXUS
+BEGIN TAXA;
+  DIMENSIONS NTAX=5;
+  TAXLABELS
+    'A'
+    'B'
+    'C'
+    'D'
+    'E'
+  ;
+ENDBLOCK;
+
+BEGIN CHARACTERS;
+  DIMENSIONS NCHAR=3;
+  FORMAT DATATYPE=STANDARD GAP=- MISSING=? SYMBOLS="0123456789";
+  CHARLABELS
+    [1] 'Cephalization'
+    [2] 'Proboscis invaginable'
+    [3] 'Degree to which the introvert can be invaginated'
+  ;
+  STATELABELS
+    1
+    'Proboscis'
+    'Distinct head'
+    ,
+    2
+    'Absent'
+    'Present'
+    ,
+    3
+    'Minimal'
+    'Extensive'
+    [no comma is present here]
+  ;
+  MATRIX
+    'A'	00-
+    'B'	0??
+    'C'	010
+    'D'	011
+    'E'	010
+  ;
+ENDBLOCK;

--- a/tests/test_parseNexus/output_expected/Test_parseNexus.errout
+++ b/tests/test_parseNexus/output_expected/Test_parseNexus.errout
@@ -1,0 +1,7 @@
+   Successfully read one character matrix from file 'data/statelabels_end_comma.nex'
+   Taxa: 5
+   Characters: 3
+
+   Successfully read one character matrix from file 'data/statelabels_no_end_comma.nex'
+   Taxa: 5
+   Characters: 3

--- a/tests/test_parseNexus/scripts/Test_parseNexus.Rev
+++ b/tests/test_parseNexus/scripts/Test_parseNexus.Rev
@@ -1,0 +1,25 @@
+################################################################################
+#
+# RevBayes Test-Script: Parsing a character matrix stored in a Nexus file that
+#                       includes a STATELABELS block
+#
+# authors: David Cerny
+#
+################################################################################
+
+# read in a toy matrix of 5 taxa and 3 characters originally provided by Martin
+# R. Smith (see https://github.com/revbayes/revbayes/issues/731)
+
+# final comma in the STATELABELS block
+chars0 = readDiscreteCharacterData("data/statelabels_end_comma.nex")
+print("   Taxa: " + chars0.size())
+print("   Characters: " + chars0.nchar() + "\n")
+
+# no final comma in the STATELABELS block
+chars1 = readDiscreteCharacterData("data/statelabels_no_end_comma.nex")
+print("   Taxa: " + chars1.size())
+print("   Characters: " + chars1.nchar())
+
+clear()
+
+q()


### PR DESCRIPTION
This PR makes a small change to one of the NCL library files that fixes issue #731. It's not a particularly elegant solution (we  now check for semicolons twice: both before and after moving to the next token), but it does get the job done.