### PR TITLE
Update build.sh for setting boost location with modern cmake

### DIFF
--- a/projects/cmake/build.sh
+++ b/projects/cmake/build.sh
@@ -34,10 +34,7 @@ debug="false"
 mpi="false"
 cmd="false"
 boost_root=""
-boost_lib=""
-boost_include=""
 boost_verbose=""
-boost_debug=""
 static_boost="false"
 j=4
 
@@ -54,21 +51,18 @@ while echo $1 | grep ^- > /dev/null; do
 -mpi            <true|false>    : set to true if you want to build the MPI version. Defaults to false.
 -cmd            <true|false>    : set to true if you want to build RevStudio with GTK2+. Defaults to false.
 -boost_root     string          : specify directory containing Boost headers and libraries (e.g. `/usr/`). Defaults to unset.
--boost_lib      string          : specify directory containing Boost libraries. (e.g. `/usr/lib`). Defaults to unset.
--boost_include  string          : specify directory containing Boost libraries. (e.g. `/usr/include`). Defaults to unset.
 -boost_verbose  <true|false>    : log some info about finding Boost
--boost_debug    <true|false>    : log MORE info about finding Boost
 -static_boost	<true|false>    : link using static Boost libraries. Defaults to false.
 -j              integer         : the number of threads to use when compiling RevBayes. Defaults to 4.
+clean                           : delete the build directory and start from scratch.
 
 You can also specify cmake variables as -DCMAKE_VAR1=value1 -DCMAKE_VAR2=value2
 
 Examples:
-  ./build.sh -mpi true -help2yml true
-  ./build.sh -boost_root /home/santa/installed-boost-1.72
-  ./build.sh -boost_include /home/santa/boost_1_72_0/ -boost_lib /home/santa/boost_1_72_0/stage/lib
-  ./build.sh -DBOOST_ROOT=/home/santa/installed-boost_1.72
-  ./build.sh -mpi true -DBOOST_ROOT=/home/santa/installed-boost_1.72'
+  ./build.sh -mpi true 
+  ./build.sh -ninja true -debug true
+  ./build.sh -boost_root /home/santa/installed-boost-1.89.0
+  ./build.sh -DCMAKE_PREFIX_PATH=/home/santa/installed-boost_1.89.0'
         exit
     fi
 
@@ -84,7 +78,7 @@ Examples:
     esac
 
     # parse pairs
-    eval $( echo $1 | sed 's/-//g' | tr -d '\012')=$2
+    eval $( echo $1 | sed 's/^-//g' | sed 's/-/_/g' | tr -d '\012')=$2
     shift
     shift
 done
@@ -129,29 +123,24 @@ if [ -n "$jupyter" ] ; then
     exit 1
 fi
 
-if [ -n "$boost_lib" ] && [ -n "$boost_include" ] ; then
-    export BOOST_INCLUDEDIR="${boost_include}"
-    export BOOST_LIBRARYDIR="${boost_lib}"
-    unset BOOST_ROOT
-    if [ -n "$boost_root" ] ; then
-        echo "If you specify -boost_lib or -boost_include, then you cannot also specify -boost_root."
+if [ -n "${boost_root}" ] ; then
+    
+    if [ ! -e "${boost_root}" ] ; then
+        echo "Error: path '$boost_root' does not exist!"
+        exit 1
+    elif [ ! -e "${boost_root}/lib" ]  ; then
+        echo "Error: path '$boost_root' does not contain a 'lib' directory.  Is it an installed boost directory?"
+        exit 1
+    elif [ ! -e "${boost_root}/include" ] ; then
+        echo "Error: path '$boost_root' does not contain an 'include' directory.  Is it an installed boost directory?"
         exit 1
     fi
-elif [ -n "$boost_lib" ] || [ -n "$boost_include" ] ; then
-    echo "The flags -boost_lib and -boost_include must be given together"
-    exit 1
-elif [ -n "$boost_root" ] ; then
-    export BOOST_ROOT="${boost_root}"
-    unset BOOST_INCLUDEDIR
-    unset BOOST_LIBRARYDIR
+
+    cmake_args="-DCMAKE_PREFIX_PATH=${boost_root}"
 fi
 
 if [ "$boost_verbose" = "true" ] ; then
     cmake_args="-DBoost_VERBOSE=ON $cmake_args"
-fi
-
-if [ "$boost_debug" = "true" ] ; then
-    cmake_args="-DBoost_DEBUG=ON $cmake_args"
 fi
 
 if [ "$static_boost" = "true" ] ; then
@@ -201,7 +190,7 @@ echo
 # * This can alert the user if some weird values have been set.
 # * This also helps us replicate the call to cmake.
 echo "Note these environment variables:"
-for var in CC CXX CFLAGS CPPFLAGS CXXFLAGS LDFLAGS BOOST_ROOT BOOST_INCLUDEDIR BOOST_LIBRARYDIR ; do
+for var in CC CXX CFLAGS CPPFLAGS CXXFLAGS LDFLAGS BOOST_ROOT BOOST_INCLUDEDIR BOOST_LIBRARYDIR CMAKE_PREFIX_PATH ; do
     cmd="if [ -n \"\${$var}\" ] ; then echo \"  ${var}=\${$var}\"; fi"
     eval $cmd
 done


### PR DESCRIPTION
So apparently build.sh wasn't setting the boost location correctly for modern cmake and modern boost.  We should be setting -DCMAKE_PREFIX_PATH.  The old -DBOOST_ROOT has no effect any more.

Mostly we didn't need to set it, but currently homebrew is pulling in boost 1.90, which is broken.  So try to get this working again.

I also removed some other stuff that doesn't work with modern cmake and modern boost, such as BOOST_INCLUDEDIR and BOOST_LIBRARYDIR