### PR TITLE
fix(WN): dnPhyloWhiteNoise summed log() of an already-log density

### DIFF
--- a/src/core/distributions/phylogenetics/continuousCharacter/PhyloWhiteNoiseProcess.cpp
+++ b/src/core/distributions/phylogenetics/continuousCharacter/PhyloWhiteNoiseProcess.cpp
@@ -58,7 +58,7 @@ double PhyloWhiteNoiseProcess::recursiveLnProb(const TopologyNode &from)
         double alpha = mean * mean / (stdev * stdev);
         double beta = mean / (stdev * stdev);
         double v = (*value)[from.getIndex()];
-        lnProb += log( RbStatistics::Gamma::lnPdf(alpha,beta,v) );
+        lnProb += RbStatistics::Gamma::lnPdf(alpha,beta,v);
     }
     
     size_t numChildren = from.getNumberOfChildren();


### PR DESCRIPTION
<!-- Thank you for contributing to RevBayes! -->

## PR Type
<!-- Delete the types that don't apply -->
- 🐛 Bug Fix

## Summary
<!-- In 1-3 sentences:-->
`PhyloWhiteNoiseProcess::recursiveLnProb:61` wraps `RbStatistics::Gamma::lnPdf`, which already returns a log-density in another `log()`, so it returns `log(log-pdf)` instead of `log-pdf`.

```cpp
lnProb += log( RbStatistics::Gamma::lnPdf(alpha,beta,v) )
```

Fixed by removing the redundant log():

```cpp
lnProb += RbStatistics::Gamma::lnPdf(alpha,beta,v);
```

## Testing
<!-- Briefly, How can we be sure that this change works? -->
<!-- Consider: What tests have you added to ensure that it won't break in the future? -->
<!-- See the tests/ directory for examples of existing tests. -->

<!-- Briefly, How can we be sure that this change works? -->

<!-- Consider: What tests have you added to ensure that it won't break in the future? -->

<!-- See the tests/ directory for examples of existing tests. -->

Checked against the closed-form density on a 2-taxon toy example:

```rev
tree <- readTrees(text="(A:1.0,B:1.0);")[1]
rel ~ dnPhyloWhiteNoise(tree=tree, sigma=1.0)
rel.setValue([1.0, 1.0])
print(rel.lnProbability())
```
Development branch returns `nan` while post-fix branch returns `-2.0` matching the analytic expectation `2 * Gamma::lnPdf(1, 1, 1)`.

No automated test added.

## Relevant issues
<!-- e.g. "Fixes #123 -->
Fixes #1053 

## Checklist
- [v] I have added or updated tests for this change, or explained why they are not needed.
- [v] I have added or updated documentation where necessary.

### AI/LLM Assistance
- [ ] I used an AI/LLM tool to assist with this PR
  - *If checked, I affirm that:*
      - *I personally understand the submitted changes and take responsibility for their correctness, style, and maintainability.*
      - *I will answer reviewer questions in my own words without copy-pasting AI output.*
      - *I am the primary author of the PR cover letter (e.g. it wasn't AI/LLM generated).*
      - *I have cleaned up the AI-generated code (e.g. removing verbose comments.)*
