### PR TITLE
Free infinite asterisks? No thank you!

### DIFF
--- a/src/core/io/ProgressBar.cpp
+++ b/src/core/io/ProgressBar.cpp
@@ -47,7 +47,13 @@ void ProgressBar::update( size_t i )
     
     if ( process_active == true )
     {
+        if ( max <= offset )
+        {
+            return;
+        }
+
         size_t progress = 68 * double(i-offset) / double(max-offset);
+        
         if ( progress > num_stars )
         {
                 

--- a/tests/test_validation/output_expected/Test_validationBurnin.errout
+++ b/tests/test_validation/output_expected/Test_validationBurnin.errout
@@ -1,0 +1,8 @@
+   
+   Running burn-in phase of 1 Monte Carlo samplers each for 10 iterations.
+   
+
+Progress:
+0---------------25---------------50---------------75--------------100
+
+

--- a/tests/test_validation/scripts/Test_validationBurnin.Rev
+++ b/tests/test_validation/scripts/Test_validationBurnin.Rev
@@ -1,0 +1,25 @@
+################################################################################
+#
+# RevBayes Test-Script: Check that the burnin progress monitor can deal with
+#                       blocks of length zero.
+#
+# authors: David Cerny
+#
+################################################################################
+
+seed(12345)
+
+# use a setup originally suggested by Wonseop Lim
+# (see https://github.com/revbayes/revbayes/issues/1046)
+
+n_val_reps = 1
+iter = 100
+moves = VectorMoves()
+monitors = VectorMonitors()
+x ~ dnNormal(0, 1)
+mymodel = model(x)
+mymcmc  = mcmc(mymodel, monitors, moves)
+v = validationAnalysis(mymcmc, n_val_reps, directory="output")
+v.burnin(generations=0.1*iter, tuningInterval=100)
+
+q()


### PR DESCRIPTION
## PR Type
- Bug Fix

## Summary
In a few edge cases (documented for `ValidationAnalysis` in #1046 and for `powerPosterior` – in anticipation of some proposed changes – over at #991), the burnin stage of a sampler may be run for 0 generations, and this causes the progress monitor to keep endlessly printing asterisks to the standard output if RevBayes was compiled with GCC (interestingly, Clang can optimize this out). Here, I add a guard against the division by zero that underlies the problem.

## Testing
I have added a new test: `test_validation/scripts/Test_validationBurnin.Rev`.

## Relevant issues
Fixes #1046.
