### PR TITLE
Recognize "Enter" keystroke on Windows

### DIFF
--- a/src/libs/linenoise/linenoise.c
+++ b/src/libs/linenoise/linenoise.c
@@ -719,6 +719,12 @@ static int fd_read(struct current *current) {
                         return SPECIAL_PAGE_UP;
                     case VK_NEXT:
                         return SPECIAL_PAGE_DOWN;
+                    case VK_RETURN:
+                        /* Numpad Enter is reported as enhanced VK_RETURN; main
+                         * Return is non-enhanced and arrives as AsciiChar '\r'
+                         * below. Without this, numpad Enter is silently ignored
+                         * (https://github.com/revbayes/revbayes/issues/529). */
+                        return '\r';
                 }
             }/* Note that control characters are already translated in AsciiChar */
             else {


### PR DESCRIPTION
## PR Type
- New Feature / Bug Fix

## Summary
This branch makes a small change to the [`linenoise`](https://github.com/revbayes/revbayes/tree/development/src/libs/linenoise) library in order to ensure that on Windows, the "Enter" keystroke is equivalent to "Return", so that both emit the carriage return `\r`.

## Approach
On Windows, the event associated with pressing "Return" is `VK_RETURN`, which emits an `\r`. However, "Enter" is treated as `VK_RETURN` + `ENHANCED_KEY`, and the modifier prevents it from being recognized – so pressing the key has no effect. The `linenoise` library already knows what to do with `ENHANCED_KEY` in a number of other cases, however, so it's just a matter of telling to recognize the `VK_RETURN` + `ENHANCED_KEY` combo as an event that emits an `\r`. 

## Testing
I don't think there's a way to test this using GitHub Actions, since the problem is inherently restricted to RevBayes behavior in interactive sessions.

## Relevant issues
Fixes #529.

## AI/LLM Assistance
I used Cursor Grok 4.5 to fix the issue. I personally understand the submitted changes and take responsibility for their correctness, style, and maintainability.
