### PR TITLE
Document the `args` vector

### DIFF
--- a/help/md/args.md
+++ b/help/md/args.md
@@ -1,0 +1,31 @@
+## name
+args
+## title
+Vector of command-line arguments
+## description
+Vector holding command-line arguments supplied using the `--args` or `--cmd` flags. If no command-line arguments are supplied, `args` is initialized to an empty vector. Like a regular RevBayes vector, `args` uses 1-based indexing (i.e., the first element is accessed using `args[1]`), but unlike a regular vector, it can hold elements of different types.
+## details
+## authors
+Sebastian Hoehna
+## see_also
+## example
+	# args is initialized to an empty vector if no command-line arguments are supplied.
+    # Assume RevBayes was called as follows: ./rb   
+	args                          # returns [ ]
+    args.size()                   # returns 0
+    
+    # However, args is not a reserved keyword. We can remove it from the workspace or overwrite it.
+    clear(args)
+    args <- readTrees("primates.tree")[1]  # args is now a tree
+    
+    # Assume RevBayes was called as follows: ./rb --args 1 5
+    args[1] + args[2]             # returns 6
+    
+    # Unlike regular vectors, args can hold values of different types.
+    # Assume RevBayes was called as follows: ./rb --args 1 5 2 "Hello " "world"
+    print(args[4] + args[5])      # prints "Hello world"
+    type(args[4])                 # returns String
+    
+    (args[1] + args[2])^args[3]   # returns 36
+    type(args[1])                 # returns Natural
+## references

--- a/help/md/args.md
+++ b/help/md/args.md
@@ -3,26 +3,34 @@ args
 ## title
 Vector of command-line arguments
 ## description
-Vector holding command-line arguments supplied using the `--args` or `--cmd` flags. If no command-line arguments are supplied, `args` is initialized to an empty vector. Like a regular RevBayes vector, `args` uses 1-based indexing (i.e., the first element is accessed using `args[1]`), but unlike a regular vector, it can hold elements of different types.
+When RevBayes is called from the command line, any tokens following the name
+of a script file (or an `-e` expression) are treated as arguments to the script
+(or to the expression) and stored in the `args` vector.
 ## details
+If no command-line arguments are supplied, `args` is initialized to an empty
+vector. Like regular RevBayes vectors, `args` uses 1-based indexing (i.e., the
+first element is accessed using `args[1]`), but unlike a regular vector, it can
+hold elements of different types.
 ## authors
 Sebastian Hoehna
+Ben Redelings
 ## see_also
 ## example
-	# args is initialized to an empty vector if no command-line arguments are supplied.
+    # args is initialized to an empty vector if no command-line arguments are supplied.
     # Assume RevBayes was called as follows: ./rb   
-	args                          # returns [ ]
+    args                          # returns [ ]
     args.size()                   # returns 0
     
-    # However, args is not a reserved keyword. We can remove it from the workspace or overwrite it.
+    # However, args is not a reserved keyword. We can remove it from the workspace or overwrite it:
     clear(args)
     args <- readTrees("primates.tree")[1]  # args is now a tree
     
-    # Assume RevBayes was called as follows: ./rb --args 1 5
+    # To illustrate how args works, run RevBayes in interactive mode with an empty expression:
+    # ./rb -i -e "" 1 5
     args[1] + args[2]             # returns 6
     
-    # Unlike regular vectors, args can hold values of different types.
-    # Assume RevBayes was called as follows: ./rb --args 1 5 2 "Hello " "world"
+    # Unlike regular vectors, args can hold values of different types. Call RevBayes as follows:
+    # ./rb -i -e "" 1 5 2 "Hello " "world"
     print(args[4] + args[5])      # prints "Hello world"
     type(args[4])                 # returns String
     

--- a/src/core/help/RbHelpDatabase.cpp
+++ b/src/core/help/RbHelpDatabase.cpp
@@ -228,6 +228,29 @@ c := append(a,b))");
 	help_strings[string("append")][string("name")] = string(R"(append)");
 	help_arrays[string("append")][string("see_also")].push_back(string(R"(rep)"));
 	help_strings[string("append")][string("title")] = string(R"(Append a value)");
