### PR TITLE
Test/windows git checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
     steps:
     - name: Install git (containers have none preinstalled)
       if: matrix.image != ''
-      run: 
+      run: |
         apt-get update && apt-get install -y git
         git config --system --add safe.directory '*'
     - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,7 +363,7 @@ jobs:
     name: Notify Slack
     needs: [build_singularity_and_upload, build_and_upload]
     runs-on: ubuntu-latest
-    if: always()
+    if: false
     steps:
     - uses: technote-space/workflow-conclusion-action@v3
     - uses: 8398a7/action-slack@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,7 +363,7 @@ jobs:
     name: Notify Slack
     needs: [build_singularity_and_upload, build_and_upload]
     runs-on: ubuntu-latest
-    if: false
+    if: always()
     steps:
     - uses: technote-space/workflow-conclusion-action@v3
     - uses: 8398a7/action-slack@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,9 @@ jobs:
     steps:
     - name: Install git (containers have none preinstalled)
       if: matrix.image != ''
-      run: apt-get update && apt-get install -y git
+      run: 
+        apt-get update && apt-get install -y git
+        git config --system --add safe.directory '*'
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,9 @@ jobs:
     container:
       image: ${{ matrix.image || '' }}
     steps:
+    - name: Install git (containers have none preinstalled)
+      if: matrix.image != ''
+      run: apt-get update && apt-get install -y git
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:


### PR DESCRIPTION


## PR Type

- 🚦 Infrastructure?

## Summary

The Windows release build's startup banner is missing its git branch and commit information (`Build from () on ...` instead of `Build from tags/v1.4.1 (3a504e) on ...`).
This is caused by the Windows job's `container: image: ubuntu 25.04` having no `git` preinstalled when `actions/checkout` runs, so checkout was falling back silently to a tarball download without the `.git` directory. This PR installs `git` before checkout and marks the workspace as a safe directory so later steps can run git commands.

## Approach

Added a step that installs `git` before `actions/checkout` runs.


## Additional notes
None.

## Testing

- Verified against a workflow run (`release.yml`) triggered by a tag.
- `actions/checkout` performed a real `git init` and `git fetch` instead of falling back to a tarball download.
- The built `rb.exe`'s startup banner shows the correct `Build from tags/zz-test-windows-git-checkout-1 (ed0709) on Sun Jul 19 11:03:32 UTC 2026` line, matching the Linux build from the same commit.


## Relevant issues
Fixes #1063.

## TODO before merging
None.

## Checklist
- [x] I have added or updated tests for this change, or explained why they are not needed.
- [ ] I have added or updated documentation where necessary.

### AI/LLM Assistance
- [x] I used an AI/LLM tool to assist with this PR to guide me with the git commands necessary for creating a tag and triggering the release action.
