### PR TITLE
Disable `dnUPP` temporarily

### DIFF
--- a/src/revlanguage/distributions/mixture/Dist_upp.h
+++ b/src/revlanguage/distributions/mixture/Dist_upp.h
@@ -89,6 +89,8 @@ template <typename valType>
 RevBayesCore::UniformPartitioningDistribution<typename valType::valueType>* RevLanguage::Dist_upp<valType>::createDistribution( void ) const
 {
 	
+    throw RbException("Uniform partitioning distribution currently disabled due to invalid calculations.");
+    
     // get the parameters
     RevBayesCore::TypedDagNode< RevBayesCore::RbVector<typename valType::valueType> >* v   = static_cast<const ModelVector<valType> &>( values->getRevObject() ).getDagNode();
     bool iz = static_cast<const RlBoolean &>(include_zero->getRevObject()).getValue();


### PR DESCRIPTION
This PR makes it impossible to use the uniform partitioning distribution (`dnUPP`).

We know that this distribution doesn't correctly propagate updates to parameter values through the DAG, although that might be at least in part due to problems with the corresponding move, `mvUPPAllocation`: see issue #499 and PR #407, which represented an unsuccessful attempt to fix it.

Moreover, in a recent attempt to fix compiler warnings (#998), I found that the distribution's `setValue()` function was broken: it attempted to do something more than the base class implementation, but since it did not properly override the latter, the extra code was never executed. To make things worse, it's not entirely clear (to me, at least) what this code was meant to do. While existing scripts utilizing `dnUPP` don't seem to involve clamping the distribution, this is still a substantial problem.

For the time being, the best solution therefore seems to be to disable the distribution, following the precedent set by PR #449. Since the distribution was used in at least two published papers (see #499 for details), we probably shouldn't remove it altogether.