+	help_arrays[string("args")][string("authors")].push_back(string(R"(Sebastian Hoehna)"));
+	help_strings[string("args")][string("description")] = string(R"(Vector holding command-line arguments supplied using the `--args` or `--cmd` flags. If no command-line arguments are supplied, `args` is initialized to an empty vector. Like a regular RevBayes vector, `args` uses 1-based indexing (i.e., the first element is accessed using `args[1]`), but unlike a regular vector, it can hold elements of different types.)");
+	help_strings[string("args")][string("example")] = string(R"(# args is initialized to an empty vector if no command-line arguments are supplied.
+# Assume RevBayes was called as follows: ./rb
+args                          # returns [ ]
+args.size()                   # returns 0
+
+# However, args is not a reserved keyword. We can remove it from the workspace or overwrite it.
+clear(args)
+args <- readTrees("primates.tree")[1]  # args is now a tree
+
+# Assume RevBayes was called as follows: ./rb --args 1 5
+args[1] + args[2]             # returns 6
+
+# Unlike regular vectors, args can hold values of different types.
+# Assume RevBayes was called as follows: ./rb --args 1 5 2 "Hello " "world"
+print(args[4] + args[5])      # prints "Hello world"
+type(args[4])                 # returns String
+
+(args[1] + args[2])^args[3]   # returns 36
+type(args[1])                 # returns Natural)");
+	help_strings[string("args")][string("name")] = string(R"(args)");
+	help_strings[string("args")][string("title")] = string(R"(Vector of command-line arguments)");
 	help_strings[string("beca")][string("name")] = string(R"(beca)");
 	help_strings[string("branchScoreDistance")][string("name")] = string(R"(branchScoreDistance)");
 	help_arrays[string("ceil")][string("authors")].push_back(string(R"(Sebastian Hoehna)"));
@@ -4950,6 +4973,16 @@ type(b))");
 	help_strings[string("type")][string("name")] = string(R"(type)");
 	help_arrays[string("type")][string("see_also")].push_back(string(R"(structure)"));
 	help_strings[string("type")][string("title")] = string(R"(The value type of a variable)");
+    help_arrays[string("tzard")][string("authors")].push_back(string(R"(Sebastian Hoehna)"));
+    help_strings[string("tzard")][string("description")] = string(R"(The value type of a variable.)");
+    help_strings[string("tzard")][string("example")] = string(R"(a <- 2
+type(a)
+
+b <- 2.0
+type(b))");
+    help_strings[string("tzard")][string("name")] = string(R"(type)");
+    help_arrays[string("tzard")][string("see_also")].push_back(string(R"(structure)"));
+    help_strings[string("tzard")][string("title")] = string(R"(The value type of a variable)");
 	help_arrays[string("v")][string("authors")].push_back(string(R"(Michael Landis)"));
 	help_strings[string("v")][string("description")] = string(R"('v' creates a vector of the elements '...')");
 	help_strings[string("v")][string("details")] = string(R"('v' creates a vector of the elements '...', which are objects of a common base type. Vector elements may themselves be vectors.)");

--- a/src/core/help/RbHelpDatabase.cpp
+++ b/src/core/help/RbHelpDatabase.cpp
@@ -229,21 +229,29 @@ c := append(a,b))");
 	help_arrays[string("append")][string("see_also")].push_back(string(R"(rep)"));
 	help_strings[string("append")][string("title")] = string(R"(Append a value)");
 	help_arrays[string("args")][string("authors")].push_back(string(R"(Sebastian Hoehna)"));
-	help_strings[string("args")][string("description")] = string(R"(Vector holding command-line arguments supplied using the `--args` or `--cmd` flags. If no command-line arguments are supplied, `args` is initialized to an empty vector. Like a regular RevBayes vector, `args` uses 1-based indexing (i.e., the first element is accessed using `args[1]`), but unlike a regular vector, it can hold elements of different types.)");
+	help_arrays[string("args")][string("authors")].push_back(string(R"(Ben Redelings)"));
+	help_strings[string("args")][string("description")] = string(R"(When RevBayes is called from the command line, any tokens following the name
+of a script file (or an `-e` expression) are treated as arguments to the script
+(or to the expression) and stored in the `args` vector.)");
+	help_strings[string("args")][string("details")] = string(R"(If no command-line arguments are supplied, `args` is initialized to an empty
+vector. Like regular RevBayes vectors, `args` uses 1-based indexing (i.e., the
+first element is accessed using `args[1]`), but unlike a regular vector, it can
+hold elements of different types.)");
 	help_strings[string("args")][string("example")] = string(R"(# args is initialized to an empty vector if no command-line arguments are supplied.
 # Assume RevBayes was called as follows: ./rb
 args                          # returns [ ]
 args.size()                   # returns 0
 
-# However, args is not a reserved keyword. We can remove it from the workspace or overwrite it.
+# However, args is not a reserved keyword. We can remove it from the workspace or overwrite it:
 clear(args)
 args <- readTrees("primates.tree")[1]  # args is now a tree
 
-# Assume RevBayes was called as follows: ./rb --args 1 5
+# To illustrate how args works, run RevBayes in interactive mode with an empty expression:
+# ./rb -i -e "" 1 5
 args[1] + args[2]             # returns 6
 
-# Unlike regular vectors, args can hold values of different types.
-# Assume RevBayes was called as follows: ./rb --args 1 5 2 "Hello " "world"
+# Unlike regular vectors, args can hold values of different types. Call RevBayes as follows:
+# ./rb -i -e "" 1 5 2 "Hello " "world"
 print(args[4] + args[5])      # prints "Hello world"
 type(args[4])                 # returns String
 
@@ -4973,16 +4981,6 @@ type(b))");
 	help_strings[string("type")][string("name")] = string(R"(type)");
 	help_arrays[string("type")][string("see_also")].push_back(string(R"(structure)"));
 	help_strings[string("type")][string("title")] = string(R"(The value type of a variable)");
