### PR TITLE
More fun with badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,16 +3,19 @@
 [![RevBayes v1.0 releases](https://img.shields.io/github/downloads/revbayes/revbayes.archive/total.svg?style=social&logo=github&label=Downloads:%20v1.0)](https://github.com/revbayes/revbayes.archive/releases)
 [![RevBayes later releases](https://img.shields.io/github/downloads/revbayes/revbayes/total.svg?style=social&logo=github&label=Downloads:%20v1.1%20and%20later)](https://github.com/revbayes/revbayes/releases)
 
-[![Release](https://img.shields.io/github/v/release/revbayes/revbayes.svg?style=plastic)](https://github.com/revbayes/revbayes/releases/tag/v1.4.0)
-[![Release date](https://img.shields.io/github/release-date/revbayes/revbayes.svg?style=plastic&color=orange)](https://github.com/revbayes/revbayes/releases/tag/v1.4.0)
-[![New commits](https://img.shields.io/github/commits-since/revbayes/revbayes/v1.3.2.svg?style=plastic&color=yellow)](https://github.com/revbayes/revbayes/commits/master)
+[![Release](https://img.shields.io/github/v/release/revbayes/revbayes.svg?style=plastic)](https://github.com/revbayes/revbayes/releases/latest)
+[![Release date](https://img.shields.io/github/release-date/revbayes/revbayes.svg?style=plastic&color=orange)](https://github.com/revbayes/revbayes/releases/latest)
+[![New commits in last release](https://img.shields.io/badge/dynamic/json?url=https://api.github.com/repos/revbayes/revbayes/compare/v1.3.2...v1.4.0&query=$.ahead_by&label=commits%20v1.3.2–v1.4.0&color=yellow&style=plastic)](https://github.com/revbayes/revbayes/compare/v1.3.2...v1.4.0)
 [![Code size](https://img.shields.io/github/languages/code-size/revbayes/revbayes.svg?style=plastic&color=green)](https://github.com/revbayes/revbayes/archive/master.zip)
-[![Downloads](https://img.shields.io/github/downloads/revbayes/revbayes/v1.4.0/total.svg?style=plastic&color=darkgreen)](https://github.com/revbayes/revbayes/releases/tag/v1.4.0)
+[![Downloads](https://img.shields.io/github/downloads/revbayes/revbayes/v1.4.0/total.svg?style=plastic&color=darkgreen)](https://github.com/revbayes/revbayes/releases/latest)
 
-[![Language](https://img.shields.io/badge/Language-C++-blue.svg)](https://en.cppreference.com)
-[![License](https://img.shields.io/badge/License-GPL%20v3-orange.svg)](https://www.gnu.org/licenses/gpl-3.0.html)
-[![Contributor covenant](https://img.shields.io/badge/Contributor%20Covenant-2.0-lightblue.svg)](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html)
-[![Build status](https://github.com/revbayes/revbayes/actions/workflows/build.yml/badge.svg)](https://github.com/revbayes/revbayes/actions/workflows/build.yml)
+[![Development branch](https://img.shields.io/badge/branch-development-134EA2)](https://github.com/revbayes/revbayes/tree/development)
+[![New commits since last release](https://img.shields.io/github/commits-since/revbayes/revbayes/latest/development?sort=semver&style=plastic&color=lightblue&label=commits%20since%20release)](https://github.com/revbayes/revbayes/commits/development)
+[![Build status](https://github.com/revbayes/revbayes/actions/workflows/build.yml/badge.svg?branch=development)](https://github.com/revbayes/revbayes/actions/workflows/build.yml)
+
+[![Language](https://img.shields.io/badge/language-C++-blue.svg)](https://en.cppreference.com)
+[![License](https://img.shields.io/github/license/revbayes/revbayes)](https://github.com/revbayes/revbayes/blob/development/LICENSE)
+[![Code of conduct](https://img.shields.io/badge/code%20of%20conduct-Contributor%20Covenant-5e0d73)](https://github.com/revbayes/revbayes/blob/development/CODE_OF_CONDUCT.md)
 
 ------------
 

--- a/doc/release-workflow.md
+++ b/doc/release-workflow.md
@@ -35,16 +35,20 @@ Neither the [master](https://github.com/revbayes/revbayes/tree/master) branch no
         
 3. Open a pull request to merge the release branch into development, making development a strict descendant of master
 
-4. Merge development into master
+4. On development, update the URLs for the following badges in `README.md`:
+    * New commits in last release
+    * Downloads
+
+5. Merge development into master
     * On doing this, GitHub creates a merge commit, giving master 1 unique change that is not on development, and making this whole dance necessary next time
     
-5. Generate a YAML-formatted help file
+6. Generate a YAML-formatted help file
 
     1. Re-build RevBayes from scratch. This automatically generates a `rb-help2yml` executable outside the `build` directory.
     2. Run the executable to generate a `help.yml` file from the contents of [`help/md`](https://github.com/revbayes/revbayes/tree/master/help/md)
         * `./rb-help2yml`
 
-6. Update website from within the [revbayes.github.io](https://github.com/revbayes/revbayes.github.io) repo
+7. Update website from within the [revbayes.github.io](https://github.com/revbayes/revbayes.github.io) repo
 
     1. Update download version by modifying `_config.yml`
     2. Copy `help.yml` to the `_data` directory


### PR DESCRIPTION
This PR

- Splits the commit-counting badge in two, so that instead of counting commits between the penultimate release and the current tip of development, we count them separately (1) between the penultimate release and the latest release, and (2) between the latest release and the current tip of development.
- Adds an item to the [release checklist](https://github.com/revbayes/revbayes/blob/development/doc/release-workflow.md) to remind us to update the links underlying these badges with every new release.