### PR TITLE
Fix block bootstrap with small values of n

### DIFF
--- a/src/core/analysis/mcmc/MarginalLikelihoodEstimator.cpp
+++ b/src/core/analysis/mcmc/MarginalLikelihoodEstimator.cpp
@@ -253,9 +253,10 @@ std::vector< std::vector< std::vector<double> > > MarginalLikelihoodEstimator::b
                 std::vector<std::int64_t> temp1( repnum );
                 bool cond = false;
                 
+                double block_length = std::max<double>(1, n*prop);
                 for (size_t k = 0; k < repnum; k++)
                 {
-                    temp0[k] = 1 + RbStatistics::Geometric::rv( 1/(n * prop), *rng );
+                    temp0[k] = 1 + RbStatistics::Geometric::rv( 1/block_length, *rng );
                     temp1[k] = std::min( temp0[k], n_sim - len_tot[k] );
                     len_tot[k] = len_tot[k] + temp1[k];
                     cond |= len_tot[k] < n_sim;

--- a/src/core/math/distributions/DistributionGeometric.cpp
+++ b/src/core/math/distributions/DistributionGeometric.cpp
@@ -185,7 +185,7 @@ std::int64_t RbStatistics::Geometric::quantile(double q, double p)
 std::int64_t RbStatistics::Geometric::rv(double p, RevBayesCore::RandomNumberGenerator &rng)
 {
     if (!RbMath::isFinite(p) || p <= 0 || p > 1) 
-        throw RbException("NaN produced in rgeom");
+        throw RbException()<<"Sampling geometric random variable: invalid success probability p = "<<p;
     
     return RbStatistics::Poisson::rv(exp(rng.uniform01()) * ((1 - p) / p),rng)+1;
 }


### PR DESCRIPTION
Issue #840 was caused by trying to run a block bootstrap with n*prop=0.9, which was calling `RbStatistics::Geometric::rv( )` with `p=1.1111111` (not NaN).