-    help_arrays[string("tzard")][string("authors")].push_back(string(R"(Sebastian Hoehna)"));
-    help_strings[string("tzard")][string("description")] = string(R"(The value type of a variable.)");
-    help_strings[string("tzard")][string("example")] = string(R"(a <- 2
-type(a)
-
-b <- 2.0
-type(b))");
-    help_strings[string("tzard")][string("name")] = string(R"(type)");
-    help_arrays[string("tzard")][string("see_also")].push_back(string(R"(structure)"));
-    help_strings[string("tzard")][string("title")] = string(R"(The value type of a variable)");
 	help_arrays[string("v")][string("authors")].push_back(string(R"(Michael Landis)"));
 	help_strings[string("v")][string("description")] = string(R"('v' creates a vector of the elements '...')");
 	help_strings[string("v")][string("details")] = string(R"('v' creates a vector of the elements '...', which are objects of a common base type. Vector elements may themselves be vectors.)");

--- a/src/core/help/RbHelpRenderer.cpp
+++ b/src/core/help/RbHelpRenderer.cpp
@@ -12,6 +12,7 @@
 #include "RbHelpFunction.h"
 #include "RbHelpReference.h"
 #include "RbHelpType.h"
+#include "RbHelpDatabase.h"
 
 using namespace RevBayesCore;
 
@@ -392,6 +393,99 @@ std::string HelpRenderer::renderHelp(const RbHelpType &typeHelp, size_t w)
     
     // see also
     result.append( renderSeeAlso( typeHelp, w ) );
