### PR TITLE
Add -p flag to print commands from -e expression or script

### DIFF
--- a/src/libs/range-v3/meta/meta.hpp
+++ b/src/libs/range-v3/meta/meta.hpp
@@ -3778,7 +3778,7 @@ namespace meta
         /// \ingroup integral
         template <char... Chs>
         constexpr fold<list<char_<Chs>...>, meta::size_t<0>, quote<detail::atoi_>>
-            operator"" _z()
+            operator""_z()
         {
             return {};
         }

--- a/src/revlanguage/RevLanguageMain.cpp
+++ b/src/revlanguage/RevLanguageMain.cpp
@@ -94,7 +94,7 @@ int RevLanguageMain::startRevLanguageEnvironment(const std::vector<std::string> 
     {
         // Should we be using RBOUT here?  It looks weird with the 2 spaces of padding.
         if (echo and rank == 0)
-            std::cerr<<"> "<<expression<<"\n";
+            std::cout<<"> "<<expression<<"\n";
 
         int result = RevLanguage::Parser::getParser().processCommand(expression, RevLanguage::Workspace::userWorkspacePtr());
         

--- a/src/revlanguage/main.cpp
+++ b/src/revlanguage/main.cpp
@@ -44,9 +44,10 @@ struct ParsedOptions
 
     bool script_or_expr() const {return filename or not expressions.empty();}
 
-    bool force_interactive = false;       /* Force interactive if script_or_expr() == true. */
-    bool force_continue_on_error = false; /* Force continue-on-error if script_or_expr() == true. */
-    bool force_quiet = false;             /* Suppress header if script_or_expr() == false */
+    bool force_interactive = false;          /* Force interactive if script_or_expr() == true. */
+    bool force_continue_on_error = false;    /* Force continue-on-error if script_or_expr() == true. */
+    bool force_quiet = false;                /* Suppress header if script_or_expr() == false */
+    bool echo_script_or_expression = false;  /* Echo commands from scripts or expressions */
 
     bool jupyter = false;
 
@@ -100,9 +101,10 @@ ParsedOptions parse_cmd_line(int argc, char* argv[])
     stage1.add_flag("-v,--version",          options.version,         "Show version and exit");
     stage1.add_flag("-j,--jupyter",          options.jupyter,         "Run in jupyter mode");
 
-    stage1.add_flag("-q,--quiet",            options.force_quiet,             "Hide startup message (if no file or -e expr)");
-    stage1.add_flag("-i,--interactive",      options.force_interactive,       "Force interactive (with file or -e expr)");
-    stage1.add_flag("-c,--continue",         options.force_continue_on_error, "Continue after error (with file or -e expr)");
+    stage1.add_flag("-q,--quiet",            options.force_quiet,               "Hide startup message (if no file or -e expr)");
+    stage1.add_flag("-i,--interactive",      options.force_interactive,         "Force interactive (with file or -e expr)");
+    stage1.add_flag("-c,--continue",         options.force_continue_on_error,   "Continue after error (with file or -e expr)");
+    stage1.add_flag("-p,--print-commands",   options.echo_script_or_expression, "Print commands from file or -e expr");
 
     stage1.add_option("-s,--seed",           options.seed,            "Random seed (unsigned integer)");
     stage1.add_option("-o,--setOption",      options.options,         "Set an option key=value  (See ?setOption for the list of available keys and their associated values)")->allow_extra_args(false);
@@ -243,7 +245,7 @@ int main(int argc, char* argv[])
 
     /* initialize environment */
     RevLanguageMain rl = RevLanguageMain(cmd_line.force_continue_on_error,
-                                         false, /* echo */
+                                         cmd_line.echo_script_or_expression,
                                          cmd_line.force_quiet);
 
     /* Set output stream */

--- a/src/revlanguage/ui/RevClient.cpp
+++ b/src/revlanguage/ui/RevClient.cpp
@@ -34,8 +34,8 @@ extern "C" {
 #include "RbException.h"
 //#define ctrl(C) ((C) - '@')
 
-const char* default_prompt = (char*) "> ";
-const char* incomplete_prompt = (char*) "+ ";
+const char* default_prompt = (const char*) "> ";
+const char* incomplete_prompt = (const char*) "+ ";
 const char* prompt = default_prompt;
 
 using namespace RevLanguage;
@@ -351,17 +351,19 @@ void execute_file(const fs::path& filename, bool echo, bool continue_on_error)
         // Read a line
         std::string line;
         RevBayesCore::safeGetline(inFile, line);
+        // Don't execute an empty line at the end of the file
+        if (line.empty() and not inFile.good()) break;
+
         lineNumber++;
-        
         if ( echo )
         {
             if ( result == 1 )
             {
-                std::cout << "+ " << line << std:: endl;
+                std::cout << incomplete_prompt << line << std:: endl;
             }
             else
             {
-                std::cout << "> " << line << std::endl;
+                std::cout << default_prompt << line << std::endl;
             }
         }
         
@@ -525,11 +527,11 @@ void startJupyterInterpreter()
         {
             if (result == 0 || result == 2)
             {
-                std::cout << "> ";
+                std::cout << default_prompt ;
             }
             else
             {
-                std::cout << "+ ";
+                std::cout << incomplete_prompt;
             }
 
             /* Get the line */

--- a/src/revlanguage/ui/RevClient.cpp
+++ b/src/revlanguage/ui/RevClient.cpp
@@ -339,6 +339,11 @@ void shutdown()
 
 void execute_file(const fs::path& filename, bool echo, bool continue_on_error)
 {
+    int rank = 0;
+#ifdef RB_MPI
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+#endif
+
     auto& settings = RbSettings::userSettings();
     std::stringstream inFile = RevBayesCore::readFileAsStringStream(filename);
 
@@ -355,7 +360,7 @@ void execute_file(const fs::path& filename, bool echo, bool continue_on_error)
         if (line.empty() and not inFile.good()) break;
 
         lineNumber++;
-        if ( echo )
+        if ( echo and rank == 0 )
         {
             if ( result == 1 )
             {

--- a/tests/run_integration_tests.sh
+++ b/tests/run_integration_tests.sh
@@ -131,6 +131,9 @@ for t in ${TESTS}; do
         if grep "^## continue-on-error" "$f" 2>&1 >/dev/null ; then
             rb_options="-c"
         fi
+        if grep "^## print-commands" "$f" 2>&1 >/dev/null ; then
+            rb_options="$rb_options -p"
+        fi
         ${rb_exec[@]} ${rb_options} $f &> output/${script_name}.errout # print output so we can see any error messages
         script_result="$?"
 

--- a/tests/test_basics/output_expected/indexing.errout
+++ b/tests/test_basics/output_expected/indexing.errout
@@ -1,7 +1,10 @@
+> ## continue-on-error
+> ## print-commands
 > x[0]
    Missing Variable:	Variable x does not exist
 > x[1]
    Missing Variable:	Variable x does not exist
+> 
 > x[-1] = -1
    Error:	Index -1 not allowed in 'x[-1]'.  The first element should be 'x[1]'
 > x[0] = 0
@@ -10,6 +13,7 @@
 > x[2] = -2
 > print(x)
 1,-2
+> 
 > x[1.5]
    Error:	Argument or label mismatch for function call.
    Arguments which could not be matched (we stopped after the first mismatch):

--- a/tests/test_basics/scripts/indexing.Rev
+++ b/tests/test_basics/scripts/indexing.Rev
@@ -1,21 +1,13 @@
 ## continue-on-error
-print("> x[0]")
-x[0]        
-print("> x[1]")
+## print-commands
+x[0]
 x[1]
 
-print("> x[-1] = -1")
 x[-1] = -1
-print("> x[0] = 0")
-x[0] = 0        
-print("> x[1] = 1")
+x[0] = 0
 x[1] = 1
-print("> x[2] = -2")
 x[2] = -2
-print("> print(x)")        
-print(x)        
+print(x)
 
-print("> x[1.5]")
 x[1.5]
-print("> x[1.5] = 1")
 x[1.5] = 1


### PR DESCRIPTION
Sometimes its nice to have revbayes print the commands that its executing from a script, so that you can see what its doing, and when it is doing it. This is conceptually similar to the `-x` flag for bash, which prints all the actions for debugging purposes.  And also its similar to what happens when we are interactive.

This PR adds a flag `-p` or `--print-commands` to do that.  With `-p`, executing the file
```
1+1
x=2
x
```
yields output like:
```
> 1+1
   2
> x=2
> x
   2
```
Running `rb -p -e '1+1' -e 'x=2' -e x` shows exactly the same output.  Running `rb -pi script` shows the same output and then starts an interactive session right underneath.  **If the  script stops with an error, this should make it a bit clearer which line has the error.**

The `-p` flag has no effect on interactive execution, where the terminal is responsible for printing what you type.

The `--help` line for `-p` looks like this:
```
  -p,      --print-commands        Print commands from file or -e expr
```
The entire help from `rb --help` looks like this:
```
Bayesian phylogenetic inference using probabilistic graphical models and an 
interpreted language 

Usage: rb [options]
       rb [options] file [args]
       rb [options] -e expr [-e expr2 ...] [args]

OPTIONS:
  -h,      --help                  Print this help message and exit 
  -v,      --version               Show version and exit 
  -j,      --jupyter               Run in jupyter mode 
  -q,      --quiet                 Hide startup message (if no file or -e expr) 
  -i,      --interactive           Force interactive (with file or -e expr) 
  -c,      --continue              Continue after error (with file or -e expr) 
  -p,      --print-commands        Print commands from file or -e expr
  -s,      --seed UINT             Random seed (unsigned integer) 
  -o,      --setOption TEXT ...    Set an option key=value (See ?setOption for 
                                   the list of available keys and their 
                                   associated values) 

Expressions (one or more '-e <expr>') may be used *instead* of 'file'. 
See http://revbayes.github.io for more information. 
```
