### PR TITLE
Fix convergence rule behavior for MPI

### DIFF
--- a/src/core/analysis/MonteCarloAnalysis.cpp
+++ b/src/core/analysis/MonteCarloAnalysis.cpp
@@ -752,6 +752,24 @@ void MonteCarloAnalysis::run( size_t kIterations, RbVector<StoppingRule> rules, 
                 }             
             }           
         }
+
+#ifdef RB_MPI
+        // Convergence rules re-read trace files; ensure all ranks finished this generation's
+        // monitor output before any rank reads (also matches verbose>1 printing paths).
+        bool any_convergence_check_this_gen = false;
+        for (size_t ri = 0; ri < rules.size(); ++ri)
+        {
+            if ( rules[ri].isConvergenceRule() && rules[ri].checkAtIteration(gen) )
+            {
+                any_convergence_check_this_gen = true;
+                break;
+            }
+        }
+        if ( any_convergence_check_this_gen )
+        {
+            MPI_Barrier( analysis_comm );
+        }
+#endif
         
         converged = true;
         size_t numConvergenceRules = 0;


### PR DESCRIPTION
Fixes #1023. We make sure all processes have finished writing a given generation's line to the trace files before we allow the convergence rules to perform any calculations on the contents of those files.

Notes:

- Normally I would add an integration test, but since we don't currently conduct testing using multi-process MPI runs, there is no point to doing so.
- We execute an extra `for`-loop when the MPI preprocessor macro is defined. I'm trying to see if it incurs any noticeable cost, but even if it does, it's not clear to me there is any other way to solve the issue at hand...