### PR TITLE
Run tutorial tests using the script from the website repo

### DIFF
--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -52,48 +52,14 @@ status=()
 
 if [ ! -d "revbayes.github.io" ] ; then
     echo "No revbayes.github.io directory, cloning it"
-git clone https://github.com/revbayes/revbayes.github.io.git
+    git clone https://github.com/revbayes/revbayes.github.io.git
 fi
 
-for t in revbayes.github.io/tutorials/*/tests.txt; do
-    testname=`echo $t | cut -d '/' -f 2-3`;
-    dirname=`echo $t | cut -d '/' -f 1-3`;
-
-
-    cd $dirname
-    tests+=($testname)
-
-    printf "\n\n#### Running test: $testname\n\n"
-
-    for script in $(cat tests.txt);
-    do
-        (
-        cd scripts
-        sed 's/generations=[0-9]*/generations=1/g' "$script" | sed 's/checkpointInterval=[0-9]*/checkpointInterval=1/g'  > "cp_$script"
-        )
-        ${rb_exec} -b scripts/cp_$script
-        res="$?"
-        if [ $res = 1 ]; then
-            res="error: $f"
-            break
-        elif [ $res = 139 ]; then
-            res="segfault: $f"
-            break
-        elif [ $res != 0 ]; then
-            res="error $res: $f"
-            break
-        fi
-        if [ $res != 0 ] ; then
-            echo "${dirname}/test.sh ==> error $res"
-        fi
-        rm scripts/cp_$script
-        rm -rf output
-    done
-
-    status+=("$res")
-
-    cd -
-done
+# Run the tutorial tests using the script from the website
+(
+    cd revbayes.github.io/tutorials
+    ./run_tutorial_tests.sh ${rb_exec}
+)
 
 for t in test_*; do
     testname=`echo $t | cut -d _ -f 2-`


### PR DESCRIPTION
I added some new tutorial tests.  However, the updated logic to change them to run only 1 generation was only in the `run_tutorial_tests.sh` script.

Change the `run_integration_tests.sh` script to run the tutorial tests via the `run_tutorial_tests.sh` script.  This has the benefit that:
- the code to run the tutorial tests is only in one place
- we use the same code to run the tutorial tests no matter whether we are running them from the revbayes repo or the website repo.