### PR TITLE
Disallow zero check frequency in convergence rules

### DIFF
--- a/src/revlanguage/analysis/RlAbstractConvergenceStoppingRule.cpp
+++ b/src/revlanguage/analysis/RlAbstractConvergenceStoppingRule.cpp
@@ -13,7 +13,7 @@
 #include "RlString.h"
 #include "SemMin.h"
 #include "TypeSpec.h"
-#include "Natural.h"
+#include "IntegerPos.h"
 #include "RevObject.h"
 #include "RevPtr.h"
 #include "RevVariable.h"
@@ -90,7 +90,7 @@ const MemberRules& AbstractConvergenceStoppingRule::getParameterRules(void) cons
     {
         
         memberRules.push_back( new ArgumentRule( "filename" , RlString::getClassTypeSpec(), "The name of the file containing the samples.", ArgumentRule::BY_VALUE, ArgumentRule::ANY ) );
-        memberRules.push_back( new ArgumentRule( "frequency", Natural::getClassTypeSpec() , "The frequency how often to check for convergence.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new Natural(10000) ) );
+        memberRules.push_back( new ArgumentRule( "frequency", IntegerPos::getClassTypeSpec() , "The frequency how often to check for convergence.", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new IntegerPos(10000) ) );
         
         std::vector<std::string> bMethods;
         bMethods.push_back( "ESS" );

--- a/src/revlanguage/analysis/RlGelmanRubinStoppingRule.cpp
+++ b/src/revlanguage/analysis/RlGelmanRubinStoppingRule.cpp
@@ -10,7 +10,7 @@
 #include "RealPos.h"
 #include "RlString.h"
 #include "TypeSpec.h"
-#include "Natural.h"
+#include "IntegerPos.h"
 #include "RevObject.h"
 #include "RevPtr.h"
 #include "RevVariable.h"
@@ -49,7 +49,7 @@ void GelmanRubinStoppingRule::constructInternalObject( void )
     
     // now allocate a new stopping rule
     double r = static_cast<const RealPos &>( R->getRevObject() ).getValue();
-    int fq = (int)static_cast<const Natural &>( frequency->getRevObject() ).getValue();
+    int fq = (int)static_cast<const IntegerPos &>( frequency->getRevObject() ).getValue();
     const std::string &fn = static_cast<const RlString &>( filename->getRevObject() ).getValue();
     
     RevBayesCore::BurninEstimatorContinuous *burninEst = constructBurninEstimator();

--- a/src/revlanguage/analysis/RlGewekeStoppingRule.cpp
+++ b/src/revlanguage/analysis/RlGewekeStoppingRule.cpp
@@ -10,7 +10,7 @@
 #include "RlGewekeStoppingRule.h"
 #include "RlString.h"
 #include "TypeSpec.h"
-#include "Natural.h"
+#include "IntegerPos.h"
 #include "RevObject.h"
 #include "RevPtr.h"
 #include "RevVariable.h"
@@ -51,7 +51,7 @@ void GewekeStoppingRule::constructInternalObject( void )
     double p = static_cast<const Probability &>( prob->getRevObject() ).getValue();
     double f1 = static_cast<const Probability &>( frac1->getRevObject() ).getValue();
     double f2 = static_cast<const Probability &>( frac2->getRevObject() ).getValue();
-    int fq = (int)static_cast<const Natural &>( frequency->getRevObject() ).getValue();
+    int fq = (int)static_cast<const IntegerPos &>( frequency->getRevObject() ).getValue();
     const std::string &fn = static_cast<const RlString &>( filename->getRevObject() ).getValue();
     
     RevBayesCore::BurninEstimatorContinuous *burninEst = constructBurninEstimator();

--- a/src/revlanguage/analysis/RlMinEssStoppingRule.cpp
+++ b/src/revlanguage/analysis/RlMinEssStoppingRule.cpp
@@ -10,7 +10,7 @@
 #include "RealPos.h"
 #include "RlString.h"
 #include "TypeSpec.h"
-#include "Natural.h"
+#include "IntegerPos.h"
 #include "RevObject.h"
 #include "RevPtr.h"
 #include "RevVariable.h"
@@ -49,7 +49,7 @@ void MinEssStoppingRule::constructInternalObject( void )
     
     // now allocate a new stopping rule
     double min = static_cast<const RealPos &>( minEss->getRevObject() ).getValue();
-    int fq = static_cast<const Natural &>( frequency->getRevObject() ).getValue();
+    int fq = static_cast<const IntegerPos &>( frequency->getRevObject() ).getValue();
     const std::string &fn = static_cast<const RlString &>( filename->getRevObject() ).getValue();
     
     RevBayesCore::BurninEstimatorContinuous *burninEst = constructBurninEstimator();

--- a/src/revlanguage/analysis/RlStationarityStoppingRule.cpp
+++ b/src/revlanguage/analysis/RlStationarityStoppingRule.cpp
@@ -10,7 +10,7 @@
 #include "Probability.h"
 #include "RlString.h"
 #include "TypeSpec.h"
-#include "Natural.h"
+#include "IntegerPos.h"
 #include "RevObject.h"
 #include "RevPtr.h"
 #include "RevVariable.h"
@@ -49,7 +49,7 @@ void StationarityStoppingRule::constructInternalObject( void )
     
     // now allocate a new stopping rule
     double p = static_cast<const Probability &>( prob->getRevObject() ).getValue();
-    int fq = static_cast<const Natural &>( frequency->getRevObject() ).getValue();
+    int fq = static_cast<const IntegerPos &>( frequency->getRevObject() ).getValue();
     const std::string &fn = static_cast<const RlString &>( filename->getRevObject() ).getValue();
     
     RevBayesCore::BurninEstimatorContinuous *burninEst = constructBurninEstimator();

--- a/tests/test_convergenceRules/output_expected/Test_zeroCheckFrequency.errout
+++ b/tests/test_convergenceRules/output_expected/Test_zeroCheckFrequency.errout
@@ -1,0 +1,15 @@
+   Error:	Argument or label mismatch for function call.
+   Arguments which could not be matched (we stopped after the first mismatch):
+   	
+   Provided call:
+   srMinESS (Natural<constant>,
+             String<constant> 'file',
+             Natural<constant> 'freq' )
+   
+   Correct usage is:
+   srMinESS (RealPos<any> minEss,
+             String<any> filename,
+             IntegerPos<any> frequency,
+             String<any> burninMethod {valid options: "ESS"|"SEM"})
+   
+   Missing Variable:	Variable stopping_rules does not exist

--- a/tests/test_convergenceRules/scripts/Test_zeroCheckFrequency.Rev
+++ b/tests/test_convergenceRules/scripts/Test_zeroCheckFrequency.Rev
@@ -1,0 +1,50 @@
+## continue-on-error
+
+################################################################################
+#
+# RevBayes Test-Script: Make sure that we do not allow setting the "frequency"
+#                       argument of convergence rules to 0.
+#
+#
+# authors: David Cerny
+#
+################################################################################
+
+seed(12345)
+
+
+# Binomial example: estimate success probability given 7 successes out of 20 trials
+
+# We place this rather unusual prior on p instead of the more logical dnUnif(0, 1)
+# because with the latter, the log prior density would be 0 for all proposed
+# values, and therefore, for all logged iterations. This would give us zero variance,
+# making the calculation of convergence statistics problematic.
+
+r ~ dnExp(10)
+p := Probability(ifelse(r < 1, r, 1))
+n <- 20
+k ~ dnBinomial(n, p)
+k.clamp(7)
+mymodel = model(k)
+
+moves = VectorMoves()
+moves.append( mvSlide(r, delta=0.1, weight=1) )
+
+monitors = VectorMonitors()
+monitors.append( mnModel(filename = "output/ESS_test.log", printgen = 100) )
+
+# Create the MCMC object with 4 independent runs. Note that the ESS statistic can
+# be calculated from a single run, so multiple runs are not strictly necessary here.
+
+mymcmc = mcmc(mymodel, monitors, moves, nruns = 4)
+
+# Try calculating the effective sample size every 0 generations: this should fail with
+# a type mismatch!
+
+stopping_rules[1] = srMinESS(50, file = "output/ESS_test.log", freq = 0)
+
+# Start the MCMC run
+mymcmc.run(rules = stopping_rules, verbose = 2)
+
+clear()
+q()


### PR DESCRIPTION
## PR Type
- Bug Fix

## Summary
Since the `frequency` argument of convergence rules is of type `Natural`, it accepts 0 as a valid value, which leads to division by zero in `AbstractConvergenceStoppingRule::checkAtIteration()` – at least with GCC. Following @ms609's suggestion, I changed the type of the argument to `IntegerPos` to require it to be strictly positive. I included a test to make sure this has the desired effect: instead of division by zero, we now get a type mismatch error.

## Approach
I also considered including an extra guard directly inside `AbstractConvergenceStoppingRule::checkAtIteration()`:

```cpp
return (checkFrequency == 0) ? false : (g % checkFrequency) == 0;
```

However, I can't see why anyone would want to define a convergence rule only to disable it, so I went with @ms609's proposal instead.

## Testing
I have added a new test: `test_convergenceRules/scripts/Test_zeroCheckFrequency.Rev`.

## Relevant issues
Fixes #1043.