### PR TITLE
Don't drop MPI argument if -boost_root is given

### DIFF
--- a/projects/cmake/build.sh
+++ b/projects/cmake/build.sh
@@ -136,7 +136,7 @@ if [ -n "${boost_root}" ] ; then
         exit 1
     fi
 
-    cmake_args="-DCMAKE_PREFIX_PATH=${boost_root}"
+    cmake_args="-DCMAKE_PREFIX_PATH=${boost_root} $cmake_args"
 fi
 
 if [ "$boost_verbose" = "true" ] ; then


### PR DESCRIPTION
Don't drop MPI argument if -boost_root is given.

Fixes #950 