### PR TITLE
Allow redrawing values for clamped nodes when necessary

### DIFF
--- a/src/core/analysis/PosteriorPredictiveSimulation.cpp
+++ b/src/core/analysis/PosteriorPredictiveSimulation.cpp
@@ -131,6 +131,8 @@ void RevBayesCore::PosteriorPredictiveSimulation::run( int thinning )
             
             if ( the_node->isClamped() == true )
             {
+                the_node->setIgnoreRedraw(false);
+                
                 // check if the PP simulation must condition on sampled tip states
                 auto& ptr = the_node->getDistribution();
                 if (condition_on_tips == true && typeid( &ptr ) == typeid(StateDependentSpeciationExtinctionProcess))

--- a/src/core/dag/DagNode.cpp
+++ b/src/core/dag/DagNode.cpp
@@ -1022,18 +1022,28 @@ void DagNode::setHidden(bool tf)
 }
 
 
+void DagNode::setIgnoreData(bool tf)
+{
+    throw RbException()<<"Error: can't ignore data at node '"<<getName()<<"' because it is not a stochastic node!";
+}
+
+
+void DagNode::setIgnoreRedraw(bool tf)
+{
+    // nothing to do in the base class
+}
+
+
 void DagNode::setIntegrationIndex( size_t i )
 {
     // nothing to do in the base class
 }
 
 
-
 void DagNode::setName(std::string const &n)
 {
     // set the internal value
     name = n;
-
 }
 
 
@@ -1054,12 +1064,6 @@ void DagNode::setParentNamePrefix(const std::string &p)
 
 }
 
