### PR TITLE
Ensure we start the interactive loop with -i is given

### DIFF
--- a/src/revlanguage/RevLanguageMain.cpp
+++ b/src/revlanguage/RevLanguageMain.cpp
@@ -26,7 +26,7 @@ RevLanguageMain::RevLanguageMain(bool c, bool e, bool q)
 }
 
 
-void RevLanguageMain::startRevLanguageEnvironment(const std::vector<std::string> &expressions, const std::optional<std::string>& filename, const std::vector<std::string> &args)
+int RevLanguageMain::startRevLanguageEnvironment(const std::vector<std::string> &expressions, const std::optional<std::string>& filename, const std::vector<std::string> &args)
 {
     auto& settings = RbSettings::userSettings();
 
@@ -85,9 +85,7 @@ void RevLanguageMain::startRevLanguageEnvironment(const std::vector<std::string>
         // We just hope for better input next time
         if ( result == 2 and not continue_on_error )
         {
-            RevClient::shutdown();
-                
-            exit(1);
+            return 1; // exit(1)
         }
     }
 
@@ -103,9 +101,7 @@ void RevLanguageMain::startRevLanguageEnvironment(const std::vector<std::string>
         // We just hope for better input next time
         if (result == 2 and not continue_on_error)
         {
-            RevClient::shutdown();
-                
-            exit(1);
+            return 1; // exit(1)
         }
     }
 
@@ -124,7 +120,7 @@ void RevLanguageMain::startRevLanguageEnvironment(const std::vector<std::string>
             e.print(msg);
             RBOUT(msg.str());
         }
-        std::exit(1);
+        return 1; // exit(1)
     }
     catch (const std::exception& e)
     {
@@ -132,7 +128,7 @@ void RevLanguageMain::startRevLanguageEnvironment(const std::vector<std::string>
         {
             RBOUT(e.what());
         }
-        std::exit(1);
+        return 1; // exit(1)
     }
     catch (...)
     {
@@ -140,8 +136,9 @@ void RevLanguageMain::startRevLanguageEnvironment(const std::vector<std::string>
         {
             RBOUT("Error:\tunknown exception!");
         }
-        std::exit(1);
+        return 1; // exit(1)
     }
     
+    return 0;
 }
 

--- a/src/revlanguage/RevLanguageMain.h
+++ b/src/revlanguage/RevLanguageMain.h
@@ -28,7 +28,7 @@ public:
     
     RevLanguageMain(bool e, bool c, bool q);
     
-    void startRevLanguageEnvironment(const std::vector<std::string> &expressions, const std::optional<std::string>& filename, const std::vector<std::string> &args);
+    int startRevLanguageEnvironment(const std::vector<std::string> &expressions, const std::optional<std::string>& filename, const std::vector<std::string> &args);
 
 private:
     

--- a/src/revlanguage/main.cpp
+++ b/src/revlanguage/main.cpp
@@ -251,13 +251,17 @@ int main(int argc, char* argv[])
     RevLanguage::UserInterface::userInterface().setOutputStream( rev_output );
 
     /* Any script or expressions from `-e expr` are executed here. */
-    rl.startRevLanguageEnvironment(cmd_line.expressions, cmd_line.filename, cmd_line.args);
+    int result = rl.startRevLanguageEnvironment(cmd_line.expressions, cmd_line.filename, cmd_line.args);
 
+    /* Don't do anything if we encountered an error and aren't interactive */
+    if (result != 0 and not cmd_line.force_interactive)
+        ;
     /* Interactive or jupyter commands are executed here. */
-    if ( cmd_line.jupyter )
+    else if ( cmd_line.jupyter )
     {
         RevClient::startJupyterInterpreter();
     }
+    /* Start the interactive loop or there's no script or we are told to do so */
     else if ( not cmd_line.script_or_expr() or cmd_line.force_interactive )
     {
         enableTermAnsi();
@@ -265,11 +269,10 @@ int main(int argc, char* argv[])
         RevClient::startInterpreter();
     }
 
-#   ifdef RB_MPI
-    MPI_Finalize();
-#   endif
-
-    return 0;
+    // MPI finalize is called here.
+    RevClient::shutdown();
+    
+    return result;
 }
 
 #endif


### PR DESCRIPTION
When a `-i` or `--interactive` is given, we should start the interactive loop -- even if there is an error.

So `RevLanguageMain::startRevLanguageEnvironment( )` should not call `std::exit(1)` when we see an error.  Make it pass back any error results to the caller instead, and let the caller decide if/when to quit.