### PR TITLE
Allow specifying `tuningInterval = 0` in `powerPosterior.burnin()`

### DIFF
--- a/src/core/analysis/PowerPosteriorAnalysis.cpp
+++ b/src/core/analysis/PowerPosteriorAnalysis.cpp
@@ -119,13 +119,10 @@ void PowerPosteriorAnalysis::burnin(size_t generations, size_t tuningInterval)
         sampler->nextCycle(false);
             
         // check for autotuning
-        if ( k % tuningInterval == 0 && k != generations )
+        if ( tuningInterval != 0 && (k % tuningInterval) == 0 && k != generations )
         {
-                
             sampler->tune();
-            
         }
-        
     }
     
     


### PR DESCRIPTION
The fix that PR #843 provided for `mcmc()` is here also implemented for `powerPosterior()`.