-
-void DagNode::setIgnoreData(bool tf)
-{
-    throw RbException()<<"Error: can't ignore data at node '"<<getName()<<"' because it is not a stochastic node!";
-
-}
 
 void DagNode::setVisitFlag(bool tf, const size_t flagType)
 {

--- a/src/core/dag/DagNode.h
+++ b/src/core/dag/DagNode.h
@@ -119,10 +119,11 @@ template <class valueType> class RbOrderedSet;
         void                                                        restoreVector(std::vector<DagNode *>& nodes);
         void                                                        setElementVariable(bool tf);                                                                //!< Set if this variable is hidden from printing.
         void                                                        setHidden(bool tf);                                                                         //!< Set if this variable is hidden from printing.
+        virtual void                                                setIgnoreData(bool tf);                                                                     //!< Set whether we want to have the probability of the prior only.
+        virtual void                                                setIgnoreRedraw(bool tf);                                                                    //!< Set whether we want the node to be redrawable (applies only to stochastic nodes).
         virtual void                                                setIntegrationIndex( size_t i );
         void                                                        setName(const std::string &n);                                                              //!< Set the name of this variable for identification purposes.
         void                                                        setParentNamePrefix(const std::string &p);
-        virtual void                                                setIgnoreData(bool tf);                                                                     //!< Set whether we want to have the probability of the prior only.
         void                                                        setVisitFlag(bool tf, const size_t flagType);
         virtual void                                                swapParent(const DagNode *oldP, const DagNode *newP);                                       //!< Exchange the parent node which includes setting myself as a child of the new parent and removing myself from my old parents children list
         void                                                        touch(bool touchAll=false);

--- a/src/core/dag/StochasticNode.h
+++ b/src/core/dag/StochasticNode.h
@@ -49,7 +49,7 @@ namespace RevBayesCore {
         void                                                redraw(SimulationCondition c = SimulationCondition::MCMC);                  //!< Redraw the current value of the node (applies only to stochastic nodes)
         virtual void                                        reInitializeMe(void);                                                       //!< The DAG was re-initialized so maybe you want to reset some stuff (delegate to distribution)
         virtual void                                        setClamped(bool tf);                                                        //!< Set directly the flag whether this node is clamped.
-        void                                                setIgnoreRedraw(bool tf=true);
+        void                                                setIgnoreRedraw(bool tf=true);                                              //!< Set whether we want the node to be redrawable.
         void                                                setIntegratedOut(bool tf=true);
         virtual void                                        setIntegrationIndex( size_t i );
         void                                                setMcmcMode(bool tf);                                                       //!< Set the modus of the DAG node to MCMC mode.
@@ -215,7 +215,7 @@ RevBayesCore::StochasticNode<valueType>& RevBayesCore::StochasticNode<valueType>
         distribution->setStochasticNode( this );
         
         clamped                             = n.clamped;
-        ignore_data                     = n.ignore_data;
+        ignore_data                         = n.ignore_data;
         ignore_redraw                       = n.ignore_redraw;
         integrated_out                      = n.integrated_out;
         lnProb                              = {};
@@ -245,6 +245,7 @@ void RevBayesCore::StochasticNode<valueType>::clamp(valueType *val)
     setValue( val );
     
     clamped = true;
+    ignore_redraw = true;
     
 }
 
@@ -675,10 +676,11 @@ void RevBayesCore::StochasticNode<valueType>::redraw( SimulationCondition c )
     // draw the value
     if ( ignore_redraw == false )
     {
-        if (this->isClamped()) {
-            throw RbException("Cannot modify the value of a clamped node.");
-        }
         distribution->redrawValue( c );
+    }
+    else if ( ignore_redraw == true and this->isClamped() )
+    {
+        throw RbException("Cannot modify the value of a clamped node.");
     }
     
     // touch this node for probability recalculation
@@ -923,6 +925,7 @@ template<class valueType>
 void RevBayesCore::StochasticNode<valueType>::unclamp( void )
 {
     clamped = false;
+    ignore_redraw = false;
 }
 
 

--- a/src/revlanguage/dag/RlContinuousStochasticNode.cpp
+++ b/src/revlanguage/dag/RlContinuousStochasticNode.cpp
@@ -190,6 +190,12 @@ RevLanguage::RevPtr<RevLanguage::RevVariable> RevLanguage::ContinuousStochasticN
         // we found the corresponding member method
         found = true;
         
+        // manually calling redraw allows value to be set unless the node is clamped
+        if (!this->isClamped())
+        {
+            this->setIgnoreRedraw( false );
+        }
+        
         // redraw the value
         this->redraw();
         

--- a/src/revlanguage/dag/RlContinuousStochasticNode.cpp
+++ b/src/revlanguage/dag/RlContinuousStochasticNode.cpp
@@ -190,9 +190,6 @@ RevLanguage::RevPtr<RevLanguage::RevVariable> RevLanguage::ContinuousStochasticN
         // we found the corresponding member method
         found = true;
         
-        // manually calling redraw allows value to be set
-        this->setIgnoreRedraw( false );
-        
         // redraw the value
         this->redraw();
         

--- a/src/revlanguage/dag/RlStochasticNode.h
+++ b/src/revlanguage/dag/RlStochasticNode.h
@@ -207,9 +207,6 @@ RevLanguage::RevPtr<RevLanguage::RevVariable> RevLanguage::StochasticNode<valueT
         // we found the corresponding member method
         found = true;
         
-        // manually calling redraw allows value to be set
-        this->setIgnoreRedraw( false );
-        
         // redraw the value
         this->redraw();
         

--- a/src/revlanguage/dag/RlStochasticNode.h
+++ b/src/revlanguage/dag/RlStochasticNode.h
@@ -207,6 +207,12 @@ RevLanguage::RevPtr<RevLanguage::RevVariable> RevLanguage::StochasticNode<valueT
         // we found the corresponding member method
         found = true;
         
+        // manually calling redraw allows value to be set unless the node is clamped
+        if (!this->isClamped())
+        {
+            this->setIgnoreRedraw( false );
+        }
+        
         // redraw the value
         this->redraw();
         


### PR DESCRIPTION
This PR is intended to fix issue #767 by making sure that posterior predictive simulations can run (and determine what they should simulate by looking for clamped nodes in the model) while still throwing an error for code such as the following:

```r
x ~ dnNorm(1, 1)
x.clamp(1)
x.redraw()
```

I was surprised to find out that my [original idea](https://github.com/revbayes/revbayes/issues/767#issuecomment-2923845795):

> maybe we could add a boolean member variable to `StochasticNode`, check for it in `redraw()`, let `clamp()` set it to `false`, but provide a dedicated setter that could override it and that we could employ in `PosteriorPredictiveSimulation::run()`

was already mostly implemented: `StochasticNode` has a protected member variable called `ignore_redraw`, which is set to `false` by default and can be toggled by a setter called `.setIgnoreRedraw()`. However, we don't employ this setter anywhere except when implementing the `.redraw()` method for (continuous) stochastic nodes, where it is always set to `false` before a redraw is attempted.

Here, I have repurposed the `ignore_redraw` variable to make sure that: (1) it is always set to `true` by `.clamp()` and to `false` by `.unclamp()`; (2) it is _not_ automatically set to `false` when the user tries to call `.redraw()` directly from Rev; and (3) `PowerPosteriorSimulation` sets it to `false` for any clamped node it finds.

Note that the following still works:

```r
x ~ dnNorm(1, 1)
x.setValue(1)
x.redraw()
```