### PR TITLE
Conditioning options for the 'coding' argument in dnPhyloCTMC

### DIFF
--- a/src/revlanguage/distributions/phylogenetics/character/Dist_phyloCTMC.cpp
+++ b/src/revlanguage/distributions/phylogenetics/character/Dist_phyloCTMC.cpp
@@ -548,7 +548,7 @@ const MemberRules& Dist_phyloCTMC::getParameterRules(void) const
         dist_member_rules.push_back( new ArgumentRule( "treatAmbiguousAsGap", RlBoolean::getClassTypeSpec(), "Should we treat ambiguous characters as gaps/missing?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean( false ) ) );
 
         std::vector<std::string> codingOptions = {"all", "noabsencesites", "nopresencesites", "informative", "variable", "nosingletonpresence", "nosingletonabsence", "nosingletons"};
-        dist_member_rules.push_back(new OptionRule("coding", new RlString("all"), codingOptions, "Should any type of conditioning be applied?"));
+        dist_member_rules.push_back(new OptionRule("coding", new RlString("all"), codingOptions, "What character patterns have been sampled?"));
 
         dist_member_rules.push_back( new ArgumentRule( "storeInternalNodes", RlBoolean::getClassTypeSpec(), "Should we store internal node states in the character matrix?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean( false ) ) );
         

--- a/src/revlanguage/distributions/phylogenetics/character/Dist_phyloCTMC.cpp
+++ b/src/revlanguage/distributions/phylogenetics/character/Dist_phyloCTMC.cpp
@@ -547,7 +547,8 @@ const MemberRules& Dist_phyloCTMC::getParameterRules(void) const
 
         dist_member_rules.push_back( new ArgumentRule( "treatAmbiguousAsGap", RlBoolean::getClassTypeSpec(), "Should we treat ambiguous characters as gaps/missing?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean( false ) ) );
 
-        dist_member_rules.push_back( new ArgumentRule("coding", RlString::getClassTypeSpec(), "", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlString("all") ) );
+        std::vector<std::string> codingOptions = {"all", "noabsencesites", "nopresencesites", "informative", "variable", "nosingletonpresence", "nosingletonabsence", "nosingletons"};
+        dist_member_rules.push_back(new OptionRule("coding", new RlString("all"), codingOptions, "Should any type of conditioning be applied?"));
 
         dist_member_rules.push_back( new ArgumentRule( "storeInternalNodes", RlBoolean::getClassTypeSpec(), "Should we store internal node states in the character matrix?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean( false ) ) );
         
@@ -716,4 +717,3 @@ void Dist_phyloCTMC::setConstParameter(const std::string& name, const RevPtr<con
     }
 
 }
-


### PR DESCRIPTION
Adding the options to coding argument in dnPhyloCTMC. 
Previously, the help for dnPhyloCTMC appeared like this:
```
                    coding : 
                             Type:       String, <any>, value
                             Default:    all
```
This PR adds the options available for 'coding':
```
                    coding : Should any type of conditioning be applied?
                             Type:       String, <any>, value
                             Default:    all
                             Options:    all|noabsencesites|nopresencesites|informative|variable|nosingletonpresence|nosingletonabsence|nosingletons
```