### PR TITLE
Make `mrcaIndex()`/`getMRCA()` work with `BranchLengthTree`s

### DIFF
--- a/help/md/mrcaIndex.md
+++ b/help/md/mrcaIndex.md
@@ -2,8 +2,18 @@
 mrcaIndex
 ## title
 ## description
+Returns the index of the most recent common ancestor (MRCA) of a given `clade`
+in a given `tree`.
 ## details
 ## authors
+Michael Landis
 ## see_also
+tmrca
 ## example
+    # Read in a tree
+    tr <- readTrees(text="(((Lemur,Galago),Tarsius),((Pan,Homo),Alouatta));")[1]
+    
+    # Find the node index of the MRCA of Pan and Homo
+    mrcaIndex(tr, clade("Homo", "Pan"))
+    
 ## references

--- a/src/core/datatypes/trees/Tree.cpp
+++ b/src/core/datatypes/trees/Tree.cpp
@@ -2342,7 +2342,7 @@ void Tree::suppressOutdegreeOneNodes(bool replace)
 
 void Tree::unroot( void )
 {
-
+    
     if ( isRooted() == true )
     {
 
@@ -2351,29 +2351,35 @@ void Tree::unroot( void )
 
         // make the tree use branch lengths instead of ages
         old_root->setUseAges(false, true);
-
-        size_t child_index = 0;
-        if ( old_root->getChild(child_index).isTip() == true )
+        
+        // if the root has more than two children, we are done: we will just mark the tree as unrooted but not change it otherwise
+        const size_t num_children = old_root->getNumberOfChildren();
+        if (num_children <= 2)
         {
-            child_index = 1;
+            size_t child_index = 0;
+            if ( old_root->getChild(child_index).isTip() == true )
+            {
+                child_index = 1;
+            }
+            TopologyNode *new_root = &old_root->getChild( child_index );
+            TopologyNode *second_child = &old_root->getChild( (child_index == 0 ? 1 : 0) );
+            
+            double bl_first = new_root->getBranchLength();
+            double bl_second = second_child->getBranchLength();
+            
+            old_root->removeChild( new_root );
+            old_root->removeChild( second_child );
+            new_root->setParent( NULL );
+            new_root->addChild( second_child );
+            second_child->setParent( new_root );
+            
+            second_child->setBranchLength( bl_first + bl_second );
+            
+            // finally we need to set the new root
+            setRoot( new_root, true);
         }
-        TopologyNode *new_root = &old_root->getChild( child_index );
-        TopologyNode *second_child = &old_root->getChild( (child_index == 0 ? 1 : 0) );
-
-        double bl_first = new_root->getBranchLength();
-        double bl_second = second_child->getBranchLength();
-
-        old_root->removeChild( new_root );
-        old_root->removeChild( second_child );
-        new_root->setParent( NULL );
-        new_root->addChild( second_child );
-        second_child->setParent( new_root );
-
-        second_child->setBranchLength( bl_first + bl_second );
-
-        // finally we need to set the new root to our tree copy
+        
         setRooted( false );
-        setRoot( new_root, true);
 
     }
 

--- a/src/core/help/RbHelpDatabase.cpp
+++ b/src/core/help/RbHelpDatabase.cpp
@@ -3258,7 +3258,16 @@ print(a) # Value is unchanged in the workspace - only the copy is modified)");
 	help_strings[string("model")][string("name")] = string(R"(model)");
 	help_strings[string("model")][string("title")] = string(R"(Create a model object)");
 	help_strings[string("module")][string("name")] = string(R"(module)");
+	help_arrays[string("mrcaIndex")][string("authors")].push_back(string(R"(Michael Landis)"));
+	help_strings[string("mrcaIndex")][string("description")] = string(R"(Returns the index of the most recent common ancestor (MRCA) of a given `clade`
+in a given `tree`.)");
+	help_strings[string("mrcaIndex")][string("example")] = string(R"(# Read in a tree
+tr <- readTrees(text="(((Lemur,Galago),Tarsius),((Pan,Homo),Alouatta));")[1]
+
+# Find the node index of the MRCA of Pan and Homo
+mrcaIndex(tr, clade("Homo", "Pan")))");
 	help_strings[string("mrcaIndex")][string("name")] = string(R"(mrcaIndex)");
+	help_arrays[string("mrcaIndex")][string("see_also")].push_back(string(R"(tmrca)"));
 	help_strings[string("mvAVMVN")][string("description")] = string(R"(The adaptive variance multivariate-normal proposal of Baele et al. 2017, uses MCMC samples to fit covariance matrix to parameters.
 
 After user-defined waiting time, proposes using covariance matrix epsilon * I + (1 - epsilon) * sigmaSquared * empirical_matrix.

--- a/src/core/statistics/tree/MrcaIndexStatistic.cpp
+++ b/src/core/statistics/tree/MrcaIndexStatistic.cpp
@@ -54,6 +54,10 @@ void MrcaIndexStatistic::initialize( void )
 
 void MrcaIndexStatistic::update( void )
 {
+    if (not tree->getValue().isRooted())
+    {
+        throw RbException("Most recent common ancestor is undefined for unrooted trees.");
+    }
     
     const std::vector<TopologyNode*> &n = tree->getValue().getNodes();
     size_t min_clade_size = n.size() + 2;

--- a/src/core/statistics/tree/MrcaIndexStatistic.cpp
+++ b/src/core/statistics/tree/MrcaIndexStatistic.cpp
@@ -6,7 +6,6 @@
 #include <vector>
 
 #include "RbException.h"
-#include "RbBitSet.h"
 #include "TopologyNode.h"
 #include "Tree.h"
 #include "TypedDagNode.h"
@@ -54,67 +53,23 @@ void MrcaIndexStatistic::initialize( void )
 
 void MrcaIndexStatistic::update( void )
 {
-    if (not tree->getValue().isRooted())
+    if ( not tree->getValue().isRooted() )
     {
         throw RbException("Most recent common ancestor is undefined for unrooted trees.");
     }
-    
-    const std::vector<TopologyNode*> &n = tree->getValue().getNodes();
-    size_t min_clade_size = n.size() + 2;
-    
-    bool found = false;
-    if ( index != -1 )
-    {
-        
-        TopologyNode *node = n[index];
-        size_t cladeSize = size_t( (node->getNumberOfNodesInSubtree(true) + 1) / 2);
-        if ( node->containsClade( clade, false ) == true )
-        {
-            
-            if ( taxa_count == cladeSize )
-            {
-                found = true;
-            }
-            else
-            {
-                min_clade_size = cladeSize;
-            }
-            
-        }
-        
-    }
-    
-    
-    if ( found == false )
-    {
-        
-        for (size_t i = tree->getValue().getNumberOfTips(); i < n.size(); ++i)
-        {
-            
-            TopologyNode *node = n[i];
-            size_t clade_size = size_t( (node->getNumberOfNodesInSubtree(true) + 1) / 2);
-            if ( clade_size < min_clade_size && clade_size >= taxa_count && node->containsClade( clade, false ) )
-            {
-                
-                index = (int)node->getIndex();
-                min_clade_size = clade_size;
-                if ( taxa_count == clade_size )
-                {
-                    break;
-                }
-                
-            }
-            
-        }
-        
-    }
-    
-    if ( index == -1 )
+
+    const Tree& t = tree->getValue();
+    const TopologyNode& root = t.getRoot();
+    const TopologyNode* node = root.getMrca( clade );
+
+    if ( node == NULL )
     {
         throw RbException("MrcaIndex-Statistics can only be applied if clade is present.");
     }
-    
-    *value = index;
+
+    index = static_cast<int>( node->getIndex() );
+    // Return 1-based index so that .getDescendantTaxa() and other Tree methods expecting 1-based node indices work
+    *value = index + 1;
 }
 
 

--- a/src/revlanguage/datatypes/phylogenetics/trees/RlBranchLengthTree.cpp
+++ b/src/revlanguage/datatypes/phylogenetics/trees/RlBranchLengthTree.cpp
@@ -81,6 +81,21 @@ RevLanguage::RevPtr<RevLanguage::RevVariable> BranchLengthTree::executeMethod(st
         
         return new RevVariable( new TimeTree( tree ) );
     }
+    else if (name == "unroot")
+    {
+        found = true;
+        
+        RevBayesCore::Tree &tree = dag_node->getValue();
+        
+        if ( not tree.isRooted() )
+        {
+            throw RbException("The tree is already unrooted.");
+        }
+        
+        tree.unroot();
+        
+        return NULL;
+    }
     
     return Tree::executeMethod( name, args, found );
 }
@@ -120,4 +135,7 @@ void BranchLengthTree::initMethods( void )
 {
     ArgumentRules* makeUltraArgRules = new ArgumentRules();
     methods.addFunction( new MemberProcedure( "makeUltrametric", RlUtils::Void, makeUltraArgRules ) );
+    
+    ArgumentRules* unrootArgRules = new ArgumentRules();
+    methods.addFunction( new MemberProcedure( "unroot", RlUtils::Void, unrootArgRules ) );
 }

--- a/src/revlanguage/datatypes/phylogenetics/trees/RlTree.cpp
+++ b/src/revlanguage/datatypes/phylogenetics/trees/RlTree.cpp
@@ -257,6 +257,13 @@ RevLanguage::RevPtr<RevLanguage::RevVariable> Tree::executeMethod(std::string co
         bool tf = this->dag_node->getValue().getNode((size_t)index).isInternal();
         return new RevVariable( new RlBoolean( tf ) );
     }
+    else if (name == "isRooted")
+    {
+        found = true;
+        
+        bool tf = this->dag_node->getValue().isRooted();
+        return new RevVariable( new RlBoolean( tf ) );
+    }
     else if (name == "names" || name == "taxa")
     {
         found = true;
@@ -471,6 +478,9 @@ void Tree::initMethods( void )
     ArgumentRules* isInternalArgRules = new ArgumentRules();
     isInternalArgRules->push_back( new ArgumentRule( "node", Natural::getClassTypeSpec(), "The index of the node.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
     methods.addFunction( new MemberProcedure( "isInternal", RlBoolean::getClassTypeSpec(), isInternalArgRules ) );
+    
+    ArgumentRules* isRootedArgRules = new ArgumentRules();
+    methods.addFunction( new MemberProcedure( "isRooted", RlBoolean::getClassTypeSpec(), isRootedArgRules ) );
 
     ArgumentRules* same_topology_arg_rules = new ArgumentRules();
     same_topology_arg_rules->push_back(        new ArgumentRule("tree"    , Tree::getClassTypeSpec(), "The reference tree.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );

--- a/src/revlanguage/functions/io/Func_readTreeTrace.cpp
+++ b/src/revlanguage/functions/io/Func_readTreeTrace.cpp
@@ -531,6 +531,10 @@ WorkspaceVector<TraceTree>* Func_readTreeTrace::readTreesNexus(const std::vector
                         tree->removeRootIfDegree2();
                         tree->setRooted(false);
                     }
+                    else
+                    {
+                        tree->setRooted(true);
+                    }
 
                     tt.addObject(tree);
                 }

--- a/src/revlanguage/functions/io/Func_readTrees.cpp
+++ b/src/revlanguage/functions/io/Func_readTrees.cpp
@@ -91,7 +91,10 @@ RevPtr<RevVariable> Func_readTrees::execute( void )
                     if (unroot_nonclock)
                     {
                         tree->removeRootIfDegree2();
-                        tree->setRooted(false);
+                    }
+                    else
+                    {
+                        tree->setRooted(true);
                     }
 
                     trees->push_back( BranchLengthTree(*tree) );
@@ -142,7 +145,10 @@ RevPtr<RevVariable> Func_readTrees::execute( void )
                 if (unroot_nonclock)
                 {
                     blTree->removeRootIfDegree2();
-                    blTree->setRooted(false);
+                }
+                else
+                {
+                    blTree->setRooted(true);
                 }
 
                 trees->push_back( BranchLengthTree(*blTree) );

--- a/src/revlanguage/functions/io/Func_readTrees.cpp
+++ b/src/revlanguage/functions/io/Func_readTrees.cpp
@@ -91,6 +91,7 @@ RevPtr<RevVariable> Func_readTrees::execute( void )
                     if (unroot_nonclock)
                     {
                         tree->removeRootIfDegree2();
+                        tree->setRooted(false);
                     }
                     else
                     {
@@ -145,6 +146,7 @@ RevPtr<RevVariable> Func_readTrees::execute( void )
                 if (unroot_nonclock)
                 {
                     blTree->removeRootIfDegree2();
+                    blTree->setRooted(false);
                 }
                 else
                 {

--- a/src/revlanguage/functions/phylogenetics/tree/Func_mrcaIndex.cpp
+++ b/src/revlanguage/functions/phylogenetics/tree/Func_mrcaIndex.cpp
@@ -3,7 +3,6 @@
 //  RevLanguage
 //
 //  Created by Michael Landis on 8/19/14.
-//  Copyright 2012 __MyCompanyName__. All rights reserved.
 //
 
 #include <iosfwd>
@@ -13,7 +12,7 @@
 #include "Func_mrcaIndex.h"
 #include "Natural.h"
 #include "RlClade.h"
-#include "RlTimeTree.h"
+#include "RlTree.h"
 #include "RlDeterministicNode.h"
 #include "MrcaIndexStatistic.h"
 #include "TypedDagNode.h"
@@ -57,7 +56,7 @@ Func_mrcaIndex* Func_mrcaIndex::clone( void ) const
 RevBayesCore::TypedFunction<std::int64_t>* Func_mrcaIndex::createFunction( void ) const
 {
     
-    RevBayesCore::TypedDagNode<RevBayesCore::Tree>* tau = static_cast<const TimeTree&>( this->args[0].getVariable()->getRevObject() ).getDagNode();
+    RevBayesCore::TypedDagNode<RevBayesCore::Tree>* tau = static_cast<const Tree&>( this->args[0].getVariable()->getRevObject() ).getDagNode();
     const RevBayesCore::Clade& c = static_cast<const Clade &>( this->args[1].getVariable()->getRevObject() ).getValue();
     RevBayesCore::MrcaIndexStatistic* f = new RevBayesCore::MrcaIndexStatistic( tau, c );
     
@@ -70,13 +69,13 @@ const ArgumentRules& Func_mrcaIndex::getArgumentRules( void ) const
 {
     
     static ArgumentRules argumentRules = ArgumentRules();
-    static bool          rules_set = false;
+    static bool rules_set = false;
     
     if ( !rules_set )
     {
         
-        argumentRules.push_back( new ArgumentRule( "tree" , TimeTree::getClassTypeSpec(), "The tree which is used to compute the MRCA.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
-        argumentRules.push_back( new ArgumentRule( "clade", Clade::getClassTypeSpec()   , "The clade for which the MRCA is searched.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
+        argumentRules.push_back( new ArgumentRule( "tree" , Tree::getClassTypeSpec(),  "The tree which is used to compute the MRCA.", ArgumentRule::BY_CONSTANT_REFERENCE, ArgumentRule::ANY ) );
+        argumentRules.push_back( new ArgumentRule( "clade", Clade::getClassTypeSpec(), "The clade for which the MRCA is searched.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
         
         rules_set = true;
     }
@@ -113,6 +112,16 @@ std::string Func_mrcaIndex::getFunctionName( void ) const
     std::string f_name = "mrcaIndex";
     
     return f_name;
+}
+
+
+std::vector<std::string> Func_mrcaIndex::getFunctionNameAliases( void ) const
+{
+    std::vector<std::string> aliases;
+
+    aliases.push_back("getMRCA");
+
+    return aliases;
 }
 
 

--- a/src/revlanguage/functions/phylogenetics/tree/Func_mrcaIndex.h
+++ b/src/revlanguage/functions/phylogenetics/tree/Func_mrcaIndex.h
@@ -34,10 +34,11 @@ namespace RevLanguage {
         static const std::string&                       getClassType(void);                                         //!< Get Rev type
         static const TypeSpec&                          getClassTypeSpec(void);                                     //!< Get class type spec
         std::string                                     getFunctionName(void) const;                                //!< Get the primary name of the function in Rev
+        std::vector<std::string>                        getFunctionNameAliases( void ) const;                       //!< Get aliases for the Rev name of the function
         const TypeSpec&                                 getTypeSpec(void) const;                                    //!< Get the type spec of the instance
         
         // Function functions you have to override
-        RevBayesCore::TypedFunction<std::int64_t>*               createFunction(void) const;                                 //!< Create internal function object
+        RevBayesCore::TypedFunction<std::int64_t>*      createFunction(void) const;                                 //!< Create internal function object
         const ArgumentRules&                            getArgumentRules(void) const;                               //!< Get argument rules
         
     };


### PR DESCRIPTION
I was mildly horrified at the thought that we don't have a free-standing `getMRCA()` function – I had to grep through the documentation to find out that we do actually have it, but call it `mrcaIndex()`. Unfortunately, it can only be called on `TimeTree`s. I don't think there is a good reason for that.

This PR:

1. Makes `mrcaIndex()` work for both `TimeTree`s and `BranchLengthTree`s;
2. Adds `getMRCA()` as its alias.
3. Adds a help page for the function.