### PR TITLE
Improve PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,35 +6,49 @@
 - 📚 Documentation
 - 🚦 Infrastructure
 
+## Summary
+<!-- In 1-3 sentences:
+1. What problem does this solve? 
+2. What strategy was chosen? 
+3. How was it checked? 
+-->
+
 ## Context 
-<!-- WHAT problem does this PR solve? -->
+<!-- If the problem is not trivial, please describe the problem this PR solves. -->
 
-## Strategy
-<!-- HOW does this PR attempt to solve this problem? -->
+## Approach
+<!-- If the solution is not trivial, please describe
+ * HOW does this PR attempts to solve this problem
+ * WHY you attempt to solve it this way
+ * WHAT other strategies did you consider, and WHY you decided to pursue this strategy instead.
+-->
 
-## Design reasoning
-<!-- WHY do you attempt to solve it this way? WHAT other strategies did you consider, and WHY did you decide to pursue this strategy instead of them? -->
+## More info
+<!-- Optionally, add more explanation or information here. -->
 
 ## Testing
-<!-- How can we be sure that this change works? What tests have you added to ensure that it won't break in the future? -->
-
-## Additional context
-<!-- Add any other context about the problem here. -->
+<!-- Briefly, How can we be sure that this change works? -->
+<!-- Consider: What tests have you added to ensure that it won't break in the future? -->
+<!-- See the tests/ directory for examples of existing tests. -->
 
 ## Relevant issues
 <!-- e.g. "Fixes #123 -->
 
-## TODO
-<!-- Things that should be addressed before merging -->
+## TODO before merging
+<!-- If non-empty, consider marking this a draft PR. -->
 
 ## Checklist
-<!-- If this checklist is deleted from the PR submission it will be immediately closed -->
-- [ ] I understand the code I am submitting.
-- [ ] I have added tests that prove my fix/feature works
-- [ ] I have run this code locally and verified it fixes the issue.
+<!-- Please keep this checklist. PRs missing the checklist may be marked incomplete until it is restored. -->
+- [ ] I have reviewed the submitted changes and understand their behavior.
+- [ ] I have added tests that prove my fix/feature works (or explained why they are not needed.)
+- [ ] I have run this code locally and verified it fixes the issue (or explained by this wasn't possible.)
 - [ ] New and existing tests pass locally
 - [ ] Documentation was updated where necessary
+
+### AI/LLM Assistance
 - [ ] I used an AI/LLM tool to assist with this PR
   - *If checked, I affirm that:*
       - *I personally understand every line of code submitted and agree to act as the sole human guarantor of this change.*
-      - *I wrote the cover letter myself, and I will answer reviewer questions in my own words without copy-pasting AI output.*
+      - *I will answer reviewer questions in my own words without copy-pasting AI output.*
+      - *I am the primary author of the PR cover letter (e.g. it wasn't AI/LLM generated).*
+      - *I have cleaned up the AI-generated code (e.g. removing verbose comments.)*


### PR DESCRIPTION
## PR Type
- 🚦 Infrastructure

## Summary
The main change for the new PR template is to ask for a 1-3 sentence summary at the top explaining what the problem is, how its being solved, and how we know the solution works.  This should hopefully decrease cognitive load on PR reviewers.

I also tried to incorporate some of @afmagee's suggestions -- mention draft PRs, split cover letter point from the respond-in-your-own-words point

There are a variety of other small changes.

It is interesting to note that this PR doesn't really fit the template :man_shrugging: 