### PR TITLE
Allow nonzero rho values in FBD analyses without extant tips

### DIFF
--- a/src/core/distributions/phylogenetics/tree/birthdeath/BirthDeathSamplingTreatmentProcess.cpp
+++ b/src/core/distributions/phylogenetics/tree/birthdeath/BirthDeathSamplingTreatmentProcess.cpp
@@ -273,11 +273,6 @@ double BirthDeathSamplingTreatmentProcess::computeLnProbabilityDivergenceTimes( 
         return RbConstants::Double::neginf;
     }
 
-    if ( offset > DBL_EPSILON && phi_event[0] > DBL_EPSILON )
-    {
-        throw RbException("Event sampling fraction at the present is non-zero but there are no tips at the present.");
-    }
-
     // precompute A_i, B_i, C_i, E_i(t_i)
     prepareProbComputation();
 


### PR DESCRIPTION
As discussed in #786, the most appropriate treatment of the extant sampling fraction (rho) in the FBD analyses of clades which we know to be extinct is likely to fix it to 1: this avoids the possibility of unsampled lineages surviving to the present. This PR makes this treatment possible by removing the error we currently throw when the user attempts to specify rho > 0 and there are no tips at the present.