### PR TITLE
Improve PR template by shrinking the checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+<!-- Thank you for contributing to RevBayes! -->
+
 ## PR Type
 <!-- Delete the types that don't apply -->
 - 🆕 New Feature
@@ -18,13 +20,13 @@
 
 ## Approach
 <!-- If the solution is not trivial, please describe
- * HOW does this PR attempts to solve this problem
+ * HOW this PR attempts to solve this problem
  * WHY you attempt to solve it this way
  * WHAT other strategies did you consider, and WHY you decided to pursue this strategy instead.
 -->
 
-## More info
-<!-- Optionally, add more explanation or information here. -->
+## Additional notes
+<!-- Optional: add anything reviewers should know that does not fit above. -->
 
 ## Testing
 <!-- Briefly, How can we be sure that this change works? -->
@@ -38,17 +40,13 @@
 <!-- If non-empty, consider marking this a draft PR. -->
 
 ## Checklist
-<!-- Please keep this checklist. PRs missing the checklist may be marked incomplete until it is restored. -->
-- [ ] I have reviewed the submitted changes and understand their behavior.
-- [ ] I have added tests that prove my fix/feature works (or explained why they are not needed.)
-- [ ] I have run this code locally and verified it fixes the issue (or explained by this wasn't possible.)
-- [ ] New and existing tests pass locally
-- [ ] Documentation was updated where necessary
+- [ ] I have added or updated tests for this change, or explained why they are not needed.
+- [ ] I have added or updated documentation where necessary.
 
 ### AI/LLM Assistance
 - [ ] I used an AI/LLM tool to assist with this PR
   - *If checked, I affirm that:*
-      - *I personally understand every line of code submitted and agree to act as the sole human guarantor of this change.*
+      - *I personally understand the submitted changes and take responsibility for their correctness, style, and maintainability.*
       - *I will answer reviewer questions in my own words without copy-pasting AI output.*
       - *I am the primary author of the PR cover letter (e.g. it wasn't AI/LLM generated).*
       - *I have cleaned up the AI-generated code (e.g. removing verbose comments.)*


### PR DESCRIPTION
## PR Type
- 🚦 Infrastructure

## Summary
The current checklist section comes across as mandatory, and also contains items like "run the tests locally" that we don't really need.  The solution here is to delete several checklist items, and also delete the line saying that the checklist should not be removed.  In theory we could instead clarify or soften the language, but deleting seems fine.

## Approach 
I left in the two checklist items for (i) tests and (ii) code, because they could be helpful reminders.  But the PR submitter can also delete them -- as in this PR.

However I'm curious if anyone thinks we should (i) improve the checklist or (ii) delete the whole checklist.

