### PR TITLE
Use temp checkpoint file and atomically rename in mcmc. 

### DIFF
--- a/src/core/analysis/mcmc/Mcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmc.cpp
@@ -31,6 +31,7 @@
 #include "RbVector.h"
 #include "RbVectorImpl.h"
 #include "RbSettings.h" // for logMCMC setting
+#include "RlUserInterface.h"
 #include "StringUtilities.h"
 
 #ifdef RB_MPI
@@ -264,6 +265,14 @@ void Mcmc::checkpoint( void ) const
         
         // clean up
         out_stream.close();
+        const bool ok = out_stream.good();
+        if ( !ok )
+        {
+            RBOUT( "Warning: failed to write checkpoint file \"" + checkpoint_file_name.string() + "\"; keeping existing file." );
+            std::error_code ec;
+            std::filesystem::remove(tmp_checkpoint_file_name, ec);
+        }
+        else
 #ifdef _WIN32
         if ( MoveFileExW(tmp_checkpoint_file_name.wstring().c_str(), checkpoint_file_name.wstring().c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) == 0 )
         {
@@ -288,6 +297,14 @@ void Mcmc::checkpoint( void ) const
         
         // clean up
         out_stream_mcmc.close();
+        const bool ok_mcmc = out_stream_mcmc.good();
+        if ( !ok_mcmc )
+        {
+            RBOUT( "Warning: failed to write checkpoint file \"" + mcmc_checkpoint_file_name.string() + "\"; keeping existing file." );
+            std::error_code ec;
+            std::filesystem::remove(tmp_mcmc_checkpoint_file_name, ec);
+        }
+        else
 #ifdef _WIN32
         if ( MoveFileExW(tmp_mcmc_checkpoint_file_name.wstring().c_str(), mcmc_checkpoint_file_name.wstring().c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) == 0 )
         {
@@ -323,6 +340,14 @@ void Mcmc::checkpoint( void ) const
         
         // clean up
         out_stream_moves.close();
+        const bool ok_moves = out_stream_moves.good();
+        if ( !ok_moves )
+        {
+            RBOUT( "Warning: failed to write checkpoint file \"" + moves_checkpoint_file_name.string() + "\"; keeping existing file." );
+            std::error_code ec;
+            std::filesystem::remove(tmp_moves_checkpoint_file_name, ec);
+        }
+        else
 #ifdef _WIN32
         if ( MoveFileExW(tmp_moves_checkpoint_file_name.wstring().c_str(), moves_checkpoint_file_name.wstring().c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) == 0 )
         {

--- a/src/core/analysis/mcmc/Mcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmc.cpp
@@ -37,6 +37,10 @@
 #include <mpi.h>
 #endif
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 
 using namespace RevBayesCore;
 
@@ -212,8 +216,9 @@ void Mcmc::checkpoint( void ) const
         // the following is useful for ensuring that in MCMCMC analyses, the chain indices in the checkpoint file names are ordered by heat:
         // std::cout << "Printing file " << checkpoint_file_name << " for chain with a posterior heat of " << getChainPosteriorHeat() << std::endl;
         
+        path tmp_checkpoint_file_name = checkpoint_file_name.parent_path() / ("." + checkpoint_file_name.filename().string() + ".tmp");
         // open the stream to the file
-        std::ofstream out_stream( checkpoint_file_name.string() );
+        std::ofstream out_stream( tmp_checkpoint_file_name.string() );
 
         // first, we write the names of the variables
         for (std::vector<DagNode *>::const_iterator it=variable_nodes.begin(); it!=variable_nodes.end(); ++it)
@@ -259,6 +264,14 @@ void Mcmc::checkpoint( void ) const
         
         // clean up
         out_stream.close();
+#ifdef _WIN32
+        if ( MoveFileExW(tmp_checkpoint_file_name.wstring().c_str(), checkpoint_file_name.wstring().c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) == 0 )
+        {
+            throw RbException() << "Could not replace checkpoint file " << checkpoint_file_name;
+        }
+#else
+        std::filesystem::rename(tmp_checkpoint_file_name, checkpoint_file_name);
+#endif
         
         
         /////////
@@ -268,12 +281,21 @@ void Mcmc::checkpoint( void ) const
         // assemble the new filename
         path mcmc_checkpoint_file_name = appendToStem(checkpoint_file_name, "_mcmc");
         
+        path tmp_mcmc_checkpoint_file_name = mcmc_checkpoint_file_name.parent_path() / ("." + mcmc_checkpoint_file_name.filename().string() + ".tmp");
         // open the stream to the file
-        std::ofstream out_stream_mcmc( mcmc_checkpoint_file_name.string() );
+        std::ofstream out_stream_mcmc( tmp_mcmc_checkpoint_file_name.string() );
         out_stream_mcmc << "iter = " << generation << std::endl;
         
         // clean up
         out_stream_mcmc.close();
+#ifdef _WIN32
+        if ( MoveFileExW(tmp_mcmc_checkpoint_file_name.wstring().c_str(), mcmc_checkpoint_file_name.wstring().c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) == 0 )
+        {
+            throw RbException() << "Could not replace checkpoint file " << mcmc_checkpoint_file_name;
+        }
+#else
+        std::filesystem::rename(tmp_mcmc_checkpoint_file_name, mcmc_checkpoint_file_name);
+#endif
         
         
         /////////
@@ -283,8 +305,9 @@ void Mcmc::checkpoint( void ) const
         // assemble the new filename
         path moves_checkpoint_file_name = appendToStem(checkpoint_file_name, "_moves");
         
+        path tmp_moves_checkpoint_file_name = moves_checkpoint_file_name.parent_path() / ("." + moves_checkpoint_file_name.filename().string() + ".tmp");
         // open the stream to the file
-        std::ofstream out_stream_moves( moves_checkpoint_file_name.string() );
+        std::ofstream out_stream_moves( tmp_moves_checkpoint_file_name.string() );
         
         for (size_t i = 0; i < moves.size(); ++i)
         {
@@ -300,6 +323,14 @@ void Mcmc::checkpoint( void ) const
         
         // clean up
         out_stream_moves.close();
+#ifdef _WIN32
+        if ( MoveFileExW(tmp_moves_checkpoint_file_name.wstring().c_str(), moves_checkpoint_file_name.wstring().c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) == 0 )
+        {
+            throw RbException() << "Could not replace checkpoint file " << moves_checkpoint_file_name;
+        }
+#else
+        std::filesystem::rename(tmp_moves_checkpoint_file_name, moves_checkpoint_file_name);
+#endif
     }
     
 }
@@ -1435,4 +1466,3 @@ void Mcmc::tune( void )
     }
     
 }
