### PR TITLE
Do not require the `system` boost library in `CMakeLists.txt`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -177,7 +177,6 @@ find_package(Boost
 1.74.0
 COMPONENTS regex
 thread
-system
 date_time
 serialization REQUIRED)
 message("Boost configuration results:")


### PR DESCRIPTION
It looks like boost v1.89.0 no longer includes the `system` component, which we currently require in `CMakeLists.txt`. This PR removes that requirement. Since `system` hasn't been necessary since v1.69, and we don't support boost versions earlier than v1.74.0 anyway, this makes no practical difference.