### PR TITLE
Fix `Real` subscript to array

### DIFF
--- a/src/core/help/RbHelpDatabase.cpp
+++ b/src/core/help/RbHelpDatabase.cpp
@@ -5061,7 +5061,7 @@ for specifying how to separate values in the RevObject (default is "").)");
 # define RevObject to write
     x <- matrix([[1, 1],[1, 1]])
 # write to CSV file
-    write(x, "/path/to/file/filenmae.csv", false, ","))");
+    write(x, "/path/to/file/filename.csv", false, ","))");
 	help_strings[string("write")][string("name")] = string(R"(write)");
 	help_arrays[string("write")][string("see_also")].push_back(string(R"(writeDelimitedCharacterData)"));
 	help_arrays[string("write")][string("see_also")].push_back(string(R"(writeFasta)"));

--- a/src/revlanguage/functions/math/Func_absInt.cpp
+++ b/src/revlanguage/functions/math/Func_absInt.cpp
@@ -1,0 +1,117 @@
+#include <iosfwd>
+#include <string>
+#include <vector>
+
+#include "AbsoluteValueFunction.h"
+#include "Func_absInt.h"
+#include "Integer.h"
+#include "Natural.h"
+#include "RlDeterministicNode.h"
+#include "TypedDagNode.h"
+#include "Argument.h"
+#include "ArgumentRule.h"
+#include "ArgumentRules.h"
+#include "DeterministicNode.h"
+#include "DynamicNode.h"
+#include "RbHelpReference.h"
+#include "RevPtr.h"
+#include "RevVariable.h"
+#include "RlFunction.h"
+#include "RlTypedFunction.h"
+#include "StringUtilities.h"
+#include "TypeSpec.h"
+#include "TypedFunction.h"
+#include "GenericFunction.h"
+
+using namespace RevLanguage;
+
+/** default constructor */
+Func_absInt::Func_absInt( void ) : TypedFunction<Natural>( )
+{
+    
+}
+
+
+/**
+ * The clone function is a convenience function to create proper copies of inherited objected.
+ * E.g. a.clone() will create a clone of the correct type even if 'a' is of derived type 'b'.
+ *
+ * \return A new copy of the process.
+ */
+Func_absInt* Func_absInt::clone( void ) const
+{
+    
+    return new Func_absInt( *this );
+}
+
+// Create a non-polymorphic function.
+std::int64_t* absInt(std::int64_t x)
+{
+    return new std::int64_t(std::abs(x));
+}
+
+RevBayesCore::TypedFunction<std::int64_t>* Func_absInt::createFunction( void ) const
+{
+    auto* arg = static_cast<const Integer &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
+
+    return RevBayesCore::generic_function_ptr< std::int64_t >( absInt, arg );
+}
+
+
+/* Get argument rules */
+const ArgumentRules& Func_absInt::getArgumentRules( void ) const
+{
+    
+    static ArgumentRules argumentRules = ArgumentRules();
+    static bool          rules_set = false;
+    
+    if ( !rules_set )
+    {
+        
+        argumentRules.push_back( new ArgumentRule( "x", Integer::getClassTypeSpec(), "A (possibly negative) number.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        
+        rules_set = true;
+    }
+    
+    return argumentRules;
+}
+
+
+const std::string& Func_absInt::getClassType(void)
+{
+    
+    static std::string rev_type = "Func_absInt";
+    
+    return rev_type; 
+}
+
+
+/* Get class type spec describing type of object */
+const TypeSpec& Func_absInt::getClassTypeSpec(void)
+{
+    
+    static TypeSpec rev_type_spec = TypeSpec( getClassType(), new TypeSpec( Function::getClassTypeSpec() ) );
+    
+	return rev_type_spec; 
+}
+
+
+/**
+ * Get the primary Rev name for this function.
+ */
+std::string Func_absInt::getFunctionName( void ) const
+{
+    // create a name variable that is the same for all instance of this class
+    std::string f_name = "abs";
+    
+    return f_name;
+}
+
+
+const TypeSpec& Func_absInt::getTypeSpec( void ) const
+{
+    
+    static TypeSpec type_spec = getClassTypeSpec();
+    
+    return type_spec;
+}

--- a/src/revlanguage/functions/math/Func_absInt.h
+++ b/src/revlanguage/functions/math/Func_absInt.h
@@ -1,0 +1,36 @@
+#ifndef Func_absInt_H
+#define Func_absInt_H
+
+#include "Natural.h"
+#include "RlTypedFunction.h"
+
+#include <string>
+
+namespace RevLanguage {
+    
+    /**
+     * The RevLanguage wrapper of the absolute value function for integers.
+     */
+    class Func_absInt : public TypedFunction<Natural> {
+        
+    public:
+        Func_absInt( void );
+        
+        // Basic utility functions
+        Func_absInt*                                    clone(void) const;                                          //!< Clone the object
+        static const std::string&                       getClassType(void);                                         //!< Get Rev type
+        static const TypeSpec&                          getClassTypeSpec(void);                                     //!< Get class type spec
+        std::string                                     getFunctionName(void) const;                                //!< Get the primary name of the function in Rev
+        const TypeSpec&                                 getTypeSpec(void) const;                                    //!< Get the type spec of the instance
+        
+        // Function functions you have to override
+        RevBayesCore::TypedFunction<std::int64_t>*      createFunction(void) const;                                 //!< Create internal function object
+        const ArgumentRules&                            getArgumentRules(void) const;                               //!< Get argument rules
+        
+    protected:
+        
+    };
+    
+}
+
+#endif

--- a/src/revlanguage/functions/math/Func_absVectorInt.cpp
+++ b/src/revlanguage/functions/math/Func_absVectorInt.cpp
@@ -1,0 +1,129 @@
+#include <iosfwd>
+#include <string>
+#include <vector>
+
+#include "AbsoluteValueVectorFunction.h"
+#include "Func_absVectorInt.h"
+#include "Real.h"
+#include "Natural.h"
+#include "RlDeterministicNode.h"
+#include "TypedDagNode.h"
+#include "Argument.h"
+#include "ArgumentRule.h"
+#include "ArgumentRules.h"
+#include "ConstantNode.h"
+#include "DagNode.h"
+#include "DeterministicNode.h"
+#include "DynamicNode.h"
+#include "IndirectReferenceFunction.h"
+#include "ModelObject.h"
+#include "ModelVector.h"
+#include "RbHelpReference.h"
+#include "RbVector.h"
+#include "RevPtr.h"
+#include "RevVariable.h"
+#include "RlConstantNode.h"
+#include "RlTypedFunction.h"
+#include "StringUtilities.h"
+#include "TypeSpec.h"
+#include "TypedFunction.h"
+#include "UserFunctionNode.h"
+#include "GenericFunction.h"
+
+using namespace RevLanguage;
+
+/** default constructor */
+Func_absVectorInt::Func_absVectorInt( void ) : TypedFunction< ModelVector<Natural> >( )
+{
+    
+}
+
+
+/**
+ * The clone function is a convenience function to create proper copies of inherited objected.
+ * E.g. a.clone() will create a clone of the correct type even if 'a' is of derived type 'b'.
+ *
+ * \return A new copy of the process.
+ */
+Func_absVectorInt* Func_absVectorInt::clone( void ) const
+{
+    
+    return new Func_absVectorInt( *this );
+}
+
+
+// Create a non-polymorphic function.
+RevBayesCore::RbVector<std::int64_t>* absVectorInt(const RevBayesCore::RbVector<std::int64_t>& x)
+{
+    auto abs_x = new RevBayesCore::RbVector<std::int64_t>(x);
+    for(auto& e: *abs_x)
+        e = std::abs(e);
+    return abs_x;
+}
+
+
+RevBayesCore::TypedFunction<RevBayesCore::RbVector<std::int64_t> >* Func_absVectorInt::createFunction( void ) const
+{
+    auto* arg = static_cast<const ModelVector<Integer> &>( this->args[0].getVariable()->getRevObject() ).getDagNode();
+
+    return RevBayesCore::generic_function_ptr< RevBayesCore::RbVector<std::int64_t> >( absVectorInt, arg );
+}
+
+
+/* Get argument rules */
+const ArgumentRules& Func_absVectorInt::getArgumentRules( void ) const
+{
+    
+    static ArgumentRules argumentRules = ArgumentRules();
+    static bool          rules_set = false;
+    
+    if ( !rules_set )
+    {
+        
+        argumentRules.push_back( new ArgumentRule( "x", ModelVector<Integer>::getClassTypeSpec(), "A vector of numbers.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        
+        rules_set = true;
+    }
+    
+    return argumentRules;
+}
+
+
+const std::string& Func_absVectorInt::getClassType(void)
+{
+    
+    static std::string rev_type = "Func_absVectorInt";
+    
+    return rev_type;
+}
+
+
+/* Get class type spec describing type of object */
+const TypeSpec& Func_absVectorInt::getClassTypeSpec(void)
+{
+    
+    static TypeSpec rev_type_spec = TypeSpec( getClassType(), new TypeSpec( TypedFunction<ModelVector<Natural> >::getClassTypeSpec() ) );
+    
+    return rev_type_spec;
+}
+
+
+/**
+ * Get the primary Rev name for this function.
+ */
+std::string Func_absVectorInt::getFunctionName( void ) const
+{
+    // create a name variable that is the same for all instance of this class
+    std::string f_name = "abs";
+    
+    return f_name;
+}
+
+
+const TypeSpec& Func_absVectorInt::getTypeSpec( void ) const
+{
+    
+    static TypeSpec type_spec = getClassTypeSpec();
+    
+    return type_spec;
+}

--- a/src/revlanguage/functions/math/Func_absVectorInt.h
+++ b/src/revlanguage/functions/math/Func_absVectorInt.h
@@ -1,0 +1,38 @@
+#ifndef Func_absVectorInt_H
+#define Func_absVectorInt_H
+
+#include "ModelVector.h"
+#include "Natural.h"
+#include "RlTypedFunction.h"
+
+#include <string>
+
+namespace RevLanguage {
+    
+    /**
+     * The RevLanguage wrapper of the absolute value function for vectors of integers.
+     */
+    class Func_absVectorInt : public TypedFunction< ModelVector<Natural> > {
+        
+    public:
+        Func_absVectorInt( void );
+        
+        // Basic utility functions
+        Func_absVectorInt*                                                  clone(void) const;                                          //!< Clone the object
+        static const std::string&                                           getClassType(void);                                         //!< Get Rev type
+        static const TypeSpec&                                              getClassTypeSpec(void);                                     //!< Get class type spec
+        std::string                                                         getFunctionName(void) const;                                //!< Get the primary name of the function in Rev
+        const TypeSpec&                                                     getTypeSpec(void) const;                                    //!< Get the type spec of the instance
+        
+        // Function functions you have to override
+        RevBayesCore::TypedFunction<RevBayesCore::RbVector<std::int64_t> >* createFunction(void) const;                                 //!< Create internal function object
+        const ArgumentRules&                                                getArgumentRules(void) const;                               //!< Get argument rules
+    
+    
+    protected:
+        
+    };
+    
+}
+
+#endif

--- a/src/revlanguage/parser/SyntaxIndexOperation.cpp
+++ b/src/revlanguage/parser/SyntaxIndexOperation.cpp
@@ -188,7 +188,13 @@ RevPtr<RevVariable> SyntaxIndexOperation::evaluateLHSContent( const std::shared_
     }
 
     // compute the index and internal name for this variable
-    int idx = (int)static_cast<Integer&>( indexVar->getRevObject() ).getValue();
+    auto& idx_obj = indexVar->getRevObject();
+    if (not idx_obj.getTypeSpec().isDerivedOf( Integer::getClassTypeSpec()))
+    {
+        throw RbException()<<"Index should be of type Natural, but is of type "<<idx_obj.getTypeSpec().getType()<<".";
+    }
+
+    int idx = (int)static_cast<Integer&>( idx_obj ).getValue();
     std::string identifier = theParentVar->getName() + "[" + std::to_string(idx) + "]";
 
     // first ensure that we've got an entry with name `identifier` in the environment

--- a/src/revlanguage/ui/RevClient.cpp
+++ b/src/revlanguage/ui/RevClient.cpp
@@ -489,7 +489,7 @@ void startInterpreter()
 
         if (result == 2)
         {
-            std::exit(1);
+            commandLine.clear();
         }
 
 /* The typed string is returned as a malloc() allocated string by

--- a/src/revlanguage/workspace/RbRegister_Func.cpp
+++ b/src/revlanguage/workspace/RbRegister_Func.cpp
@@ -243,6 +243,7 @@
 #include "Func_abs.h"
 #include "Func_absInt.h"
 #include "Func_absVector.h"
+#include "Func_absVectorInt.h"
 #include "Func_ceil.h"
 #include "Func_choose.h"
 #include "Func_coala.h"
@@ -494,6 +495,7 @@ void RevLanguage::Workspace::initializeFuncGlobalWorkspace(void)
         addFunction( new Func_abs()                  );
         addFunction( new Func_absVector()            );
         addFunction( new Func_absInt()               );
+        addFunction( new Func_absVectorInt()         );
 
 		// ceil function
         addFunction( new Func_ceil<Real,Integer>()  );

--- a/src/revlanguage/workspace/RbRegister_Func.cpp
+++ b/src/revlanguage/workspace/RbRegister_Func.cpp
@@ -241,6 +241,7 @@
 
 /* Math functions (in folder "functions/math") */
 #include "Func_abs.h"
+#include "Func_absInt.h"
 #include "Func_absVector.h"
 #include "Func_ceil.h"
 #include "Func_choose.h"
@@ -492,6 +493,7 @@ void RevLanguage::Workspace::initializeFuncGlobalWorkspace(void)
 		// absolute function
         addFunction( new Func_abs()                  );
         addFunction( new Func_absVector()            );
+        addFunction( new Func_absInt()               );
 
 		// ceil function
         addFunction( new Func_ceil<Real,Integer>()  );

--- a/tests/test_basics/output_expected/indexing.errout
+++ b/tests/test_basics/output_expected/indexing.errout
@@ -1,0 +1,24 @@
+> x[0]
+   Missing Variable:	Variable x does not exist
+> x[1]
+   Missing Variable:	Variable x does not exist
+> x[-1] = -1
+   Error:	Index -1 not allowed in 'x[-1]'.  The first element should be 'x[1]'
+> x[0] = 0
+   Error:	Index 0 not allowed in 'x[0]'.  The first element should be 'x[1]'
+> x[1] = 1
+> x[2] = -2
+> print(x)
+1,-2
+> x[1.5]
+   Error:	Argument or label mismatch for function call.
+   Arguments which could not be matched (we stopped after the first mismatch):
+   	index
+   Provided call:
+   [] (RealPos<constant> 'index' )
+   
+   Correct usage is:
+   [] (Natural<any> index)
+   
+> x[1.5] = 1
+   Error:	Index should be of type Natural, but is of type RealPos.

--- a/tests/test_basics/scripts/indexing.Rev
+++ b/tests/test_basics/scripts/indexing.Rev
@@ -1,0 +1,21 @@
+## continue-on-error
+print("> x[0]")
+x[0]        
+print("> x[1]")
+x[1]
+
+print("> x[-1] = -1")
+x[-1] = -1
+print("> x[0] = 0")
+x[0] = 0        
+print("> x[1] = 1")
+x[1] = 1
+print("> x[2] = -2")
+x[2] = -2
+print("> print(x)")        
+print(x)        
+
+print("> x[1.5]")
+x[1.5]
+print("> x[1.5] = 1")
+x[1.5] = 1


### PR DESCRIPTION
This PR fixes issue #855.  The issue is that `abs(-3)` returns RealPos instead of Natural, and also subscripting by Reals doesn't work -- it does a bad typecast and ends up treating the real subscript as zero.  Additionally, it seems that errors in interactive mode were causing the interpreter to quit?

Each commit/patch pretty much does what it says in the title.