### PR TITLE
Remove boost filesystem

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,7 +154,7 @@ jobs:
           curl -O -L https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.gz
           tar -xzvf boost_1_88_0.tar.gz
           cd boost_1_88_0
-          ./bootstrap.sh --with-libraries=atomic,chrono,filesystem,system,regex,thread,date_time,program_options,math,serialization --prefix=../installed-boost-1.88.0
+          ./bootstrap.sh --with-libraries=atomic,chrono,system,regex,thread,date_time,program_options,math,serialization --prefix=../installed-boost-1.88.0
           ./b2 link=static install
           echo -e "\n    BOOST root is at $(cd ../installed-boost-1.88.0; pwd)\n"
           echo BOOST_ROOT=$(cd ../installed-boost-1.88.0; pwd) >> $GITHUB_ENV

--- a/meson.build
+++ b/meson.build
@@ -49,7 +49,6 @@ endif
 
 boost_modules = [ 'program_options',
                   'thread',
-                  'filesystem',
                   'date_time',
                   'serialization']
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -179,7 +179,6 @@ COMPONENTS regex
 program_options
 thread
 system
-filesystem
 date_time
 serialization REQUIRED)
 message("Boost configuration results:")

--- a/src/core/analysis/PowerPosteriorAnalysis.cpp
+++ b/src/core/analysis/PowerPosteriorAnalysis.cpp
@@ -229,7 +229,7 @@ void PowerPosteriorAnalysis::runAll(size_t gen, double burnin_fraction, size_t p
 void PowerPosteriorAnalysis::runStone(size_t idx, size_t gen, double burnin_fraction, size_t pre_burnin_generations, size_t tuning_interval, bool one_only)
 {
     // create the directory if necessary
-    if (filename.filename().empty() or filename.filename_is_dot() or filename.filename_is_dot_dot())
+    if (filename.filename().empty() or filename.filename() == "." or filename.filename() == "..")
     {
         throw RbException("Please provide a filename with an extension");
     }

--- a/src/core/io/NclReader.cpp
+++ b/src/core/io/NclReader.cpp
@@ -1260,7 +1260,7 @@ std::vector<AbstractCharacterData*> NclReader::readMatrices(const path &fn)
     
     // are we reading a single file or are we reading the contents of a directory?
     bool readingDirectory = false;
-    if ( fn.filename().empty() or fn.filename_is_dot() or fn.filename_is_dot_dot())
+    if ( fn.filename().empty() or fn.filename() == "." or fn.filename() == "..")
         readingDirectory = true;
     if (readingDirectory == true)
         RBOUT( "Recursively reading the contents of a directory\n" );
@@ -1634,7 +1634,7 @@ std::vector<Tree*>* NclReader::readBranchLengthTrees(const path &fn)
     
     // are we reading a single file or are we reading the contents of a directory?
     bool readingDirectory = false;
-    if ( fn.filename().empty() or fn.filename_is_dot() or fn.filename_is_dot_dot())
+    if ( fn.filename().empty() or fn.filename() == "." or fn.filename() == "..")
     {
         readingDirectory = true;
     }

--- a/src/core/utils/RbFileManager.cpp
+++ b/src/core/utils/RbFileManager.cpp
@@ -12,8 +12,7 @@
 #include "RbSettings.h"
 #include "RbException.h"
 #include "StringUtilities.h"
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/operations.hpp>
+#include <filesystem>
 
 // TODO: remove all these includes
 #ifdef _WIN32
@@ -28,7 +27,7 @@
 
 // TODO: fix setValueFromFile
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 namespace RevBayesCore
 {
@@ -128,7 +127,7 @@ path expandUserDir(std::string dir)
 */
 void formatError(const path& p, std::string& errorStr)
 {
-    bool file_nameProvided    = (not p.filename().empty() and not p.filename_is_dot());
+    bool file_nameProvided    = not p.filename().empty();
     bool isfile_nameGood      = is_regular_file(p);
     bool isDirectoryNameGood = is_directory( p.parent_path() );
     
@@ -164,7 +163,7 @@ void formatError(const path& p, std::string& errorStr)
 */
 bool setStringWithNamesOfFilesInDirectory(const path& dirpath, std::vector<path>& sv, bool recursive)
 {
-    // FIXME: It should be converted to use boost:filesystem.
+    // FIXME: It should be converted to use std::filesystem.
     //        This is a holdover from the days of RbFileManager
     //        We should try and remove the #ifdef _WIN32, and 
     std::string dirstring = dirpath.string();

--- a/src/core/utils/RbFileManager.h
+++ b/src/core/utils/RbFileManager.h
@@ -5,12 +5,11 @@
 #include <string>
 #include <vector>
 
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/operations.hpp>
+#include <filesystem>
 
 namespace RevBayesCore {
 
-    using namespace boost::filesystem;
+    using namespace std::filesystem;
     
     std::istream&           safeGetline(std::istream& is, std::string& t); //!< Gets one line from a stream
     path                    expandUserDir(std::string path); //!< Get full path to user directory

--- a/src/core/utils/RbSettings.cpp
+++ b/src/core/utils/RbSettings.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <vector>
 #include <boost/lexical_cast.hpp>
+#include <cassert>
 
 #include "RbException.h"
 #include "RbFileManager.h"

--- a/src/libs/tensorphylo/Loader.cpp
+++ b/src/libs/tensorphylo/Loader.cpp
@@ -11,7 +11,7 @@
 #include <cassert>
 #include <iostream>
 #include <cstdlib>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include <boost/dll.hpp>
 #include <boost/function.hpp>
@@ -52,20 +52,20 @@ bool Loader::loadTensorPhylo() {
 bool Loader::loadTensorPhylo(const std::string &aPluginFolder) {
 
 	// Checking for the plugin folder
-	boost::filesystem::path pluginPath(aPluginFolder);
-	if(!boost::filesystem::is_directory(pluginPath)) {
+	std::filesystem::path pluginPath(aPluginFolder);
+	if(!std::filesystem::is_directory(pluginPath)) {
 		throw RbException("The folder doesn't exist.");
 		return false;
 	}
 
 	// Listing all files
-	std::vector<boost::filesystem::directory_entry> vecPlugins;
-    copy(boost::filesystem::directory_iterator(pluginPath), boost::filesystem::directory_iterator(), std::back_inserter(vecPlugins));
+	std::vector<std::filesystem::directory_entry> vecPlugins;
+    copy(std::filesystem::directory_iterator(pluginPath), std::filesystem::directory_iterator(), std::back_inserter(vecPlugins));
 
     // Look for TensorPhylo
     bool found = false;
-	boost::filesystem::path tensorPhyloPath;
-	for(std::vector<boost::filesystem::directory_entry>::const_iterator it = vecPlugins.begin(); it != vecPlugins.end();  ++ it ) {
+	std::filesystem::path tensorPhyloPath;
+	for(std::vector<std::filesystem::directory_entry>::const_iterator it = vecPlugins.begin(); it != vecPlugins.end();  ++ it ) {
 		std::string filePath(it->path().string());
 		if(filePath.find(PLUGIN_TENSORPHYLO_NAME) != std::string::npos &&
 			 (filePath.find(".so") != std::string::npos ||
@@ -83,7 +83,7 @@ bool Loader::loadTensorPhylo(const std::string &aPluginFolder) {
 
 	// try to load TensorPhylo
 	try {
-		pluginTensorPhylo.load(tensorPhyloPath, boost::dll::load_mode::append_decorations);
+                pluginTensorPhylo.load(tensorPhyloPath, boost::dll::load_mode::append_decorations);
 	} catch(const std::exception& e) {
 		throw RbException("TensorPhylo failed to load.");
 		return false;

--- a/src/libs/tensorphylo/Loader.h
+++ b/src/libs/tensorphylo/Loader.h
@@ -8,6 +8,8 @@
 #ifndef REVBAYES_LOADER_H_
 #define REVBAYES_LOADER_H_
 
+#define BOOST_DLL_USE_STD_FS
+
 #include "DistributionHandler.h"
 
 #include <string>

--- a/src/revlanguage/functions/basic/Func_getwd.cpp
+++ b/src/revlanguage/functions/basic/Func_getwd.cpp
@@ -1,5 +1,6 @@
 #include <fstream>
 #include <vector>
+#include <filesystem>
 
 #include "Func_getwd.h"
 #include "RbSettings.h"
@@ -12,12 +13,9 @@
 #include "RevVariable.h"
 #include "RlFunction.h"
 
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/operations.hpp>
-
 using namespace RevLanguage;
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 /** Default constructor */
 Func_getwd::Func_getwd( void ) : Procedure()

--- a/src/revlanguage/functions/basic/Func_setwd.cpp
+++ b/src/revlanguage/functions/basic/Func_setwd.cpp
@@ -1,6 +1,7 @@
 #include <cstddef>
 #include <fstream>
 #include <vector>
+#include <filesystem>
 
 #include "Argument.h"
 #include "ArgumentRule.h"
@@ -16,12 +17,9 @@
 #include "RevVariable.h"
 #include "RlFunction.h"
 
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/operations.hpp>
-
 using namespace RevLanguage;
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 /** Default constructor */
 Func_setwd::Func_setwd( void ) : Procedure()

--- a/src/revlanguage/functions/io/Func_source.cpp
+++ b/src/revlanguage/functions/io/Func_source.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <filesystem>
 
 #include "Argument.h"
 #include "ArgumentRule.h"
@@ -21,11 +22,10 @@
 #include "RevVariable.h"
 #include "RlBoolean.h"
 #include "RlFunction.h"
-#include <boost/filesystem/path.hpp>
 
 using namespace RevLanguage;
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 /** Default constructor */
 Func_source::Func_source( void ) : Procedure()

--- a/src/revlanguage/ui/RevClient.cpp
+++ b/src/revlanguage/ui/RevClient.cpp
@@ -11,8 +11,6 @@
 #include "RevPtr.h"
 #include "TypeSpec.h"
 #include "boost/algorithm/string/trim.hpp"
-#include <boost/filesystem/path.hpp>
-#include <boost/filesystem/operations.hpp>
 
 #ifdef RB_MPI
 #include <mpi.h>
@@ -22,7 +20,7 @@ extern "C" {
 #include "linenoise.h"
 }
 
-#include <boost/foreach.hpp>
+#include <filesystem>
 #include <boost/algorithm/string/predicate.hpp>
 #include <cstdlib>
 #include <iostream>
@@ -40,7 +38,7 @@ const char* prompt = default_prompt;
 
 using namespace RevLanguage;
 
-namespace fs = boost::filesystem;
+namespace fs = std::filesystem;
 
 std::vector<std::string> getFileList(const RevBayesCore::path& dir)
 {
@@ -176,7 +174,7 @@ void completeOnTab(const char *buf, linenoiseCompletions *lc)
 
         // find position of right most expression separator in cmd
 
-        BOOST_FOREACH(std::string s, expressionSeparator)
+        for(auto& s: expressionSeparator)
         {
             if (debug) { std::cout << "linenoise-debug: rfind(\"" << s << "\",\"" << cmd << "\")=" << cmd.rfind(s) << "\n"; }
             size_t find_idx = cmd.rfind(s);
@@ -251,7 +249,7 @@ void completeOnTab(const char *buf, linenoiseCompletions *lc)
 
     // populate linenoise completions
     
-    BOOST_FOREACH(std::string m, completions)
+    for(auto& m: completions)
     {
         if (boost::starts_with(m, compMatch))
         {


### PR DESCRIPTION
We can now use `std::filesystem` in place of `boost::filesystem`, dropping a link-time dependency on one boost library.