### PR TITLE
Improve error messages and exception handling

### DIFF
--- a/src/core/utils/RbException.cpp
+++ b/src/core/utils/RbException.cpp
@@ -57,9 +57,6 @@ void RbException::print(std::ostream &o) const
         case MATH_ERROR:
             error_type = "Mathematical Error";
             break;
-        case MISSING_VARIABLE:
-            error_type = "Missing Variable";
-            break;
         case STOP:
             error_type = "Stop";
             break;

--- a/src/core/utils/RbException.cpp
+++ b/src/core/utils/RbException.cpp
@@ -60,9 +60,6 @@ void RbException::print(std::ostream &o) const
         case MISSING_VARIABLE:
             error_type = "Missing Variable";
             break;
-        case QUIT:
-            error_type = "Quit";
-            break;
         case STOP:
             error_type = "Stop";
             break;

--- a/src/core/utils/RbException.cpp
+++ b/src/core/utils/RbException.cpp
@@ -25,7 +25,7 @@ RbException::RbException(const RbException& E)
     message.flags(E.message.flags());
     message.precision(E.message.precision());
     message.width(E.message.width());
-    // We haven't copies the locate.
+    // We haven't copied the locale.
 }
 
 RbException::ExceptionType RbException::getExceptionType(void) const

--- a/src/core/utils/RbException.h
+++ b/src/core/utils/RbException.h
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include <sstream>
+#include <exception>
 
 class RbException {
 
@@ -13,7 +14,6 @@ class RbException {
                                                     BUG,
                                                     MATH_ERROR,
                                                     SKIP_PROPOSAL,
-                                                    MISSING_VARIABLE,
                                                     STOP };         //!< Exception types
 
                                     RbException(void) = default;                            //!< Default constructor
@@ -47,6 +47,13 @@ RbException& RbException::operator<<(const T& t) {
 struct RbQuitException
 {
     int status = 0;
+};
+
+struct RbMissingVariableError
+{
+    std::string name;
+
+    RbMissingVariableError(const std::string& s):name(s) {};
 };
 
 

--- a/src/core/utils/RbException.h
+++ b/src/core/utils/RbException.h
@@ -14,7 +14,6 @@ class RbException {
                                                     MATH_ERROR,
                                                     SKIP_PROPOSAL,
                                                     MISSING_VARIABLE,
-                                                    QUIT,
                                                     STOP };         //!< Exception types
 
                                     RbException(void) = default;                            //!< Default constructor
@@ -44,6 +43,11 @@ RbException& RbException::operator<<(const T& t) {
     message<<t;
     return *this;
 }
+
+struct RbQuitException
+{
+    int status = 0;
+};
 
 
 #endif

--- a/src/revlanguage/functions/basic/Func_quit.cpp
+++ b/src/revlanguage/functions/basic/Func_quit.cpp
@@ -61,7 +61,7 @@ const ArgumentRules& Func_quit::getArgumentRules( void ) const
     if ( !rules_set )
     {
         
-        argumentRules.push_back( new ArgumentRule( "status", Natural::getClassTypeSpec(), "The exit code used to quit.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, 0 ) );
+        argumentRules.push_back( new ArgumentRule( "status", Natural::getClassTypeSpec(), "The exit code used to quit.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new Natural(0) ) );
         rules_set = true;
     }
     

--- a/src/revlanguage/functions/basic/Func_quit.cpp
+++ b/src/revlanguage/functions/basic/Func_quit.cpp
@@ -7,6 +7,7 @@
 #include "RlUtils.h"
 #include "TypeSpec.h"
 #include "ArgumentRules.h"
+#include "Natural.h"
 #include "Procedure.h"
 #include "RbHelpReference.h"
 #include "RevPtr.h"
@@ -38,8 +39,13 @@ Func_quit* Func_quit::clone( void ) const
 /** Execute function */
 RevPtr<RevVariable> Func_quit::execute( void )
 {
-    
-    throw RbException( RbException::QUIT );
+    // We could in theory just call std::exit(status) here.
+    // Throwing an exception provides a way to notify our callers.
+    // The best way to quit is really to return the exit code from main.
+
+    unsigned int status = (unsigned int)static_cast<const Natural &>( args[0].getVariable()->getRevObject() ).getValue();
+
+    throw RbQuitException(status);
     
     return NULL;
 }
@@ -50,6 +56,14 @@ const ArgumentRules& Func_quit::getArgumentRules( void ) const
 {
     
     static ArgumentRules argumentRules = ArgumentRules();
+    static bool          rules_set = false;
+    
+    if ( !rules_set )
+    {
+        
+        argumentRules.push_back( new ArgumentRule( "status", Natural::getClassTypeSpec(), "The exit code used to quit.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, 0 ) );
+        rules_set = true;
+    }
     
     return argumentRules;
 }

--- a/src/revlanguage/parser/Parser.cpp
+++ b/src/revlanguage/parser/Parser.cpp
@@ -156,14 +156,6 @@ int RevLanguage::Parser::execute(SyntaxElement* root, const std::shared_ptr<Envi
     {
         result = root->evaluateContent(env);
     }
-    catch (RbQuitException& q)
-    {
-        delete( root);
-            
-        RevClient::shutdown();
-
-        exit(q.status);
-    }
     catch (RbMissingVariableError& v)
     {
         // Catch a missing variable exception that might be interpreted as a request for usage help on a function
@@ -187,35 +179,17 @@ int RevLanguage::Parser::execute(SyntaxElement* root, const std::shared_ptr<Envi
                 return 0;
             }
         }
-
+        
         // If it was NOT a request for help.
-        std::ostringstream msg;
-        msg<<"Error: variable '"<<v.name<<"' does not exist!";
-        RBOUT(msg.str());
-
-        // Return signal indicating problem
-        return 2;
+        delete root;
+        Signals::getSignals().clearFlags();
+        throw;
     }
-    catch (RbException& rbException)
+    catch (...)
     {
-        std::ostringstream msg;
-        // All other exceptions
-        rbException.print(msg);
-        RBOUT(msg.str());
-
-        // Return signal indicating problem
-        return 2;
-    }
-    // Also handle non-Rb exceptions (such as file-not-found).
-    catch (std::exception& e)
-    {
-        std::ostringstream msg;
-        msg<<"Error: ";
-        msg<<e.what();
-        RBOUT(msg.str());
-
-        // Return signal indicating problem
-        return 2;
+        delete root;
+        Signals::getSignals().clearFlags();
+        throw;
     }
 
     // Print result if the root is not an assign expression
@@ -455,15 +429,36 @@ int RevLanguage::Parser::processCommand(std::string& command, const std::shared_
             RevClient::shutdown();
             exit(q.status);
         }
+        catch (RbMissingVariableError& v)
+        {
+            std::ostringstream msg;
+            msg<<"Error: variable '"<<v.name<<"' does not exist!";
+            RBOUT(msg.str());
+
+            // Return signal indicating problem
+            command = "";
+            return 2;
+        }
         catch (RbException& rbException)
         {
-            // All other uncaught exceptions
+            std::ostringstream msg;
+            // All other exceptions
+            rbException.print(msg);
+            RBOUT(msg.str());
 
-            rbException.print(std::cerr);
-            std::cerr << std::endl;
-            
-            // We exit immediately, discarding any remaining buffer content
-            // We return 2 to signal a problem, which the caller may choose to ignore or act upon
+            // Return signal indicating problem
+            command = "";
+            return 2;
+        }
+        // Also handle non-Rb exceptions (such as file-not-found).
+        catch (std::exception& e)
+        {
+            std::ostringstream msg;
+            msg<<"Error: ";
+            msg<<e.what();
+            RBOUT(msg.str());
+
+            // Return signal indicating problem
             command = "";
             return 2;
         }

--- a/src/revlanguage/parser/Parser.cpp
+++ b/src/revlanguage/parser/Parser.cpp
@@ -156,20 +156,17 @@ int RevLanguage::Parser::execute(SyntaxElement* root, const std::shared_ptr<Envi
     {
         result = root->evaluateContent(env);
     }
+    catch (RbQuitException& q)
+    {
+        delete( root);
+            
+        RevClient::shutdown();
+
+        exit(q.status);
+    }
     catch (RbException& rbException)
     {
-
         std::ostringstream msg;
-
-        // Catch a quit request
-        if (rbException.getExceptionType() == RbException::QUIT)
-        {
-            delete( root);
-            
-            RevClient::shutdown();
-
-            exit(0);
-        }
 
         // Catch a missing variable exception that might be interpreted as a request for
         // usage help on a function
@@ -445,17 +442,15 @@ int RevLanguage::Parser::processCommand(std::string& command, const std::shared_
         {
             result = yyparse();
         }
+        catch (RbQuitException &q)
+        {
+            RevClient::shutdown();
+            exit(q.status);
+        }
         catch (RbException& rbException)
         {
-
-            // Catch a quit request in case it was not caught before
-            if (rbException.getExceptionType() == RbException::QUIT)
-            {
-                RevClient::shutdown();
-                exit(0);
-            }
             // All other uncaught exceptions
-            
+
             rbException.print(std::cerr);
             std::cerr << std::endl;
             
@@ -603,7 +598,6 @@ ParserInfo Parser::checkCommand(std::string& command, const std::shared_ptr<Envi
         pi.argument_label = argument_label;
         pi.result = 0;
 
-
         /* prepare globals for call to parser */
         rrcommand.str((*i));
         rrcommand.clear();
@@ -613,15 +607,28 @@ ParserInfo Parser::checkCommand(std::string& command, const std::shared_ptr<Envi
 
         pi.message.append("\n\rCalling bison with rrcommand:\n\r").append(rrcommand.str()).append("\n\r");
 
-        int result;
+        int result = 2;
         try {
             result = yyparse();
-        }        catch (RbException& rbException) {
+        }
+        catch (RbQuitException&)
+        {
             pi.message.append("Caught an exception calling yyparse\n\r");
+
             // Catch a quit request in case it was not caught before
-            if (rbException.getExceptionType() == RbException::QUIT) {
-                pi.message.append("ignoring QUIT request");
-            }
+            pi.message.append("ignoring QUIT request");
+
+            // All other uncaught exceptions
+            pi.message.append("Abnormal exception during parsing or execution of statement; discarding any remaining command buffer\n\r");
+
+            // try parsing next line
+            pi.result = 2;
+            continue;
+        }
+        catch (RbException& rbException)
+        {
+            pi.message.append("Caught an exception calling yyparse\n\r");
+
             // All other uncaught exceptions
             pi.message.append("Abnormal exception during parsing or execution of statement; discarding any remaining command buffer\n\r");
 

--- a/src/revlanguage/parser/Parser.cpp
+++ b/src/revlanguage/parser/Parser.cpp
@@ -164,25 +164,19 @@ int RevLanguage::Parser::execute(SyntaxElement* root, const std::shared_ptr<Envi
 
         exit(q.status);
     }
-    catch (RbException& rbException)
+    catch (RbMissingVariableError& v)
     {
-        std::ostringstream msg;
-
-        // Catch a missing variable exception that might be interpreted as a request for
-        // usage help on a function
-        SyntaxVariable* rootPtr = dynamic_cast<SyntaxVariable*> ((SyntaxElement*) root);
-        SyntaxVariable* theVariable = rootPtr;
-        if (rbException.getExceptionType() == RbException::MISSING_VARIABLE && theVariable != NULL)
+        // Catch a missing variable exception that might be interpreted as a request for usage help on a function
+        if (auto theVariable = dynamic_cast<SyntaxVariable*> ((SyntaxElement*) root))
         {
-
             const std::string& fxnName = theVariable->getIdentifier();
             const std::vector<Function*>& functions = Workspace::userWorkspace().getFunctionTable().findFunctions(fxnName);
             if (functions.size() != 0)
             {
-                for (std::vector<Function*>::const_iterator i = functions.begin(); i != functions.end(); i++)
+                for (auto& f: functions)
                 {
                     std::ostringstream s;
-                    (*i)->printValue(s,true);
+                    f->printValue(s,true);
                     RBOUT(s.str());
 
                     // Uncommenting this as the function callSignature() does not produce the call signature despite its name
@@ -192,9 +186,19 @@ int RevLanguage::Parser::execute(SyntaxElement* root, const std::shared_ptr<Envi
                 
                 return 0;
             }
-            
         }
 
+        // If it was NOT a request for help.
+        std::ostringstream msg;
+        msg<<"Error: variable '"<<v.name<<"' does not exist!";
+        RBOUT(msg.str());
+
+        // Return signal indicating problem
+        return 2;
+    }
+    catch (RbException& rbException)
+    {
+        std::ostringstream msg;
         // All other exceptions
         rbException.print(msg);
         RBOUT(msg.str());
@@ -202,10 +206,14 @@ int RevLanguage::Parser::execute(SyntaxElement* root, const std::shared_ptr<Envi
         // Return signal indicating problem
         return 2;
     }
-    // Don't crash the intepreter for non-Rb exceptions such as file-not-found.
+    // Also handle non-Rb exceptions (such as file-not-found).
     catch (std::exception& e)
     {
-        RBOUT(e.what());
+        std::ostringstream msg;
+        msg<<"Error: ";
+        msg<<e.what();
+        RBOUT(msg.str());
+
         // Return signal indicating problem
         return 2;
     }

--- a/src/revlanguage/parser/Parser.cpp
+++ b/src/revlanguage/parser/Parser.cpp
@@ -367,7 +367,7 @@ void RevLanguage::Parser::setParserMode(ParserMode mode)
  *       signal is set to 2. Any remaining part of the command buffer
  *       is discarded.
  */
-int RevLanguage::Parser::processCommand(std::string& command, const std::shared_ptr<Environment>& env)
+int RevLanguage::Parser::processCommand(std::string& command, const std::shared_ptr<Environment>& env, const std::optional<LocInfo>& locinfo)
 {
 
     // make sure mode is not checking
@@ -433,6 +433,8 @@ int RevLanguage::Parser::processCommand(std::string& command, const std::shared_
         {
             std::ostringstream msg;
             msg<<"Error: variable '"<<v.name<<"' does not exist!";
+            if (locinfo)
+                msg<<"\n   Note: at line "<<locinfo->line<<" in file '"<<locinfo->filename<<"'";
             RBOUT(msg.str());
 
             // Return signal indicating problem
@@ -445,7 +447,8 @@ int RevLanguage::Parser::processCommand(std::string& command, const std::shared_
             // All other exceptions
             rbException.print(msg);
             RBOUT(msg.str());
-
+            if (locinfo)
+                msg<<"\n   Note: at line "<<locinfo->line<<" in file '"<<locinfo->filename<<"'";
             // Return signal indicating problem
             command = "";
             return 2;
@@ -456,6 +459,8 @@ int RevLanguage::Parser::processCommand(std::string& command, const std::shared_
             std::ostringstream msg;
             msg<<"Error: ";
             msg<<e.what();
+            if (locinfo)
+                msg<<"\n   Note: at line "<<locinfo->line<<" in file '"<<locinfo->filename<<"'";
             RBOUT(msg.str());
 
             // Return signal indicating problem

--- a/src/revlanguage/parser/Parser.h
+++ b/src/revlanguage/parser/Parser.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <sstream>
 #include <vector>
+#include <filesystem>
 
 #include "RevPtr.h"
 #include "RevVariable.h"
@@ -25,6 +26,13 @@ namespace RevLanguage {
         RevPtr<RevVariable> base_variable;
     };
     
+    struct LocInfo
+    {
+        std::filesystem::path filename;
+        int line;
+        LocInfo(const std::filesystem::path& p, int l):filename(p),line(l) {}
+    };
+
     class Environment;
     class SyntaxElement;
     class SyntaxFunctionCall;
@@ -99,7 +107,7 @@ namespace RevLanguage {
         int                 help(const std::string& symbol) const;                                  //!< Get help for a symbol
         int                 help(const std::string& baseSymbol, const std::string& symbol) const;   //!< Get help for a symbol
         int                 help(const SyntaxFunctionCall* root) const;                             //!< Get help for a function call
-        int                 processCommand(std::string& command, const std::shared_ptr<Environment>& env);     //!< Process command with help from Bison
+        int                 processCommand(std::string& command, const std::shared_ptr<Environment>& env, const std::optional<LocInfo>& locinfo = {});     //!< Process command with help from Bison
 
         // State checking functions
         bool                isChecking(void) { return parser_mode == CHECKING; }                     //!< Are we in state-checking mode?

--- a/src/revlanguage/ui/RevClient.cpp
+++ b/src/revlanguage/ui/RevClient.cpp
@@ -383,18 +383,11 @@ void execute_file(const fs::path& filename, bool echo, bool continue_on_error)
         }
 
         // Process the line and record result
-        result = Parser::getParser().processCommand( commandLine, Workspace::userWorkspacePtr() );
-        if ( result == 2 )
-        {
-            if (not continue_on_error)
-                throw RbException() << "Problem processing line " << lineNumber << " in file " << filename;
-            else
-            {
-                std::ostringstream err;
-                err<<"Error:\tProblem processing line " << lineNumber << " in file " << filename;
-                RBOUT(err.str());
-            }
-        }
+        result = Parser::getParser().processCommand( commandLine, Workspace::userWorkspacePtr(), LocInfo(filename, lineNumber) );
+
+        // Stop executing the file on errors, unless we are told to continue.
+        if (result == 2 and not continue_on_error)
+            break;
     }
 }
 

--- a/src/revlanguage/workspace/Environment.cpp
+++ b/src/revlanguage/workspace/Environment.cpp
@@ -241,7 +241,7 @@ void Environment::eraseVariable(const std::string& name)
 
     if ( it == variableTable.end() )
     {
-        throw RbException(RbException::MISSING_VARIABLE, "Variable " + name + " does not exist in environment");
+        throw RbMissingVariableError(name);
     }
     else
     {
@@ -410,7 +410,7 @@ RevPtr<RevVariable>& Environment::getVariable(const std::string& name)
         }
         else
         {
-            throw RbException(RbException::MISSING_VARIABLE, "Variable " + name + " does not exist");
+            throw RbMissingVariableError(name);
         }
         
     }
@@ -432,7 +432,7 @@ const RevPtr<RevVariable>& Environment::getVariable(const std::string& name) con
         }
         else
         {
-            throw RbException(RbException::MISSING_VARIABLE, "Variable " + name + " does not exist");
+            throw RbMissingVariableError(name);
         }
         
     }


### PR DESCRIPTION
This PR does a few things:
* teach `q()` how to specify the exit code via e.g. `q(status=1)`
* split RbQuitException out from RbException.  This allows us to do `catch(RbQuitException& q)`, so do that.
* split RbMissingVariableError out from RbException, and make it hold the name that failed.  This allows us to do `catch(RbMissingVariableError& v)`, so do that.
* move most exception handling from `RevLanguage::Parser::execute( )` to the caller `RevLanguage::Parser::processCommand( )`.  
* allow passing the file and line number being executed into `processCommand( )`, and use it to print a better error location.

The old output looks like this:
```
$ rb test.Rev 
   Missing Variable:	Variable a does not exist
   Error:	Problem processing line 1 in file "test.Rev"
```

The new output looks like this:
```
$ rb test.Rev
   Error: variable 'a' does not exist!
      Note: at line 1 in file 'test.Rev'
```

TODO:
* add color for the words "Error: " (red) and "Note: " (cyan) if the output is a terminal