-

--- a/src/core/analysis/mcmc/Mcmcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmcmc.cpp
@@ -29,6 +29,10 @@
 #include "RbVectorImpl.h"
 #include "StringUtilities.h"
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 #ifdef RB_MPI
 #include <mpi.h>
 #endif
@@ -251,11 +255,20 @@ void Mcmcmc::checkpoint( void ) const
             path heat_checkpoint_file_name = appendToStem(chain_file_name, "_heat");
             
             // open the stream to the file
-            std::ofstream out_stream_mcmc( heat_checkpoint_file_name.string() );
+            path tmp_heat_checkpoint_file_name = heat_checkpoint_file_name.parent_path() / ("." + heat_checkpoint_file_name.filename().string() + ".tmp");
+            std::ofstream out_stream_mcmc( tmp_heat_checkpoint_file_name.string() );
             out_stream_mcmc << "heat = " << chains[i]->getChainPosteriorHeat() << std::endl;
             
             // clean up
             out_stream_mcmc.close();
+#ifdef _WIN32
+            if ( MoveFileExW(tmp_heat_checkpoint_file_name.wstring().c_str(), heat_checkpoint_file_name.wstring().c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) == 0 )
+            {
+                throw RbException() << "Could not replace checkpoint file " << heat_checkpoint_file_name;
+            }
+#else
+            std::filesystem::rename(tmp_heat_checkpoint_file_name, heat_checkpoint_file_name);
+#endif
         }
         
     }
@@ -2035,4 +2048,3 @@ void Mcmcmc::writeMonitorHeaders( bool screen_monitor_only )
     }
     
 }
-

--- a/src/core/analysis/mcmc/Mcmcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmcmc.cpp
@@ -27,6 +27,7 @@
 #include "RbIteratorImpl.h"
 #include "RbVector.h"
 #include "RbVectorImpl.h"
+#include "RlUserInterface.h"
 #include "StringUtilities.h"
 
 #ifdef _WIN32
@@ -261,6 +262,14 @@ void Mcmcmc::checkpoint( void ) const
             
             // clean up
             out_stream_mcmc.close();
+            const bool ok = out_stream_mcmc.good();
+            if ( !ok )
+            {
+                RBOUT( "Warning: failed to write checkpoint file \"" + heat_checkpoint_file_name.string() + "\"; keeping existing file." );
+                std::error_code ec;
+                std::filesystem::remove(tmp_heat_checkpoint_file_name, ec);
+            }
+            else
 #ifdef _WIN32
             if ( MoveFileExW(tmp_heat_checkpoint_file_name.wstring().c_str(), heat_checkpoint_file_name.wstring().c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) == 0 )
             {


### PR DESCRIPTION
This change makes RevBayes checkpointing more robust against unexpected exits by writing to hidden temporary files and then performing an atomic replace. The main `Mcmc::checkpoint()` now writes to `.<checkpoint>.tmp` (and the associated _mcmc and _moves files) before replacing the original, so a partial write can’t corrupt the prior checkpoint. On Unix this uses `std::filesystem::rename` (atomic on the same filesystem). On Windows it uses `MoveFileExW` with `MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH` to preserve atomic replace semantics.

This may close #930. 