### PR TITLE
More options for resolving multifurcations in `BranchLengthTree`s

### DIFF
--- a/src/core/datatypes/trees/TopologyNode.cpp
+++ b/src/core/datatypes/trees/TopologyNode.cpp
@@ -1904,7 +1904,7 @@ void TopologyNode::renameNodeParameter(const std::string &old_name, const std::s
 }
 
 
-void TopologyNode::resolveMultifurcation(bool resolve_root)
+void TopologyNode::resolveMultifurcation(bool resolve_root, bool halve_branch_length)
 {
     if (children.size() < 3) return;
 
@@ -2050,12 +2050,39 @@ void TopologyNode::resolveMultifurcation(bool resolve_root)
 
             // create a parent for the two
             TopologyNode* prnt = new TopologyNode(); // leave the new node without index
-            
-            if (not std::isnan(branch_length))
+
+            // halve_branch_length: get a nonzero length for the new edge this->prnt; snapshot branch_length
+            // as b_in before setBranchLength (it mutates this node's member).
+            if ( halve_branch_length )
+            {
+                const double b_in = branch_length;
+                double pl = leftChild->getBranchLength();
+                double pr = rightChild->getBranchLength();
+                if ( std::isnan(pl) ) pl = 0.0;
+                if ( std::isnan(pr) ) pr = 0.0;
+
+                // (1) If this polytomy has a positive-length subtending branch, split it with this->prnt.
+                // (2) Otherwise (root, or zero/NaN length of the subtending branch): take length from the
+                //     two merged child branches (same as a trifurcating root in makeRootBifurcating).
+                const bool subtending_ok = ( not std::isnan(b_in) && b_in > 0.0 );
+
+                if ( subtending_ok )
+                {
+                    setBranchLength(0.5 * b_in);
+                    prnt->setBranchLength(0.5 * b_in);
+                }
+                else if ( pl > 0.0 || pr > 0.0 )
+                {
+                    prnt->setBranchLength( 0.5 * (pl + pr) );
+                    leftChild->setBranchLength( 0.5 * pl );
+                    rightChild->setBranchLength( 0.5 * pr );
+                }
+            }
+            else if ( not std::isnan(branch_length) )
             {
                 prnt->setBranchLength(0.0);          // set the length of the branch subtending it to zero
             }
-            
+
             prnt->addChild( leftChild );
             prnt->addChild( rightChild );
             leftChild->setParent( prnt );

--- a/src/core/datatypes/trees/TopologyNode.h
+++ b/src/core/datatypes/trees/TopologyNode.h
@@ -164,7 +164,7 @@ namespace RevBayesCore {
         void                                        removeAllChildren(void);                                                            //!< Removes all of the children of the node
         size_t                                      removeChild(TopologyNode* c);                                                       //!< Removes a specific child
         void                                        removeTree(Tree *t);                                                                //!< Removes the tree pointer
-        void                                        resolveMultifurcation(bool resolve_root = true);                                    //!< If node has more than 2 children, randomly resolve them into a bifurcating subtree
+        void                                        resolveMultifurcation(bool resolve_root = true, bool halve_branch_length = false);  //!< If node has more than 2 children, randomly resolve them into a bifurcating subtree
         void                                        scaleAgesFromTaxonAgesMBL(double minbl);                                            //!< Sets the age of the parent to the age of the oldest of its children + minbl
         void                                        setAge(double a, bool propagate = true );                                           //!< Set the age of this node (should only be done for tips).
         void                                        setBranchLength(double b, bool flag_dirty=true);                                    //!< Set the length of the branch leading to this node.

--- a/src/core/datatypes/trees/Tree.cpp
+++ b/src/core/datatypes/trees/Tree.cpp
@@ -2084,7 +2084,7 @@ void Tree::resetTaxonBitSetMap( void )
 }
 
 
-void Tree::resolveMultifurcations( bool resolve_root )
+void Tree::resolveMultifurcations( bool resolve_root, bool halve_branch_length )
 {
     // Collect the multifurcation nodes.
     std::vector<TopologyNode*> multifurcating_nodes;
@@ -2097,7 +2097,7 @@ void Tree::resolveMultifurcations( bool resolve_root )
 
     // Resolve the multifurcations.
     for(auto node: multifurcating_nodes)
-        node->resolveMultifurcation( resolve_root );
+        node->resolveMultifurcation( resolve_root, halve_branch_length );
 
     // We need to reindex nodes because we added new ones
     reindexNodes();

--- a/src/core/datatypes/trees/Tree.h
+++ b/src/core/datatypes/trees/Tree.h
@@ -148,7 +148,7 @@ namespace RevBayesCore {
         bool                                                removeRootIfDegree2();
         void                                                renameNodeParameter(const std::string &old_name, const std::string &new_name);
         void                                                resetTaxonBitSetMap(void);                                                                          //!< Resets the map that holds the BitSet index for each taxon
-        void                                                resolveMultifurcations(bool resolve_root);                                                           //!< Make sure the tree is fully bifurcating
+        void                                                resolveMultifurcations(bool resolve_root, bool halve_branch_length = false);                        //!< Make sure the tree is fully bifurcating
         TopologyNode&                                       reverseParentChild(TopologyNode &n);                                                                //!< Reverse the parent child relationship.
         void                                                setNegativeConstraint(bool);
         void                                                setRoot(TopologyNode* r, bool reindex);                                                             //!< Set the root and bootstrap the Tree from it

--- a/src/revlanguage/datatypes/phylogenetics/trees/RlTree.cpp
+++ b/src/revlanguage/datatypes/phylogenetics/trees/RlTree.cpp
@@ -341,8 +341,9 @@ RevLanguage::RevPtr<RevLanguage::RevVariable> Tree::executeMethod(std::string co
         found = true;
         
         bool resolve_root = static_cast<RlBoolean &>( args[0].getVariable()->getRevObject() ).getValue();
+        bool halve_branch_length = static_cast<RlBoolean &>( args[1].getVariable()->getRevObject() ).getValue();
         RevBayesCore::Tree &tree = dag_node->getValue();
-        tree.resolveMultifurcations( resolve_root );
+        tree.resolveMultifurcations( resolve_root, halve_branch_length );
         
         return NULL;
     }
@@ -613,6 +614,7 @@ void Tree::initMethods( void )
     
     ArgumentRules* resolveMultiArgRules = new ArgumentRules();
     resolveMultiArgRules->push_back( new ArgumentRule( "resolveRoot", RlBoolean::getClassTypeSpec(), "Do we want a bifurcation at the root as well?", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
+    resolveMultiArgRules->push_back( new ArgumentRule( "nonzeroBranchLengths", RlBoolean::getClassTypeSpec(), "In branch-length trees, should we reapportion existing branch lengths to avoid creating zero-length branches?", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new RlBoolean(false) ) );
     methods.addFunction( new MemberProcedure( "resolveMultifurcations", RlUtils::Void, resolveMultiArgRules ) );
 
     ArgumentRules* getDescendantTaxaArgRules = new ArgumentRules();

--- a/tests/data/multifurcating_branch_length_tree.tre
+++ b/tests/data/multifurcating_branch_length_tree.tre
@@ -1,1 +1,1 @@
-(taxon0,taxon1,(taxon2,((taxon3,taxon4,taxon5,taxon6),(taxon7,taxon8,taxon9))));
+(taxon0:1.0,taxon1:1.0,(taxon2:1.0,((taxon3:1.0,taxon4:1.0,taxon5:1.0,taxon6:1.0):1.0,(taxon7:1.0,taxon8:1.0,taxon9:1.0):1.0):1.0):1.0);

--- a/tests/test_nonBifurcating/output_expected/Test_resolveMultifurcations.errout
+++ b/tests/test_nonBifurcating/output_expected/Test_resolveMultifurcations.errout
@@ -29,13 +29,28 @@ Resolving multifurcations in a branch length tree
    Tree type: BranchLengthTree
    The tree has 10 tips and 5 internal nodes.
    Is the tree binary? FALSE
+   Tree length: 14
 
-Resolving all multifurcations...
+Resolving all multifurcations; allowing zero-length branches...
 
    The modified tree has 10 tips and 9 internal nodes.
    Is the modified tree binary? TRUE
+   Tree length: 14
 
-Resolving multifurcations except at the root...
+Resolving multifurcations except at the root; allowing zero-length branches...
 
    The modified tree has 10 tips and 8 internal nodes.
    Is the modified tree binary? FALSE
+   Tree length: 14
+
+Resolving all multifurcations; eliminating zero-length branches...
+
+   The modified tree has 10 tips and 9 internal nodes.
+   Is the modified tree binary? TRUE
+   Tree length: 14
+
+Resolving multifurcations except at the root; eliminating zero-length branches...
+
+   The modified tree has 10 tips and 8 internal nodes.
+   Is the modified tree binary? FALSE
+   Tree length: 14

--- a/tests/test_nonBifurcating/output_expected/branch_length_tree_all_but_root_resolved.nex
+++ b/tests/test_nonBifurcating/output_expected/branch_length_tree_all_but_root_resolved.nex
@@ -1,5 +1,0 @@
-#NEXUS
-
-Begin trees;
-tree TREE1 = [&U](taxon0[&index=10],taxon1[&index=9],(taxon2[&index=8],((taxon3[&index=7],(taxon5[&index=6],(taxon6[&index=5],taxon4[&index=4])[&index=11])[&index=12])[&index=13],(taxon7[&index=3],(taxon9[&index=2],taxon8[&index=1])[&index=14])[&index=15])[&index=16])[&index=17])[&index=18]:0.000000;
-End;

--- a/tests/test_nonBifurcating/output_expected/branch_length_tree_all_but_root_resolved_nonzero_length.nex
+++ b/tests/test_nonBifurcating/output_expected/branch_length_tree_all_but_root_resolved_nonzero_length.nex
@@ -1,0 +1,5 @@
+#NEXUS
+
+Begin trees;
+tree TREE1 = [&U](taxon0[&index=10]:1.000000,taxon1[&index=9]:1.000000,(taxon2[&index=8]:1.000000,(((taxon6[&index=7]:1.000000,taxon4[&index=6]:1.000000)[&index=11]:0.500000,(taxon5[&index=5]:1.000000,taxon3[&index=4]:1.000000)[&index=12]:0.250000)[&index=13]:0.250000,(taxon8[&index=3]:1.000000,(taxon9[&index=2]:1.000000,taxon7[&index=1]:1.000000)[&index=14]:0.500000)[&index=15]:0.500000)[&index=16]:1.000000)[&index=17]:1.000000)[&index=18]:0.000000;
+End;

--- a/tests/test_nonBifurcating/output_expected/branch_length_tree_all_but_root_resolved_zero_length.nex
+++ b/tests/test_nonBifurcating/output_expected/branch_length_tree_all_but_root_resolved_zero_length.nex
@@ -1,0 +1,5 @@
+#NEXUS
+
+Begin trees;
+tree TREE1 = [&U](taxon0[&index=10]:1.000000,taxon1[&index=9]:1.000000,(taxon2[&index=8]:1.000000,((taxon3[&index=7]:1.000000,(taxon5[&index=6]:1.000000,(taxon6[&index=5]:1.000000,taxon4[&index=4]:1.000000)[&index=11]:0.000000)[&index=12]:0.000000)[&index=13]:1.000000,(taxon7[&index=3]:1.000000,(taxon9[&index=2]:1.000000,taxon8[&index=1]:1.000000)[&index=14]:0.000000)[&index=15]:1.000000)[&index=16]:1.000000)[&index=17]:1.000000)[&index=18]:0.000000;
+End;

--- a/tests/test_nonBifurcating/output_expected/branch_length_tree_all_resolved.nex
+++ b/tests/test_nonBifurcating/output_expected/branch_length_tree_all_resolved.nex
@@ -1,5 +1,0 @@
-#NEXUS
-
-Begin trees;
-tree TREE1 = [&U]((taxon2[&index=10],(((taxon6[&index=9],taxon5[&index=8])[&index=11],(taxon3[&index=7],taxon4[&index=6])[&index=12])[&index=13],(taxon9[&index=5],(taxon7[&index=4],taxon8[&index=3])[&index=14])[&index=15])[&index=16])[&index=17],(taxon1[&index=2],taxon0[&index=1])[&index=18]:0.000000)[&index=19]:0.000000;
-End;

--- a/tests/test_nonBifurcating/output_expected/branch_length_tree_all_resolved_nonzero_length.nex
+++ b/tests/test_nonBifurcating/output_expected/branch_length_tree_all_resolved_nonzero_length.nex
@@ -1,0 +1,5 @@
+#NEXUS
+
+Begin trees;
+tree TREE1 = [&U](taxon0[&index=10]:1.000000,((taxon2[&index=9]:1.000000,((taxon3[&index=8]:1.000000,((taxon5[&index=7]:1.000000,taxon6[&index=6]:1.000000)[&index=11]:0.500000,taxon4[&index=5]:1.000000)[&index=12]:0.250000)[&index=13]:0.250000,(taxon8[&index=4]:1.000000,(taxon7[&index=3]:1.000000,taxon9[&index=2]:1.000000)[&index=14]:0.500000)[&index=15]:0.500000)[&index=16]:1.000000)[&index=17]:0.500000,taxon1[&index=1]:0.500000)[&index=18]:1.000000)[&index=19]:0.000000;
+End;

--- a/tests/test_nonBifurcating/output_expected/branch_length_tree_all_resolved_zero_length.nex
+++ b/tests/test_nonBifurcating/output_expected/branch_length_tree_all_resolved_zero_length.nex
@@ -1,0 +1,5 @@
+#NEXUS
+
+Begin trees;
+tree TREE1 = [&U]((taxon2[&index=10]:1.000000,(((taxon6[&index=9]:1.000000,taxon5[&index=8]:1.000000)[&index=11]:0.000000,(taxon3[&index=7]:1.000000,taxon4[&index=6]:1.000000)[&index=12]:0.000000)[&index=13]:1.000000,(taxon9[&index=5]:1.000000,(taxon7[&index=4]:1.000000,taxon8[&index=3]:1.000000)[&index=14]:0.000000)[&index=15]:1.000000)[&index=16]:1.000000)[&index=17]:1.000000,(taxon1[&index=2]:1.000000,taxon0[&index=1]:1.000000)[&index=18]:0.000000)[&index=19]:0.000000;
+End;

--- a/tests/test_nonBifurcating/output_expected/branch_length_tree_dropped_nonroot_child.nex
+++ b/tests/test_nonBifurcating/output_expected/branch_length_tree_dropped_nonroot_child.nex
@@ -1,5 +1,5 @@
 #NEXUS
 
 Begin trees;
-tree TREE1 = [&U](taxon0[&index=9],taxon1[&index=8],(taxon2[&index=7],((taxon3[&index=6],taxon5[&index=5],taxon6[&index=4])[&index=10],(taxon7[&index=3],taxon8[&index=2],taxon9[&index=1])[&index=11])[&index=12])[&index=13])[&index=14]:0.000000;
+tree TREE1 = [&U](taxon0[&index=9]:1.000000,taxon1[&index=8]:1.000000,(taxon2[&index=7]:1.000000,((taxon3[&index=6]:1.000000,taxon5[&index=5]:1.000000,taxon6[&index=4]:1.000000)[&index=10]:1.000000,(taxon7[&index=3]:1.000000,taxon8[&index=2]:1.000000,taxon9[&index=1]:1.000000)[&index=11]:1.000000)[&index=12]:1.000000)[&index=13]:1.000000)[&index=14]:0.000000;
 End;

--- a/tests/test_nonBifurcating/output_expected/branch_length_tree_dropped_root_child.nex
+++ b/tests/test_nonBifurcating/output_expected/branch_length_tree_dropped_root_child.nex
@@ -1,5 +1,5 @@
 #NEXUS
 
 Begin trees;
-tree TREE1 = [&U](taxon1[&index=9],(taxon2[&index=8],((taxon3[&index=7],taxon4[&index=6],taxon5[&index=5],taxon6[&index=4])[&index=10],(taxon7[&index=3],taxon8[&index=2],taxon9[&index=1])[&index=11])[&index=12])[&index=13])[&index=14]:0.000000;
+tree TREE1 = [&U](taxon1[&index=9]:1.000000,(taxon2[&index=8]:1.000000,((taxon3[&index=7]:1.000000,taxon4[&index=6]:1.000000,taxon5[&index=5]:1.000000,taxon6[&index=4]:1.000000)[&index=10]:1.000000,(taxon7[&index=3]:1.000000,taxon8[&index=2]:1.000000,taxon9[&index=1]:1.000000)[&index=11]:1.000000)[&index=12]:1.000000)[&index=13]:1.000000)[&index=14]:0.000000;
 End;

--- a/tests/test_nonBifurcating/scripts/Test_resolveMultifurcations.Rev
+++ b/tests/test_nonBifurcating/scripts/Test_resolveMultifurcations.Rev
@@ -15,6 +15,7 @@ print("========================================\n")
 
 tt <- readTrees("data/multifurcating_time_tree.tre")[1]
 tt_copy <- tt
+
 print( "\n   Tree type: " + type(tt) )
 print( "   The tree has " + tt.ntips() + " tips and " + (tt.nnodes() - tt.ntips()) + " internal nodes." )
 print( "   Is the tree binary? " + ifelse( tt.isBinary(), "TRUE", "FALSE") + "\n" )
@@ -36,22 +37,42 @@ print("Resolving multifurcations in a branch length tree")
 print("=================================================\n")
 
 blt <- readTrees("data/multifurcating_branch_length_tree.tre", treetype="non-clock")[1]
-blt_copy <- blt
+blt_1 <- blt
+blt_2 <- blt
+blt_3 <- blt
+
 print( "\n   Tree type: " + type(blt) )
 print( "   The tree has " + blt.ntips() + " tips and " + (blt.nnodes() - blt.ntips()) + " internal nodes." )
-print( "   Is the tree binary? " + ifelse( blt.isBinary(), "TRUE", "FALSE") + "\n" )
+print( "   Is the tree binary? " + ifelse( blt.isBinary(), "TRUE", "FALSE") )
+print( "   Tree length: " + blt.treeLength() + "\n" )
 
-print( "Resolving all multifurcations...\n" )
-blt.resolveMultifurcations(resolveRoot=TRUE)
+print( "Resolving all multifurcations; allowing zero-length branches...\n" )
+blt.resolveMultifurcations(resolveRoot=TRUE, nonzeroBranchLengths=FALSE)
 print( "   The modified tree has " + blt.ntips() + " tips and " + (blt.nnodes() - blt.ntips()) + " internal nodes." )
-print( "   Is the modified tree binary? " + ifelse( blt.isBinary(), "TRUE", "FALSE") + "\n" )
-writeNexus(filename="output/branch_length_tree_all_resolved.nex", blt)
+print( "   Is the modified tree binary? " + ifelse( blt.isBinary(), "TRUE", "FALSE") )
+print( "   Tree length: " + blt.treeLength() + "\n" )
+writeNexus(filename="output/branch_length_tree_all_resolved_zero_length.nex", blt)
 
-print( "Resolving multifurcations except at the root...\n" )
-blt_copy.resolveMultifurcations(resolveRoot=FALSE)
-print( "   The modified tree has " + blt_copy.ntips() + " tips and " + (blt_copy.nnodes() - blt_copy.ntips()) + " internal nodes." )
-print( "   Is the modified tree binary? " + ifelse( blt_copy.isBinary(), "TRUE", "FALSE") )
-writeNexus(filename="output/branch_length_tree_all_but_root_resolved.nex", blt_copy)
+print( "Resolving multifurcations except at the root; allowing zero-length branches...\n" )
+blt_1.resolveMultifurcations(resolveRoot=FALSE, nonzeroBranchLengths=FALSE)
+print( "   The modified tree has " + blt_1.ntips() + " tips and " + (blt_1.nnodes() - blt_1.ntips()) + " internal nodes." )
+print( "   Is the modified tree binary? " + ifelse( blt_1.isBinary(), "TRUE", "FALSE") )
+print( "   Tree length: " + blt_1.treeLength() + "\n" )
+writeNexus(filename="output/branch_length_tree_all_but_root_resolved_zero_length.nex", blt_1)
+
+print( "Resolving all multifurcations; eliminating zero-length branches...\n" )
+blt_2.resolveMultifurcations(resolveRoot=TRUE, nonzeroBranchLengths=TRUE)
+print( "   The modified tree has " + blt_2.ntips() + " tips and " + (blt_2.nnodes() - blt_2.ntips()) + " internal nodes." )
+print( "   Is the modified tree binary? " + ifelse( blt_2.isBinary(), "TRUE", "FALSE") )
+print( "   Tree length: " + blt_2.treeLength() + "\n" )
+writeNexus(filename="output/branch_length_tree_all_resolved_nonzero_length.nex", blt_2)
+
+print( "Resolving multifurcations except at the root; eliminating zero-length branches...\n" )
+blt_3.resolveMultifurcations(resolveRoot=FALSE, nonzeroBranchLengths=TRUE)
+print( "   The modified tree has " + blt_3.ntips() + " tips and " + (blt_3.nnodes() - blt_3.ntips()) + " internal nodes." )
+print( "   Is the modified tree binary? " + ifelse( blt_3.isBinary(), "TRUE", "FALSE") )
+print( "   Tree length: " + blt_3.treeLength() )
+writeNexus(filename="output/branch_length_tree_all_but_root_resolved_nonzero_length.nex", blt_3)
 
 clear()
 


### PR DESCRIPTION
When the `.resolveMultifurcations()` method inserts new branches into a `BranchLengthTree` to break up polytomies, it currently sets their length to 0. This PR provides a new argument, `nonzeroBranchLengths`, which instead allows the newly inserted nodes to "steal" one half of the length of their parent's subtending branch (or, if the parent is the root, one half of the length of their sibling's subtending branch) for themselves.

For the motivation behind this, see my comment under issue #992.