### PR TITLE
Be explicit about flagging all children of a deterministic node as dirty

### DIFF
--- a/src/core/dag/DeterministicNode.h
+++ b/src/core/dag/DeterministicNode.h
@@ -475,11 +475,6 @@ template<class valueType>
 void RevBayesCore::DeterministicNode<valueType>::touchMe( const DagNode *toucher, bool touchAll )
 {
 
-    // store if the state of the variable was dirty (needed an update)
-    bool needed_update = needs_update;
-    bool was_touched = this->touched;
-
-
     // delegate call to base class
     // this will set the touched flag if it wasn't set already
     DynamicNode<valueType>::touchMe( toucher, touchAll );

--- a/src/core/dag/DeterministicNode.h
+++ b/src/core/dag/DeterministicNode.h
@@ -495,12 +495,8 @@ void RevBayesCore::DeterministicNode<valueType>::touchMe( const DagNode *toucher
     // mark for update
     needs_update = true;
 
-    // only if this function did not need an update we delegate the touch affected
-    if ( needed_update == false || was_touched == false || true )
-    {
-        // Dispatch the touch message to downstream nodes
-        this->touchAffected( touchAll );
-    }
+    // Dispatch the touch message to downstream nodes
+    this->touchAffected( touchAll );
 
 }
 


### PR DESCRIPTION
This PR is intended to close #578 by removing some rather perplexing code from `DeterministicNode.h`. Between old Slack conversations and the commit history in the archived pre-rapture repo, I think I was able to piece together how we got where we are:

- The original condition was simply `if ( needed_update == false )`, and was introduced by @hoehna in commit [`98de84d`](https://github.com/revbayes/revbayes.archive/commit/98de84d327a26de29465295edce881bface65aca) ("Important fix when flagging deterministic nodes for updates");
- It was extended to `if ( needed_update == false || was_touched == false )` in commit [`111a386`](https://github.com/revbayes/revbayes.archive/commit/111a386161249c1510d0e7655ec02114c92c926b) ("Improving touch behavior of DAG nodes");
- Finally, it grew to `if ( needed_update == false || was_touched == false || true )` with commit [`ca126dd`](https://github.com/revbayes/revbayes.archive/commit/ca126dd61b05502c03f1ee7bbf37abe723111911), labeled simply "Preparing for UCI workshop" (March 2016).
- In November 2018, @mlandis asked on Slack:

    > The last condition of that if statement (`|| true`) means that all children (and n-children) are flagged as dirty when a node is touched, like it is when computing its probability. Removing that or-true condition returns the speed to normal. And for this simple model, the behavior seems to be correct without the or-true condition, but it might misbehave for more complicated DAGs… that’ll take a little testing.
    
    > @hoehna If I remove the or-true condition and RevBayes passes our test scripts, would it be fine to commit the change to development? Hard to tell if the or-true condition is there intentionally or if it’s a holdover from debugging…
    
    Sebastian replied that this was indeed likely a holdover from debugging.
    
- The extra `|| true` was then indeed removed in commit [`b295ea2`](https://github.com/revbayes/revbayes.archive/commit/b295ea2cd93bd40beb61d6c1654af1e2974d76dc), with the commit message explicitly confirming that it "passes validation tests". This apparently resulted in substantial speedup.
- However, one month later, @afmagee confirmed that @mlandis' initial suspicion – that not flagging all children as dirty "might misbehave for more complicated DAGs" – was indeed correct, and the `|| true` condition was restored "until we can find a better workaround" in commit [`4cdc9d1`](https://github.com/revbayes/revbayes.archive/commit/4cdc9d1a734891c96dc0cd089d5870318c11954b). A new integration test ([`mcmc_UCLD_noncentered.rev`](https://github.com/revbayes/revbayes/blob/master/tests/test_UCLD_noncentered/scripts/mcmc_UCLD_noncentered.rev)) was added with a DAG in which updates would not be propagated correctly without aggressive flagging. Andy later summed it up on Slack as follows:

    > Michael and I thought we had a way to reduce the number of DAG traversals, and it passed all existing tests. We found out it messed up hierarchical models with certain parameterizations and aborted, but that's why there's the "UCLD_noncentered" test, in case we tamper with the DAG traversing again later
    
Tl;dr We need to flag _all_ children of a deterministic node as dirty, because there are hierarchical models that we can't get to work otherwise. This PR makes that explicit by removing a condition that ended up being always true.