### PR TITLE
Allow specifying a fixed burnin fraction in convergence rules

### DIFF
--- a/help/md/srGelmanRubin.md
+++ b/help/md/srGelmanRubin.md
@@ -13,16 +13,27 @@ be calculated when two or more independent runs are performed, and its value
 tends to unity (1) as the runs converge.
 
 The number of samples to be removed as burnin before calculating the test
-statistic is determined using the `burninMethod`. Different burnin lengths are
-tested, increasing from 0 to 50% (for `ESS`) or 100% (for `SEM`) of the length
-of the trace in increments of 10 samples. If the `ESS` option is chosen
-(default), effective sample sizes (ESS) are calculated for all monitored
-parameters after removing the number of samples corresponding to each candidate
-burnin length. The best burnin length for a given parameter is the one that
-maximizes its ESS value. If the `SEM` option is chosen, the standard error of
-the mean (SEM) is calculated instead, and the best burnin length for a given
-parameter is the one that minimizes its SEM value. In both cases, the final
-burnin length is set to the maximum of the parameter-specific burnin lengths.
+statistic is determined using the `burninMethod`. If the `"ESS"` (default) or
+`"SEM"` options are chosen, different burnin lengths are tested, increasing
+from 0 to 50% (for `"ESS"`) or 100% (for `"SEM"`) of the length of the trace in
+increments of 10 samples. The `"ESS"` option calculates effective sample sizes
+(ESS) for all monitored parameters after removing the number of samples
+corresponding to each candidate burnin length. The best burnin length for a
+given parameter is the one that maximizes its ESS value. The `"SEM"` option
+instead calculates the standard error of the mean (SEM), and the best burnin
+length for a given parameter is the one that minimizes its SEM value. In both
+cases, the final burnin length is set to the maximum of the parameter-specific
+burnin lengths.
+
+Alternatively, the user may set `burninMethod` to `"fixed"`, which discards a
+constant fraction of the samples collected up to that point. This fraction can
+be specified using the `burnin` argument, and is set to 0.1 by default. The
+`burnin` argument has no effect if the `"ESS"` or `"SEM"` options are chosen,
+and a corresponding warning is displayed if the user explicitly sets the
+argument without specifying `burninMethod="fixed"`. The `"fixed"` option is 
+appropriate for analyses with very long parameter traces and large numbers of
+monitored variables, for which the automatic burnin determination may be too
+computationally demanding.
 
 See also the tutorial on [convergence assessment](https://revbayes.github.io/tutorials/convergence/).
 ## authors

--- a/help/md/srGelmanRubin.md
+++ b/help/md/srGelmanRubin.md
@@ -27,7 +27,7 @@ burnin lengths.
 
 Alternatively, the user may set `burninMethod` to `"fixed"`, which discards a
 constant fraction of the samples collected up to that point. This fraction can
-be specified using the `burnin` argument, and is set to 0.1 by default. The
+be specified using the `burnin` argument, and is set to 0.25 by default. The
 `burnin` argument has no effect if the `"ESS"` or `"SEM"` options are chosen,
 and a corresponding warning is displayed if the user explicitly sets the
 argument without specifying `burninMethod="fixed"`. The `"fixed"` option is 

--- a/help/md/srGeweke.md
+++ b/help/md/srGeweke.md
@@ -34,7 +34,7 @@ burnin lengths.
 
 Alternatively, the user may set `burninMethod` to `"fixed"`, which discards a
 constant fraction of the samples collected up to that point. This fraction can
-be specified using the `burnin` argument, and is set to 0.1 by default. The
+be specified using the `burnin` argument, and is set to 0.25 by default. The
 `burnin` argument has no effect if the `"ESS"` or `"SEM"` options are chosen,
 and a corresponding warning is displayed if the user explicitly sets the
 argument without specifying `burninMethod="fixed"`. The `"fixed"` option is 

--- a/help/md/srGeweke.md
+++ b/help/md/srGeweke.md
@@ -20,16 +20,27 @@ asymptotically independent, which requires that the sum of `frac1` and `frac2`
 be strictly less than 1.
 
 The number of samples to be removed as burnin before calculating the test
-statistic is determined using the `burninMethod`. Different burnin lengths are
-tested, increasing from 0 to 50% (for `ESS`) or 100% (for `SEM`) of the length
-of the trace in increments of 10 samples. If the `ESS` option is chosen
-(default), effective sample sizes (ESS) are calculated for all monitored
-parameters after removing the number of samples corresponding to each candidate
-burnin length. The best burnin length for a given parameter is the one that
-maximizes its ESS value. If the `SEM` option is chosen, the standard error of
-the mean (SEM) is calculated instead, and the best burnin length for a given
-parameter is the one that minimizes its SEM value. In both cases, the final
-burnin length is set to the maximum of the parameter-specific burnin lengths.
+statistic is determined using the `burninMethod`. If the `"ESS"` (default) or
+`"SEM"` options are chosen, different burnin lengths are tested, increasing
+from 0 to 50% (for `"ESS"`) or 100% (for `"SEM"`) of the length of the trace in
+increments of 10 samples. The `"ESS"` option calculates effective sample sizes
+(ESS) for all monitored parameters after removing the number of samples
+corresponding to each candidate burnin length. The best burnin length for a
+given parameter is the one that maximizes its ESS value. The `"SEM"` option
+instead calculates the standard error of the mean (SEM), and the best burnin
+length for a given parameter is the one that minimizes its SEM value. In both
+cases, the final burnin length is set to the maximum of the parameter-specific
+burnin lengths.
+
+Alternatively, the user may set `burninMethod` to `"fixed"`, which discards a
+constant fraction of the samples collected up to that point. This fraction can
+be specified using the `burnin` argument, and is set to 0.1 by default. The
+`burnin` argument has no effect if the `"ESS"` or `"SEM"` options are chosen,
+and a corresponding warning is displayed if the user explicitly sets the
+argument without specifying `burninMethod="fixed"`. The `"fixed"` option is 
+appropriate for analyses with very long parameter traces and large numbers of
+monitored variables, for which the automatic burnin determination may be too
+computationally demanding.
 
 See also the tutorial on [convergence assessment](https://revbayes.github.io/tutorials/convergence/).
 

--- a/help/md/srMinESS.md
+++ b/help/md/srMinESS.md
@@ -31,7 +31,7 @@ burnin lengths.
 
 Alternatively, the user may set `burninMethod` to `"fixed"`, which discards a
 constant fraction of the samples collected up to that point. This fraction can
-be specified using the `burnin` argument, and is set to 0.1 by default. The
+be specified using the `burnin` argument, and is set to 0.25 by default. The
 `burnin` argument has no effect if the `"ESS"` or `"SEM"` options are chosen,
 and a corresponding warning is displayed if the user explicitly sets the
 argument without specifying `burninMethod="fixed"`. The `"fixed"` option is 

--- a/help/md/srMinESS.md
+++ b/help/md/srMinESS.md
@@ -17,16 +17,27 @@ of generations required to meet the ESS threshold, even though it may increase
 the number of indepedent samples in the final, pooled posterior sample.
 
 The number of samples to be removed as burnin before calculating the test
-statistic is determined using the `burninMethod`. Different burnin lengths are
-tested, increasing from 0 to 50% (for `ESS`) or 100% (for `SEM`) of the length
-of the trace in increments of 10 samples. If the `ESS` option is chosen
-(default), ESS is calculated for all monitored parameters after removing the
-number of samples corresponding to each candidate burnin length. The best
-burnin length for a given parameter is the one that maximizes its ESS value.
-If the `SEM` option is chosen, the standard error of the mean (SEM) is
-calculated instead, and the best burnin length for a given parameter is the one
-that minimizes its SEM value. In both cases, the final burnin length is set to
-the maximum of the parameter-specific burnin lengths.
+statistic is determined using the `burninMethod`. If the `"ESS"` (default) or
+`"SEM"` options are chosen, different burnin lengths are tested, increasing
+from 0 to 50% (for `"ESS"`) or 100% (for `"SEM"`) of the length of the trace in
+increments of 10 samples. The `"ESS"` option calculates effective sample sizes
+(ESS) for all monitored parameters after removing the number of samples
+corresponding to each candidate burnin length. The best burnin length for a
+given parameter is the one that maximizes its ESS value. The `"SEM"` option
+instead calculates the standard error of the mean (SEM), and the best burnin
+length for a given parameter is the one that minimizes its SEM value. In both
+cases, the final burnin length is set to the maximum of the parameter-specific
+burnin lengths.
+
+Alternatively, the user may set `burninMethod` to `"fixed"`, which discards a
+constant fraction of the samples collected up to that point. This fraction can
+be specified using the `burnin` argument, and is set to 0.1 by default. The
+`burnin` argument has no effect if the `"ESS"` or `"SEM"` options are chosen,
+and a corresponding warning is displayed if the user explicitly sets the
+argument without specifying `burninMethod="fixed"`. The `"fixed"` option is 
+appropriate for analyses with very long parameter traces and large numbers of
+monitored variables, for which the automatic burnin determination may be too
+computationally demanding.
 
 The [convergence assessment](https://revbayes.github.io/tutorials/convergence/)
 tutorial contains a discusson on the calculation and interpretation of the ESS

--- a/help/md/srStationarity.md
+++ b/help/md/srStationarity.md
@@ -12,16 +12,27 @@ constructed for the mean of each individual run. Accordingly, it can only be
 calculated when two or more independent runs are performed.
 
 The number of samples to be removed as burnin before calculating the test
-statistic is determined using the `burninMethod`. Different burnin lengths are
-tested, increasing from 0 to 50% (for `ESS`) or 100% (for `SEM`) of the length
-of the trace in increments of 10 samples. If the `ESS` option is chosen
-(default), effective sample sizes (ESS) are calculated for all monitored
-parameters after removing the number of samples corresponding to each candidate
-burnin length. The best burnin length for a given parameter is the one that
-maximizes its ESS value. If the `SEM` option is chosen, the standard error of
-the mean (SEM) is calculated instead, and the best burnin length for a given
-parameter is the one that minimizes its SEM value. In both cases, the final
-burnin length is set to the maximum of the parameter-specific burnin lengths.
+statistic is determined using the `burninMethod`. If the `"ESS"` (default) or
+`"SEM"` options are chosen, different burnin lengths are tested, increasing
+from 0 to 50% (for `"ESS"`) or 100% (for `"SEM"`) of the length of the trace in
+increments of 10 samples. The `"ESS"` option calculates effective sample sizes
+(ESS) for all monitored parameters after removing the number of samples
+corresponding to each candidate burnin length. The best burnin length for a
+given parameter is the one that maximizes its ESS value. The `"SEM"` option
+instead calculates the standard error of the mean (SEM), and the best burnin
+length for a given parameter is the one that minimizes its SEM value. In both
+cases, the final burnin length is set to the maximum of the parameter-specific
+burnin lengths.
+
+Alternatively, the user may set `burninMethod` to `"fixed"`, which discards a
+constant fraction of the samples collected up to that point. This fraction can
+be specified using the `burnin` argument, and is set to 0.1 by default. The
+`burnin` argument has no effect if the `"ESS"` or `"SEM"` options are chosen,
+and a corresponding warning is displayed if the user explicitly sets the
+argument without specifying `burninMethod="fixed"`. The `"fixed"` option is 
+appropriate for analyses with very long parameter traces and large numbers of
+monitored variables, for which the automatic burnin determination may be too
+computationally demanding.
 
 See also the tutorial on [convergence assessment](https://revbayes.github.io/tutorials/convergence/).
 ## authors

--- a/help/md/srStationarity.md
+++ b/help/md/srStationarity.md
@@ -26,7 +26,7 @@ burnin lengths.
 
 Alternatively, the user may set `burninMethod` to `"fixed"`, which discards a
 constant fraction of the samples collected up to that point. This fraction can
-be specified using the `burnin` argument, and is set to 0.1 by default. The
+be specified using the `burnin` argument, and is set to 0.25 by default. The
 `burnin` argument has no effect if the `"ESS"` or `"SEM"` options are chosen,
 and a corresponding warning is displayed if the user explicitly sets the
 argument without specifying `burninMethod="fixed"`. The `"fixed"` option is 

--- a/src/core/analysis/mcmc/convergence/FixedBurnin.cpp
+++ b/src/core/analysis/mcmc/convergence/FixedBurnin.cpp
@@ -1,0 +1,31 @@
+#include "FixedBurnin.h"
+
+#include "Cloneable.h"
+#include "TraceNumeric.h"
+
+using namespace RevBayesCore;
+
+FixedBurnin::FixedBurnin(double f)
+{
+    this->fraction = f;
+}
+
+
+/**
+ * The clone function is a convenience function to create proper copies of inherited objected.
+ * E.g. a.clone() will create a clone of the correct type even if 'a' is of derived type 'B'.
+ *
+ * \return A new copy of myself
+ */
+FixedBurnin* FixedBurnin::clone(void) const
+{
+
+    return new FixedBurnin( *this );
+}
+
+
+std::size_t FixedBurnin::estimateBurnin(const TraceNumeric& trace)
+{
+
+    return static_cast<std::size_t>( fraction * trace.size() );
+}

--- a/src/core/analysis/mcmc/convergence/FixedBurnin.h
+++ b/src/core/analysis/mcmc/convergence/FixedBurnin.h
@@ -1,0 +1,27 @@
+#ifndef FixedBurnin_H
+#define FixedBurnin_H
+
+#include <cstddef>
+
+#include "BurninEstimatorContinuous.h"
+
+namespace RevBayesCore {
+class TraceNumeric;
+
+    class FixedBurnin : public BurninEstimatorContinuous {
+
+    public:
+        FixedBurnin(double f);
+
+        FixedBurnin*    clone(void) const;                                              //!< Clone function. This is similar to the copy constructor but useful in inheritance.
+        std::size_t     estimateBurnin(const TraceNumeric& trace);
+
+    private:
+
+        double          fraction;
+
+    };
+
+}
+
+#endif

--- a/src/core/help/RbHelpDatabase.cpp
+++ b/src/core/help/RbHelpDatabase.cpp
@@ -4993,7 +4993,7 @@ burnin lengths.
 
 Alternatively, the user may set `burninMethod` to `"fixed"`, which discards a
 constant fraction of the samples collected up to that point. This fraction can
-be specified using the `burnin` argument, and is set to 0.1 by default. The
+be specified using the `burnin` argument, and is set to 0.25 by default. The
 `burnin` argument has no effect if the `"ESS"` or `"SEM"` options are chosen,
 and a corresponding warning is displayed if the user explicitly sets the
 argument without specifying `burninMethod="fixed"`. The `"fixed"` option is 
@@ -5065,7 +5065,7 @@ burnin lengths.
 
 Alternatively, the user may set `burninMethod` to `"fixed"`, which discards a
 constant fraction of the samples collected up to that point. This fraction can
-be specified using the `burnin` argument, and is set to 0.1 by default. The
+be specified using the `burnin` argument, and is set to 0.25 by default. The
 `burnin` argument has no effect if the `"ESS"` or `"SEM"` options are chosen,
 and a corresponding warning is displayed if the user explicitly sets the
 argument without specifying `burninMethod="fixed"`. The `"fixed"` option is 
@@ -5193,7 +5193,7 @@ burnin lengths.
 
 Alternatively, the user may set `burninMethod` to `"fixed"`, which discards a
 constant fraction of the samples collected up to that point. This fraction can
-be specified using the `burnin` argument, and is set to 0.1 by default. The
+be specified using the `burnin` argument, and is set to 0.25 by default. The
 `burnin` argument has no effect if the `"ESS"` or `"SEM"` options are chosen,
 and a corresponding warning is displayed if the user explicitly sets the
 argument without specifying `burninMethod="fixed"`. The `"fixed"` option is 
@@ -5257,7 +5257,7 @@ burnin lengths.
 
 Alternatively, the user may set `burninMethod` to `"fixed"`, which discards a
 constant fraction of the samples collected up to that point. This fraction can
-be specified using the `burnin` argument, and is set to 0.1 by default. The
+be specified using the `burnin` argument, and is set to 0.25 by default. The
 `burnin` argument has no effect if the `"ESS"` or `"SEM"` options are chosen,
 and a corresponding warning is displayed if the user explicitly sets the
 argument without specifying `burninMethod="fixed"`. The `"fixed"` option is 

--- a/src/core/help/RbHelpDatabase.cpp
+++ b/src/core/help/RbHelpDatabase.cpp
@@ -4979,16 +4979,27 @@ be calculated when two or more independent runs are performed, and its value
 tends to unity (1) as the runs converge.
 
 The number of samples to be removed as burnin before calculating the test
-statistic is determined using the `burninMethod`. Different burnin lengths are
-tested, increasing from 0 to 50% (for `ESS`) or 100% (for `SEM`) of the length
-of the trace in increments of 10 samples. If the `ESS` option is chosen
-(default), effective sample sizes (ESS) are calculated for all monitored
-parameters after removing the number of samples corresponding to each candidate
-burnin length. The best burnin length for a given parameter is the one that
-maximizes its ESS value. If the `SEM` option is chosen, the standard error of
-the mean (SEM) is calculated instead, and the best burnin length for a given
-parameter is the one that minimizes its SEM value. In both cases, the final
-burnin length is set to the maximum of the parameter-specific burnin lengths.
+statistic is determined using the `burninMethod`. If the `"ESS"` (default) or
+`"SEM"` options are chosen, different burnin lengths are tested, increasing
+from 0 to 50% (for `"ESS"`) or 100% (for `"SEM"`) of the length of the trace in
+increments of 10 samples. The `"ESS"` option calculates effective sample sizes
+(ESS) for all monitored parameters after removing the number of samples
+corresponding to each candidate burnin length. The best burnin length for a
+given parameter is the one that maximizes its ESS value. The `"SEM"` option
+instead calculates the standard error of the mean (SEM), and the best burnin
+length for a given parameter is the one that minimizes its SEM value. In both
+cases, the final burnin length is set to the maximum of the parameter-specific
+burnin lengths.
+
+Alternatively, the user may set `burninMethod` to `"fixed"`, which discards a
+constant fraction of the samples collected up to that point. This fraction can
+be specified using the `burnin` argument, and is set to 0.1 by default. The
+`burnin` argument has no effect if the `"ESS"` or `"SEM"` options are chosen,
+and a corresponding warning is displayed if the user explicitly sets the
+argument without specifying `burninMethod="fixed"`. The `"fixed"` option is 
+appropriate for analyses with very long parameter traces and large numbers of
+monitored variables, for which the automatic burnin determination may be too
+computationally demanding.
 
 See also the tutorial on [convergence assessment](https://revbayes.github.io/tutorials/convergence/).)");
 	help_strings[string("srGelmanRubin")][string("example")] = string(R"(# Binomial example: estimate success probability given 7 successes out of 20 trials
@@ -5040,16 +5051,27 @@ asymptotically independent, which requires that the sum of `frac1` and `frac2`
 be strictly less than 1.
 
 The number of samples to be removed as burnin before calculating the test
-statistic is determined using the `burninMethod`. Different burnin lengths are
-tested, increasing from 0 to 50% (for `ESS`) or 100% (for `SEM`) of the length
-of the trace in increments of 10 samples. If the `ESS` option is chosen
-(default), effective sample sizes (ESS) are calculated for all monitored
-parameters after removing the number of samples corresponding to each candidate
-burnin length. The best burnin length for a given parameter is the one that
-maximizes its ESS value. If the `SEM` option is chosen, the standard error of
-the mean (SEM) is calculated instead, and the best burnin length for a given
-parameter is the one that minimizes its SEM value. In both cases, the final
-burnin length is set to the maximum of the parameter-specific burnin lengths.
+statistic is determined using the `burninMethod`. If the `"ESS"` (default) or
+`"SEM"` options are chosen, different burnin lengths are tested, increasing
+from 0 to 50% (for `"ESS"`) or 100% (for `"SEM"`) of the length of the trace in
+increments of 10 samples. The `"ESS"` option calculates effective sample sizes
+(ESS) for all monitored parameters after removing the number of samples
+corresponding to each candidate burnin length. The best burnin length for a
+given parameter is the one that maximizes its ESS value. The `"SEM"` option
+instead calculates the standard error of the mean (SEM), and the best burnin
+length for a given parameter is the one that minimizes its SEM value. In both
+cases, the final burnin length is set to the maximum of the parameter-specific
+burnin lengths.
+
+Alternatively, the user may set `burninMethod` to `"fixed"`, which discards a
+constant fraction of the samples collected up to that point. This fraction can
+be specified using the `burnin` argument, and is set to 0.1 by default. The
+`burnin` argument has no effect if the `"ESS"` or `"SEM"` options are chosen,
+and a corresponding warning is displayed if the user explicitly sets the
+argument without specifying `burninMethod="fixed"`. The `"fixed"` option is 
+appropriate for analyses with very long parameter traces and large numbers of
+monitored variables, for which the automatic burnin determination may be too
+computationally demanding.
 
 See also the tutorial on [convergence assessment](https://revbayes.github.io/tutorials/convergence/).
 
@@ -5157,16 +5179,27 @@ of generations required to meet the ESS threshold, even though it may increase
 the number of indepedent samples in the final, pooled posterior sample.
 
 The number of samples to be removed as burnin before calculating the test
-statistic is determined using the `burninMethod`. Different burnin lengths are
-tested, increasing from 0 to 50% (for `ESS`) or 100% (for `SEM`) of the length
-of the trace in increments of 10 samples. If the `ESS` option is chosen
-(default), ESS is calculated for all monitored parameters after removing the
-number of samples corresponding to each candidate burnin length. The best
-burnin length for a given parameter is the one that maximizes its ESS value.
-If the `SEM` option is chosen, the standard error of the mean (SEM) is
-calculated instead, and the best burnin length for a given parameter is the one
-that minimizes its SEM value. In both cases, the final burnin length is set to
-the maximum of the parameter-specific burnin lengths.
+statistic is determined using the `burninMethod`. If the `"ESS"` (default) or
+`"SEM"` options are chosen, different burnin lengths are tested, increasing
+from 0 to 50% (for `"ESS"`) or 100% (for `"SEM"`) of the length of the trace in
+increments of 10 samples. The `"ESS"` option calculates effective sample sizes
+(ESS) for all monitored parameters after removing the number of samples
+corresponding to each candidate burnin length. The best burnin length for a
+given parameter is the one that maximizes its ESS value. The `"SEM"` option
+instead calculates the standard error of the mean (SEM), and the best burnin
+length for a given parameter is the one that minimizes its SEM value. In both
+cases, the final burnin length is set to the maximum of the parameter-specific
+burnin lengths.
+
+Alternatively, the user may set `burninMethod` to `"fixed"`, which discards a
+constant fraction of the samples collected up to that point. This fraction can
+be specified using the `burnin` argument, and is set to 0.1 by default. The
+`burnin` argument has no effect if the `"ESS"` or `"SEM"` options are chosen,
+and a corresponding warning is displayed if the user explicitly sets the
+argument without specifying `burninMethod="fixed"`. The `"fixed"` option is 
+appropriate for analyses with very long parameter traces and large numbers of
+monitored variables, for which the automatic burnin determination may be too
+computationally demanding.
 
 The [convergence assessment](https://revbayes.github.io/tutorials/convergence/)
 tutorial contains a discusson on the calculation and interpretation of the ESS
@@ -5210,16 +5243,27 @@ constructed for the mean of each individual run. Accordingly, it can only be
 calculated when two or more independent runs are performed.
 
 The number of samples to be removed as burnin before calculating the test
-statistic is determined using the `burninMethod`. Different burnin lengths are
-tested, increasing from 0 to 50% (for `ESS`) or 100% (for `SEM`) of the length
-of the trace in increments of 10 samples. If the `ESS` option is chosen
-(default), effective sample sizes (ESS) are calculated for all monitored
-parameters after removing the number of samples corresponding to each candidate
-burnin length. The best burnin length for a given parameter is the one that
-maximizes its ESS value. If the `SEM` option is chosen, the standard error of
-the mean (SEM) is calculated instead, and the best burnin length for a given
-parameter is the one that minimizes its SEM value. In both cases, the final
-burnin length is set to the maximum of the parameter-specific burnin lengths.
+statistic is determined using the `burninMethod`. If the `"ESS"` (default) or
+`"SEM"` options are chosen, different burnin lengths are tested, increasing
+from 0 to 50% (for `"ESS"`) or 100% (for `"SEM"`) of the length of the trace in
+increments of 10 samples. The `"ESS"` option calculates effective sample sizes
+(ESS) for all monitored parameters after removing the number of samples
+corresponding to each candidate burnin length. The best burnin length for a
+given parameter is the one that maximizes its ESS value. The `"SEM"` option
+instead calculates the standard error of the mean (SEM), and the best burnin
+length for a given parameter is the one that minimizes its SEM value. In both
+cases, the final burnin length is set to the maximum of the parameter-specific
+burnin lengths.
+
+Alternatively, the user may set `burninMethod` to `"fixed"`, which discards a
+constant fraction of the samples collected up to that point. This fraction can
+be specified using the `burnin` argument, and is set to 0.1 by default. The
+`burnin` argument has no effect if the `"ESS"` or `"SEM"` options are chosen,
+and a corresponding warning is displayed if the user explicitly sets the
+argument without specifying `burninMethod="fixed"`. The `"fixed"` option is 
+appropriate for analyses with very long parameter traces and large numbers of
+monitored variables, for which the automatic burnin determination may be too
+computationally demanding.
 
 See also the tutorial on [convergence assessment](https://revbayes.github.io/tutorials/convergence/).)");
 	help_strings[string("srStationarity")][string("example")] = string(R"(# Binomial example: estimate success probability given 7 successes out of 20 trials

--- a/src/revlanguage/analysis/RlAbstractConvergenceStoppingRule.cpp
+++ b/src/revlanguage/analysis/RlAbstractConvergenceStoppingRule.cpp
@@ -47,6 +47,10 @@ RevBayesCore::BurninEstimatorContinuous* AbstractConvergenceStoppingRule::constr
     
     if ( bm == "ESS" )
     {
+        // We want to throw a warning when the user explicitly specifies the `burnin` argument while simultaneously setting
+        // `burninMethod` to "ESS" or "SEM". However, the argument has a default value, so it will not be NULL even if the user does
+        // not explicitly set it. To circumvent the issue, we will exploit an implicit convention in Function::processArguments():
+        // when an optional parameter is assigned its ArgumentRule default, its name is prepended with a leading dot.
         if ( burnin != NULL && burnin->getName() != ".burnin" )
         {
             RBOUT( "Warning: the `burnin` argument is ignored when `burninMethod` is \"ESS\"." );

--- a/src/revlanguage/analysis/RlAbstractConvergenceStoppingRule.cpp
+++ b/src/revlanguage/analysis/RlAbstractConvergenceStoppingRule.cpp
@@ -113,7 +113,7 @@ const MemberRules& AbstractConvergenceStoppingRule::getParameterRules(void) cons
         bMethods.push_back( "SEM" );
         bMethods.push_back( "fixed" );
         memberRules.push_back( new OptionRule( "burninMethod", new RlString("ESS"), bMethods, "Which type of burnin method to use." ) );
-        memberRules.push_back( new ArgumentRule( "burnin", Probability::getClassTypeSpec(), "The fraction of samples to discard as burnin (only used when burninMethod is \"fixed\").", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new Probability(0.1) ) );
+        memberRules.push_back( new ArgumentRule( "burnin", Probability::getClassTypeSpec(), "The fraction of samples to discard as burnin (only used when burninMethod is \"fixed\").", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new Probability(0.25) ) );
         
         
         rules_set = true;

--- a/src/revlanguage/analysis/RlAbstractConvergenceStoppingRule.cpp
+++ b/src/revlanguage/analysis/RlAbstractConvergenceStoppingRule.cpp
@@ -7,10 +7,13 @@
 #include "ArgumentRule.h"
 #include "ArgumentRules.h"
 #include "EssMax.h"
+#include "FixedBurnin.h"
 #include "OptionRule.h"
+#include "Probability.h"
 #include "RlAbstractConvergenceStoppingRule.h"
 #include "RbException.h"
 #include "RlString.h"
+#include "RlUserInterface.h"
 #include "SemMin.h"
 #include "TypeSpec.h"
 #include "IntegerPos.h"
@@ -44,11 +47,24 @@ RevBayesCore::BurninEstimatorContinuous* AbstractConvergenceStoppingRule::constr
     
     if ( bm == "ESS" )
     {
+        if ( burnin != NULL && burnin->getName() != ".burnin" )
+        {
+            RBOUT( "Warning: the `burnin` argument is ignored when `burninMethod` is \"ESS\"." );
+        }
         burninEst = new RevBayesCore::EssMax();
     }
     else if ( bm == "SEM" )
     {
+        if ( burnin != NULL && burnin->getName() != ".burnin" )
+        {
+            RBOUT( "Warning: the `burnin` argument is ignored when `burninMethod` is \"SEM\"." );
+        }
         burninEst = new RevBayesCore::SemMin();
+    }
+    else if ( bm == "fixed" )
+    {
+        double fraction = static_cast<const Probability &>( burnin->getRevObject() ).getValue();
+        burninEst = new RevBayesCore::FixedBurnin( fraction );
     }
     else
     {
@@ -95,8 +111,9 @@ const MemberRules& AbstractConvergenceStoppingRule::getParameterRules(void) cons
         std::vector<std::string> bMethods;
         bMethods.push_back( "ESS" );
         bMethods.push_back( "SEM" );
-        //        optionsUnits.push_back( "fixed" );
+        bMethods.push_back( "fixed" );
         memberRules.push_back( new OptionRule( "burninMethod", new RlString("ESS"), bMethods, "Which type of burnin method to use." ) );
+        memberRules.push_back( new ArgumentRule( "burnin", Probability::getClassTypeSpec(), "The fraction of samples to discard as burnin (only used when burninMethod is \"fixed\").", ArgumentRule::BY_VALUE, ArgumentRule::ANY, new Probability(0.1) ) );
         
         
         rules_set = true;
@@ -119,7 +136,11 @@ const TypeSpec& AbstractConvergenceStoppingRule::getTypeSpec( void ) const
 void AbstractConvergenceStoppingRule::setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var)
 {
     
-    if ( name == "burninMethod" )
+    if ( name == "burnin" )
+    {
+        burnin = var;
+    }
+    else if ( name == "burninMethod" )
     {
         burninMethod = var;
     }

--- a/src/revlanguage/analysis/RlAbstractConvergenceStoppingRule.h
+++ b/src/revlanguage/analysis/RlAbstractConvergenceStoppingRule.h
@@ -43,6 +43,7 @@ namespace RevLanguage {
         
         virtual void                                setConstParameter(const std::string& name, const RevPtr<const RevVariable> &var);     //!< Set member variable
         
+        RevPtr<const RevVariable>                   burnin;
         RevPtr<const RevVariable>                   burninMethod;
         RevPtr<const RevVariable>                   filename;
         RevPtr<const RevVariable>                   frequency;

--- a/tests/test_convergenceRules/output_expected/Test_multipleRules.errout
+++ b/tests/test_convergenceRules/output_expected/Test_multipleRules.errout
@@ -13,19 +13,19 @@
    Minimum effective sample size (ESS): 4.322936 (target: > 50)
    Maximum value of the Gelman-Rubin statistic (PSRF): 1.031482 (target: < 1.01)
    Comparisons in which the Geweke test statistic is < 0.0005 or > 0.9995: 10/20 (target: 0/20)
-   Comparisons in which the CI of a single-chain mean excludes the overall mean at p = 0.25: 3/20 (target: 0/20)
+   Comparisons in which the CI of a single-chain mean excludes the overall mean at p = 0.25: 6/20 (target: 0/20)
    
    
    Minimum effective sample size (ESS): 11.000000 (target: > 50)
    Maximum value of the Gelman-Rubin statistic (PSRF): 1.031441 (target: < 1.01)
    Comparisons in which the Geweke test statistic is < 0.0005 or > 0.9995: 0/20 (target: 0/20)
-   Comparisons in which the CI of a single-chain mean excludes the overall mean at p = 0.25: 0/20 (target: 0/20)
+   Comparisons in which the CI of a single-chain mean excludes the overall mean at p = 0.25: 4/20 (target: 0/20)
    
    
    Minimum effective sample size (ESS): 15.850371 (target: > 50)
    Maximum value of the Gelman-Rubin statistic (PSRF): 0.992524 (target: < 1.01)
    Comparisons in which the Geweke test statistic is < 0.0005 or > 0.9995: 1/20 (target: 0/20)
-   Comparisons in which the CI of a single-chain mean excludes the overall mean at p = 0.25: 0/20 (target: 0/20)
+   Comparisons in which the CI of a single-chain mean excludes the overall mean at p = 0.25: 1/20 (target: 0/20)
    
    
    Minimum effective sample size (ESS): 26.164988 (target: > 50)
@@ -37,7 +37,7 @@
    Minimum effective sample size (ESS): 40.212909 (target: > 50)
    Maximum value of the Gelman-Rubin statistic (PSRF): 0.995007 (target: < 1.01)
    Comparisons in which the Geweke test statistic is < 0.0005 or > 0.9995: 1/20 (target: 0/20)
-   Comparisons in which the CI of a single-chain mean excludes the overall mean at p = 0.25: 0/20 (target: 0/20)
+   Comparisons in which the CI of a single-chain mean excludes the overall mean at p = 0.25: 1/20 (target: 0/20)
    
    
    Minimum effective sample size (ESS): 51.000000 (target: > 50)

--- a/tests/test_convergenceRules/output_expected/Test_multipleRules.errout
+++ b/tests/test_convergenceRules/output_expected/Test_multipleRules.errout
@@ -11,37 +11,37 @@
    
    
    Minimum effective sample size (ESS): 4.322936 (target: > 50)
-   Maximum value of the Gelman-Rubin statistic (PSRF): 1.030398 (target: < 1.01)
+   Maximum value of the Gelman-Rubin statistic (PSRF): 1.031482 (target: < 1.01)
    Comparisons in which the Geweke test statistic is < 0.0005 or > 0.9995: 10/20 (target: 0/20)
-   Comparisons in which the CI of a single-chain mean excludes the overall mean at p = 0.25: 5/20 (target: 0/20)
+   Comparisons in which the CI of a single-chain mean excludes the overall mean at p = 0.25: 3/20 (target: 0/20)
    
    
    Minimum effective sample size (ESS): 11.000000 (target: > 50)
-   Maximum value of the Gelman-Rubin statistic (PSRF): 1.001832 (target: < 1.01)
+   Maximum value of the Gelman-Rubin statistic (PSRF): 1.031441 (target: < 1.01)
    Comparisons in which the Geweke test statistic is < 0.0005 or > 0.9995: 0/20 (target: 0/20)
-   Comparisons in which the CI of a single-chain mean excludes the overall mean at p = 0.25: 2/20 (target: 0/20)
+   Comparisons in which the CI of a single-chain mean excludes the overall mean at p = 0.25: 0/20 (target: 0/20)
    
    
    Minimum effective sample size (ESS): 15.850371 (target: > 50)
-   Maximum value of the Gelman-Rubin statistic (PSRF): 0.993161 (target: < 1.01)
+   Maximum value of the Gelman-Rubin statistic (PSRF): 0.992524 (target: < 1.01)
    Comparisons in which the Geweke test statistic is < 0.0005 or > 0.9995: 1/20 (target: 0/20)
    Comparisons in which the CI of a single-chain mean excludes the overall mean at p = 0.25: 0/20 (target: 0/20)
    
    
    Minimum effective sample size (ESS): 26.164988 (target: > 50)
-   Maximum value of the Gelman-Rubin statistic (PSRF): 0.992706 (target: < 1.01)
+   Maximum value of the Gelman-Rubin statistic (PSRF): 0.997423 (target: < 1.01)
    Comparisons in which the Geweke test statistic is < 0.0005 or > 0.9995: 0/20 (target: 0/20)
    Comparisons in which the CI of a single-chain mean excludes the overall mean at p = 0.25: 0/20 (target: 0/20)
    
    
    Minimum effective sample size (ESS): 40.212909 (target: > 50)
-   Maximum value of the Gelman-Rubin statistic (PSRF): 0.993523 (target: < 1.01)
-   Comparisons in which the Geweke test statistic is < 0.0005 or > 0.9995: 0/20 (target: 0/20)
-   Comparisons in which the CI of a single-chain mean excludes the overall mean at p = 0.25: 1/20 (target: 0/20)
+   Maximum value of the Gelman-Rubin statistic (PSRF): 0.995007 (target: < 1.01)
+   Comparisons in which the Geweke test statistic is < 0.0005 or > 0.9995: 1/20 (target: 0/20)
+   Comparisons in which the CI of a single-chain mean excludes the overall mean at p = 0.25: 0/20 (target: 0/20)
    
    
    Minimum effective sample size (ESS): 51.000000 (target: > 50)
-   Maximum value of the Gelman-Rubin statistic (PSRF): 0.993101 (target: < 1.01)
+   Maximum value of the Gelman-Rubin statistic (PSRF): 0.987537 (target: < 1.01)
    Comparisons in which the Geweke test statistic is < 0.0005 or > 0.9995: 0/20 (target: 0/20)
    Comparisons in which the CI of a single-chain mean excludes the overall mean at p = 0.25: 0/20 (target: 0/20)
    

--- a/tests/test_convergenceRules/output_expected/Test_zeroCheckFrequency.errout
+++ b/tests/test_convergenceRules/output_expected/Test_zeroCheckFrequency.errout
@@ -10,6 +10,7 @@
    srMinESS (RealPos<any> minEss,
              String<any> filename,
              IntegerPos<any> frequency,
-             String<any> burninMethod {valid options: "ESS"|"SEM"})
+             String<any> burninMethod {valid options: "ESS"|"SEM"|"fixed"},
+             Probability<any> burnin)
    
    Missing Variable:	Variable stopping_rules does not exist

--- a/tests/test_convergenceRules/scripts/Test_multipleRules.Rev
+++ b/tests/test_convergenceRules/scripts/Test_multipleRules.Rev
@@ -35,13 +35,25 @@ monitors.append( mnModel(filename = "output/multipleRules_test.log", printgen = 
 
 mymcmc = mcmc(mymodel, monitors, moves, nruns = 4)
 
-# Calculate the four convergence rules after every 1000 iterations, and stop as soon as
-# all of them reach their respective thresholds:
+#########################################################################################
+# Calculate the four convergence rules after every 1000 iterations, and stop as soon as #
+# all of them reach their respective thresholds:                                        #
+#########################################################################################
 
+# Default burninMethod (ESS)
 stopping_rules[1] = srMinESS(50, file = "output/multipleRules_test.log", freq = 1000)
-stopping_rules[2] = srGelmanRubin(1.01, file = "output/multipleRules_test.log", freq = 1000)
-stopping_rules[3] = srGeweke(0.001, file = "output/multipleRules_test.log", freq = 1000)
-stopping_rules[4] = srStationarity(0.25, file = "output/multipleRules_test.log", freq = 1000)
+
+# Fixed burnin, non-default value
+stopping_rules[2] = srGelmanRubin(1.01, file = "output/multipleRules_test.log", freq = 1000,
+                                  burninMethod = "fixed", burnin = 0.25)
+
+# Setting burninMethod to SEM
+stopping_rules[3] = srGeweke(0.001, file = "output/multipleRules_test.log", freq = 1000,
+                             burninMethod = "SEM")
+
+# Fixed burnin, default value
+stopping_rules[4] = srStationarity(0.25, file = "output/multipleRules_test.log", freq = 1000,
+                                   burninMethod = "fixed")
 
 # Start the MCMC run
 mymcmc.run(rules = stopping_rules, verbose = 2)


### PR DESCRIPTION
## PR Type
- New Feature

## Summary
Our convergence rules (`srGelmanRubin`, `srGeweke`, `srMinESS`, `srStationarity`) automatically determine the burnin fraction to be discarded in order to optimize the test statistic, but this can be too computationally demanding for very long traces with lots of monitored parameters. Here, I implement a new option, `burninMethod="fixed"`, that simply discards a constant fraction of samples collected so far. I have modified an existing test to check that it works as intended.

## Approach
The `burninMethod` argument is still set to `"ESS"` by default, since the computational cost is trivial in most cases. When the `"fixed"` option is chosen instead, the newly added `burnin` parameter is used to specify what fraction of the chain should be discarded before the test statistic is computed. By default, `burnin` is set to 0.25. If the user explicitly sets `burnin` but uses `burninMethod="ESS"` or `burninMethod="SEM"`, a warning is displayed to let the user know that the argument will be ignored.

I considered throwing an exception when `burninMethod="fixed"` and `burnin` is not specified, but I think a default value makes more sense.

## Additional notes
The fact that `burnin` has a default value (i.e., it is never null) but we want to display a warning if the user explicitly sets it while using an incompatible `burninMethod` leads to something of a conundrum – we don't have an established way of distinguishing between arguments that are non-null because they have a default, and arguments that are non-null because they have been explicitly set by the user. This PR solves this problem by exploiting the fact that when `Function::processArguments()` fills in an empty slot using its `ArgumentRule` default, the synthesized variable is named with a leading dot. Since we do not allow variable names with leading dots in the user space, this criterion is reliable.

## Testing
I have modified an existing test: `test_convergenceRules/scripts/Test_multipleRules.Rev`.

## Relevant issues
See #1020 for a case where this option comes in handy.

## Checklist
- I have added or updated tests for this change, or explained why they are not needed.
- I have added or updated documentation where necessary.

### AI/LLM Assistance
- I used Composer 2.5 to assist with this PR. It helped me figure out that instead of a more extensive refactoring of the Core back ends of the individual convergence rules, which I originally thought would be necessary, it's more elegant to just create a new class deriving from `BurninEstimatorContinuous`.