### PR TITLE
Adding age HPD to sampled ancestor node/tip

### DIFF
--- a/src/core/analysis/mcmc/output/TreeSummary.cpp
+++ b/src/core/analysis/mcmc/output/TreeSummary.cpp
@@ -717,7 +717,7 @@ void TreeSummary::annotateTree( Tree &tree, AnnotationReport report, bool verbos
             double saFreq = sampled_ancestor_counts[n->getTaxon()];
 
             // annotate sampled ancestor prob
-            if ( ((n->isTip() && n->isFossil()) || saFreq > 0) && report.sampled_ancestor_probs )
+            if ( (n->isFossil() || saFreq > 0) && report.sampled_ancestor_probs )
             {
                 n->addNodeParameter("sampled_ancestor", saFreq / totalSamples);
             }
@@ -836,7 +836,7 @@ void TreeSummary::annotateTree( Tree &tree, AnnotationReport report, bool verbos
 
             if ( clock == true )
             {
-                if ( n->isTip() == false || ( ( n->isFossil() || upper != lower) && !n->isSampledAncestorTip() ) )
+                if ( n->isTip() == false || n->isFossil() || upper != lower )
                 {
                     std::string label = "age_" + StringUtilities::toString( (int)(report.node_ages_HPD * 100) ) + "%_HPD";
                     n->addNodeParameter(label, interval);


### PR DESCRIPTION
This PR attempts to fix issue #457. Turns out the fix is really simple--we just had a check preventing tips from getting the HPD if they were sampled-ancestor tips. I removed those checks, so now any fossil tip will get a 95% age HPD. I suspect I can simplify the check further, but PTSD from removing what looked like a redundant || statement in an if loop and discovering a huge problem months later has made me really cautious, so I just removed the check that prevented SAs from receiving the annotation. 

[Here](https://github.com/user-attachments/files/21585392/bears.mcc.new.tre.txt) is an example of an MCC tree generated with the trace from the issue. Note that the node representing the sampled ancestor and the "tip" coming out of this node have slightly different 95% HPD intervals (e.g. consider the node with index 27, HPD `{14.3451,15.9694}`, representing the SA _Ursavus_primaevus_, which has HPD `{14.2137,15.9694}`). My MCC trees from BEAST2 analyses show the same behavior, so I'm wondering if it has something to do with the fact we consider clades where _Ursavus_primaevus_ is an SA separately from clades where it is (a fact that has led to a lot of disagreement, see #467 and #787). Still, I wonder if this is expected behavior--since the SA is represented by both the node and tip, I assume we'd want them to be calculating the ages HPD from the same sample, be it restricted to the case where that taxon is an SA or not. I'm interested to hear what others think, though.