### PR TITLE
Add badges with download counters & other info to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,21 @@
 # RevBayes 
 
+[![RevBayes v1.0 releases](https://img.shields.io/github/downloads/revbayes/revbayes.archive/total.svg?style=social&logo=github&label=Downloads:%20v1.0)](https://github.com/revbayes/revbayes.archive/releases)
+[![RevBayes later releases](https://img.shields.io/github/downloads/revbayes/revbayes/total.svg?style=social&logo=github&label=Downloads:%20v1.1%20and%20later)](https://github.com/revbayes/revbayes/releases)
+
+[![Release](https://img.shields.io/github/v/release/revbayes/revbayes.svg?style=plastic)](https://github.com/revbayes/revbayes/releases/tag/v1.4.0)
+[![Release date](https://img.shields.io/github/release-date/revbayes/revbayes.svg?style=plastic&color=orange)](https://github.com/revbayes/revbayes/releases/tag/v1.4.0)
+[![New commits](https://img.shields.io/github/commits-since/revbayes/revbayes/v1.3.2.svg?style=plastic&color=yellow)](https://github.com/revbayes/revbayes/commits/master)
+[![Code size](https://img.shields.io/github/languages/code-size/revbayes/revbayes.svg?style=plastic&color=green)](https://github.com/revbayes/revbayes/archive/master.zip)
+[![Downloads](https://img.shields.io/github/downloads/revbayes/revbayes/v1.4.0/total.svg?style=plastic&color=darkgreen)](https://github.com/revbayes/revbayes/releases/tag/v1.4.0)
+
+[![Language](https://img.shields.io/badge/Language-C++-blue.svg)](https://en.cppreference.com)
+[![License](https://img.shields.io/badge/License-GPL%20v3-orange.svg)](https://www.gnu.org/licenses/gpl-3.0.html)
+[![Contributor covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-lightblue.svg)](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html)
+[![Build status](https://github.com/revbayes/revbayes/actions/workflows/build.yml/badge.svg)](https://github.com/revbayes/revbayes/actions/workflows/build.yml)
+
+------------
+
 **RevBayes** -- Bayesian phylogenetic inference using probabilistic graphical models and an interactive language.
 
 RevBayes is free software released under the GPL license, version 3.


### PR DESCRIPTION
At the developer meeting this past Tuesday, @hoehna suggested tracking the number of downloads for different versions of RevBayes. We can get these numbers pretty easily for executable downloads, and display them using GitHub badges. While I was at it, I added a few other badges, too.