### PR TITLE
Update macOS runner images

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,8 @@ jobs:
                ubuntu-gcc-15,
                ubuntu-gcc-15-debugoptimized,
                ubuntu-clang-15,
-               macos-xcode-15-intel,
-               macos-xcode-16-arm,
+               macos-xcode-16-intel,
+               macos-xcode-26-arm,
                windows
                ]
 
@@ -97,17 +97,17 @@ jobs:
             mpi: false
             arch: linux64
 
-          - name: macos-xcode-15-intel
-            os: macos-13
+          - name: macos-xcode-16-intel
+            os: macos-15-intel
             compiler: xcode
-            version: "15"
+            version: "16"
             mpi: false
             arch: mac-intel64
 
-          - name: macos-xcode-16-arm
-            os: macos-14
+          - name: macos-xcode-26-arm
+            os: macos-latest
             compiler: xcode
-            version: "16"
+            version: "26"
             mpi: false
             arch: mac-arm64
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,8 @@ jobs:
     strategy:
       matrix:
         name: [ubuntu-22.04-gcc-12,
-               macos-xcode-15-intel,
-               macos-xcode-15-arm,
+               macos-xcode-16-intel,
+               macos-xcode-26-arm,
                windows
                ]
 
@@ -61,17 +61,17 @@ jobs:
             mpi: false
             arch: linux64
 
-          - name: macos-xcode-15-intel
-            os: macos-13
+          - name: macos-xcode-16-intel
+            os: macos-15-intel
             compiler: xcode
-            version: "15"
+            version: "16"
             mpi: false
             arch: mac-intel64
 
-          - name: macos-xcode-15-arm
+          - name: macos-xcode-26-arm
             os: macos-14
             compiler: xcode
-            version: "15"
+            version: "26"
             mpi: false
             arch: mac-arm64
 


### PR DESCRIPTION
The macOS 13 runner we are currently using is [deprecated](https://github.com/actions/runner-images/issues/13046), and will be fully phased out in less than a month. This PR replaces the corresponding image label in our workflows (both "build" and "release") with `macos-15-intel`, which is the last macOS runner for the x86_64 architecture and which will continue to be supported [until August 2027](https://github.com/actions/runner-images/issues/13045). Since macOS 15 (Sequoia) doesn't support Xcode 15 without workarounds, I also bumped up the corresponding Xcode version from 15 to 16.

For the ARM64 build, no upgrade is currently necessary, but since it's probably a good idea to keep it up-to-date anyway, I changed the image label from `macos-14` to `macos-latest`, and specified Xcode 26 instead of Xcode 16.