+    
+    
+    return result;
+}
+
+
+// For rendering general database entries
+std::string HelpRenderer::renderHelp(const RbHelpDatabase &hd, std::string entry_name, size_t w)
+{
+    std::string result = "";
+    
+    const std::string &title_prelim = RbHelpDatabase::getHelpDatabase().getHelpString(entry_name, "title");
+    const std::string &description_prelim = RbHelpDatabase::getHelpDatabase().getHelpString(entry_name, "description");
+    const std::string &details_prelim = RbHelpDatabase::getHelpDatabase().getHelpString(entry_name, "details");
+    const std::string &example_prelim = RbHelpDatabase::getHelpDatabase().getHelpString(entry_name, "example");
+    const std::vector<std::string> &authors_prelim = RbHelpDatabase::getHelpDatabase().getHelpStringVector(entry_name, "authors");
+    const std::vector<std::string> &see_also_prelim = RbHelpDatabase::getHelpDatabase().getHelpStringVector(entry_name, "see_also");
+    
+    std::string title = "";
+    std::string description = "";
+    std::string details = "";
+    std::string example = "";
+    std::string authors = "";
+    std::string see_also = "";
+
+    if ( title_prelim.size() > 0 )
+    {
+        title.append( title_prelim );
+        title.append( line_break );
+        title.append( section_break );
+    }
+    
+    if ( description_prelim.size() > 0 )
+    {
+        description.append( TerminalFormatter::makeUnderlined("Description") );
+        description.append( section_break );
+    
+        description.append( StringUtilities::formatTabWrap(description_prelim, 1, w, false) );
+        description.append( line_break );
+        description.append( section_break );
+    }
+    
+    if ( details_prelim.size() > 0)
+    {
+        details.append( TerminalFormatter::makeUnderlined("Details") );
+        details.append( section_break );
+        
+        details.append( StringUtilities::formatTabWrap(details_prelim, 1, w, false) );
+        details.append( line_break );
+        details.append( section_break );
+    }
+    
+    if ( example_prelim.size() > 0 )
+    {
+        example.append( TerminalFormatter::makeUnderlined("Example") );
+        example.append( section_break );
+
+        example.append( StringUtilities::formatTabWrap(example_prelim, 1, w, false) );
+        example.append( section_break );
+    }
+    
+    if ( authors_prelim.size() > 0 )
+    {
+        authors.append( TerminalFormatter::makeUnderlined("Author") );
+        authors.append( section_break );
+    
+        for (std::vector<std::string>::const_iterator it = authors_prelim.begin(); it != authors_prelim.end(); ++it)
+        {
+            authors.append( StringUtilities::formatTabWrap(*it, 1, w, false) );
+            authors.append( line_break );
+        }
+        authors.append( section_break );
+    }
+    
+    if ( see_also_prelim.size() > 0 )
+    {
+        see_also.append( TerminalFormatter::makeUnderlined("See also") );
+        see_also.append( section_break );
+        
+        for (std::vector<std::string>::const_iterator it = see_also_prelim.begin(); it != see_also_prelim.end(); ++it)
+        {
+            see_also.append( StringUtilities::formatTabWrap(*it, 1, w) );
+            see_also.append( line_break );
+        }
+        see_also.append(line_break);
+    }
+    
+    result.append( title );
+    result.append( description );
+    result.append( details );
+    result.append( example );
+    result.append( authors );
+    result.append( see_also );
     
     
     return result;

--- a/src/core/help/RbHelpRenderer.h
+++ b/src/core/help/RbHelpRenderer.h
@@ -10,6 +10,7 @@ class RbHelpArgument;
 class RbHelpEntry;
 class RbHelpFunction;
 class RbHelpType;
+class RbHelpDatabase;
     
     /**
      * @brief Class rendering the help to the console output.
@@ -28,6 +29,7 @@ class RbHelpType;
         std::string                 renderHelp(const RbHelpEntry &entryHelp, size_t w);
         std::string                 renderHelp(const RbHelpFunction &functionHelp, size_t w);
         std::string                 renderHelp(const RbHelpType &typeHelp, size_t w);
+        std::string                 renderHelp(const RbHelpDatabase &hd, std::string entry_name, size_t w);
         
         
         

--- a/src/revlanguage/parser/Parser.cpp
+++ b/src/revlanguage/parser/Parser.cpp
@@ -11,6 +11,7 @@
 #include "RbException.h"
 #include "RbHelpRenderer.h"
 #include "RbHelpSystem.h"
+#include "RbHelpDatabase.h"
 #include "RbSettings.h"
 #include "RbUtil.h"
 #include "RevNullObject.h"
@@ -283,11 +284,22 @@ int RevLanguage::Parser::help(const std::string& symbol) const
     
     // Get some help
     RevBayesCore::RbHelpSystem& hs = RevBayesCore::RbHelpSystem::getHelpSystem();
+    RevBayesCore::RbHelpDatabase& hd = RevBayesCore::RbHelpDatabase::getHelpDatabase();
+    const std::string& help_title = hd.getHelpString(symbol, "name");
+    
     if ( hs.isHelpAvailableForQuery(symbol) )
     {
         const RevBayesCore::RbHelpEntry& h = hs.getHelp( symbol );
         RevBayesCore::HelpRenderer hRenderer;
         std::string hStr = hRenderer.renderHelp(h, RbSettings::userSettings().getLineWidth() - RevBayesCore::RbUtils::PAD.size());
+        UserInterface::userInterface().output("\n", true);
+        UserInterface::userInterface().output("\n", true);
+        UserInterface::userInterface().output(hStr, true);
+    }
+    else if ( not hs.isHelpAvailableForQuery(symbol) and help_title.size() > 0 )
+    {
+        RevBayesCore::HelpRenderer hRenderer;
+        std::string hStr = hRenderer.renderHelp(hd, symbol, RbSettings::userSettings().getLineWidth() - RevBayesCore::RbUtils::PAD.size());
         UserInterface::userInterface().output("\n", true);
         UserInterface::userInterface().output("\n", true);
         UserInterface::userInterface().output(hStr, true);


### PR DESCRIPTION
This PR is intended as a follow-up to #803 and documents how RevBayes stores and accesses command-line arguments.

Since the `args` vector does not belong to any class of Rev objects that we can currently document (distributions, functions, moves, etc.), this required some changes to the help infrastructure. Perhaps these might prove useful for other purposes too.