### PR TITLE
Add a Rev function to get the number of MPI processes

### DIFF
--- a/help/md/getNumProcesses.md
+++ b/help/md/getNumProcesses.md
@@ -16,13 +16,11 @@ David Černý
     # For `mpirun -np 16 ./rb-mpi`, this prints 16:
     getNumProcesses()
     
-    # Set the number of MCMC replicates to the number of available processes,
-    # but at least to 4:
-    N_RUNS = max( [getNumProcesses(), 4] )
+    # Record the process count for reproducibility bookkeeping
+    print("Running on " + getNumProcesses() + " process(es).")
     
-    # Create a simple model (unclamped), and run the number of replicates
-    # specified above:
-    x ~ dnExp(10)
-    mymcmc = mcmc( model(x), [mvSlide(x, delta=0.1)], [mnScreen()], nruns=N_RUNS )
-    mymcmc.run(100)
+    # Guard-check the launch configuration
+    if (getNumProcesses() != 32) {
+        stop("Expected 32 processes, got " + getNumProcesses() + ".")
+    }
 ## references

--- a/help/md/getNumProcesses.md
+++ b/help/md/getNumProcesses.md
@@ -1,0 +1,28 @@
+## name
+getNumProcesses
+## title
+Get the number of MPI processes
+## description
+Returns the number of processes used by the current RevBayes session.
+## details
+In an MPI-enabled build (i.e., `rb-mpi`, launched as `mpirun -np N ./rb-mpi`),
+the function returns `N` (i.e., the size of the `MPI_COMM_WORLD` communicator).
+In a non-MPI build, it always returns 1. The value is the number of MPI ranks,
+not necessarily the number of hardware CPU cores.
+## authors
+David Černý
+## see_also
+## example
+    # For `mpirun -np 16 ./rb-mpi`, this prints 16:
+    getNumProcesses()
+    
+    # Set the number of MCMC replicates to the number of available processes,
+    # but at least to 4:
+    N_RUNS = max( [getNumProcesses(), 4] )
+    
+    # Create a simple model (unclamped), and run the number of replicates
+    # specified above:
+    x ~ dnExp(10)
+    mymcmc = mcmc( model(x), [mvSlide(x, delta=0.1)], [mnScreen()], nruns=N_RUNS )
+    mymcmc.run(100)
+## references

--- a/src/core/help/RbHelpDatabase.cpp
+++ b/src/core/help/RbHelpDatabase.cpp
@@ -2940,6 +2940,26 @@ Q3 := fndNdS(fnX3(fnGTR(er, nuc_pi)), omega)         # GTR + X3 + dNdS)");
 	help_strings[string("fndNdS")][string("title")] = string(R"(Add a dN/dS factor to a codon rate matrix.)");
 	help_strings[string("formatDiscreteCharacterData")][string("name")] = string(R"(formatDiscreteCharacterData)");
 	help_strings[string("gamma")][string("name")] = string(R"(gamma)");
+	help_arrays[string("getNumProcesses")][string("authors")].push_back(string(R"(David Černý)"));
+	help_strings[string("getNumProcesses")][string("description")] = string(R"(Returns the number of processes used by the current RevBayes session.)");
+	help_strings[string("getNumProcesses")][string("details")] = string(R"(In an MPI-enabled build (i.e., `rb-mpi`, launched as `mpirun -np N ./rb-mpi`),
+the function returns `N` (i.e., the size of the `MPI_COMM_WORLD` communicator).
+In a non-MPI build, it always returns 1. The value is the number of MPI ranks,
+not necessarily the number of hardware CPU cores.)");
+	help_strings[string("getNumProcesses")][string("example")] = string(R"(# For `mpirun -np 16 ./rb-mpi`, this prints 16:
+getNumProcesses()
+
+# Set the number of MCMC replicates to the number of available processes,
+# but at least to 4:
+N_RUNS = max( [getNumProcesses(), 4] )
+
+# Create a simple model (unclamped), and run the number of replicates
+# specified above:
+x ~ dnExp(10)
+mymcmc = mcmc( model(x), [mvSlide(x, delta=0.1)], [mnScreen()], nruns=N_RUNS )
+mymcmc.run(100))");
+	help_strings[string("getNumProcesses")][string("name")] = string(R"(getNumProcesses)");
+	help_strings[string("getNumProcesses")][string("title")] = string(R"(Get the number of MPI processes)");
 	help_arrays[string("getOption")][string("authors")].push_back(string(R"(Sebastian Hoehna)"));
 	help_strings[string("getOption")][string("description")] = string(R"(Get a global option for RevBayes.)");
 	help_strings[string("getOption")][string("details")] = string(R"(Runtime options are used to personalize RevBayes and are stored on the local machine. See `setOption` for the list of available keys and their associated values.)");

--- a/src/core/help/RbHelpDatabase.cpp
+++ b/src/core/help/RbHelpDatabase.cpp
@@ -2949,15 +2949,13 @@ not necessarily the number of hardware CPU cores.)");
 	help_strings[string("getNumProcesses")][string("example")] = string(R"(# For `mpirun -np 16 ./rb-mpi`, this prints 16:
 getNumProcesses()
 
-# Set the number of MCMC replicates to the number of available processes,
-# but at least to 4:
-N_RUNS = max( [getNumProcesses(), 4] )
+# Record the process count for reproducibility bookkeeping
+print("Running on " + getNumProcesses() + " process(es).")
 
-# Create a simple model (unclamped), and run the number of replicates
-# specified above:
-x ~ dnExp(10)
-mymcmc = mcmc( model(x), [mvSlide(x, delta=0.1)], [mnScreen()], nruns=N_RUNS )
-mymcmc.run(100))");
+# Guard-check the launch configuration
+if (getNumProcesses() != 32) {
+    stop("Expected 32 processes, got " + getNumProcesses() + ".")
+})");
 	help_strings[string("getNumProcesses")][string("name")] = string(R"(getNumProcesses)");
 	help_strings[string("getNumProcesses")][string("title")] = string(R"(Get the number of MPI processes)");
 	help_arrays[string("getOption")][string("authors")].push_back(string(R"(Sebastian Hoehna)"));

--- a/src/revlanguage/functions/basic/Func_getNumProcesses.cpp
+++ b/src/revlanguage/functions/basic/Func_getNumProcesses.cpp
@@ -1,0 +1,110 @@
+#include "Func_getNumProcesses.h"
+
+#include "Natural.h"
+#include "TypeSpec.h"
+#include "ArgumentRules.h"
+#include "Procedure.h"
+#include "RevPtr.h"
+#include "RevVariable.h"
+#include "RlFunction.h"
+
+#ifdef RB_MPI
+#include <mpi.h>
+#endif
+
+using namespace RevLanguage;
+
+/** Default constructor */
+Func_getNumProcesses::Func_getNumProcesses( void ) : Procedure()
+{
+
+}
+
+
+/**
+ * The clone function is a convenience function to create proper copies of inherited objects.
+ * E.g. a.clone() will create a clone of the correct type even if 'a' is of derived type 'b'.
+ *
+ * \return A new copy of the function.
+ */
+Func_getNumProcesses* Func_getNumProcesses::clone( void ) const
+{
+
+    return new Func_getNumProcesses( *this );
+}
+
+
+/** Execute function */
+RevPtr<RevVariable> Func_getNumProcesses::execute( void )
+{
+
+    int num_processes = 1;
+
+#ifdef RB_MPI
+    MPI_Comm_size(MPI_COMM_WORLD, &num_processes);
+#endif
+
+    return new RevVariable( new Natural( num_processes ) );
+}
+
+
+/** Get argument rules */
+const ArgumentRules& Func_getNumProcesses::getArgumentRules( void ) const
+{
+
+    static ArgumentRules argumentRules = ArgumentRules();
+
+    return argumentRules;
+}
+
+
+/** Get Rev type of object */
+const std::string& Func_getNumProcesses::getClassType(void)
+{
+
+    static std::string rev_type = "Func_getNumProcesses";
+
+    return rev_type;
+}
+
+
+/** Get class type spec describing type of object */
+const TypeSpec& Func_getNumProcesses::getClassTypeSpec(void)
+{
+
+    static TypeSpec rev_type_spec = TypeSpec( getClassType(), new TypeSpec( Function::getClassTypeSpec() ) );
+
+    return rev_type_spec;
+}
+
+
+/**
+ * Get the primary Rev name for this function.
+ */
+std::string Func_getNumProcesses::getFunctionName( void ) const
+{
+    // create a name variable that is the same for all instance of this class
+    std::string f_name = "getNumProcesses";
+
+    return f_name;
+}
+
+
+/** Get type spec */
+const TypeSpec& Func_getNumProcesses::getTypeSpec( void ) const
+{
+
+    static TypeSpec type_spec = getClassTypeSpec();
+
+    return type_spec;
+}
+
+
+/** Get return type */
+const TypeSpec& Func_getNumProcesses::getReturnType( void ) const
+{
+
+    static TypeSpec return_typeSpec = Natural::getClassTypeSpec();
+
+    return return_typeSpec;
+}

--- a/src/revlanguage/functions/basic/Func_getNumProcesses.h
+++ b/src/revlanguage/functions/basic/Func_getNumProcesses.h
@@ -1,0 +1,38 @@
+#ifndef Func_getNumProcesses_H
+#define Func_getNumProcesses_H
+
+#include "Procedure.h"
+
+namespace RevLanguage {
+
+    /**
+     * @brief Rev function to get the number of MPI processes.
+     *
+     * For an MPI build, this is MPI_Comm_size(MPI_COMM_WORLD).
+     * For a non-MPI build, this is always 1.
+     */
+    class Func_getNumProcesses : public Procedure {
+
+    public:
+        Func_getNumProcesses( void );
+
+        // Basic utility functions
+        Func_getNumProcesses*                       clone(void) const;                                                          //!< Clone object
+        static const std::string&                   getClassType(void);                                                         //!< Get Rev type
+        static const TypeSpec&                      getClassTypeSpec(void);                                                     //!< Get class type spec
+        std::string                                 getFunctionName(void) const;
+        const TypeSpec&                             getTypeSpec(void) const;                                                    //!< Get language type of the object
+
+        // Func_getNumProcesses functions
+        const ArgumentRules&                        getArgumentRules(void) const;                                               //!< Get argument rules
+        const TypeSpec&                             getReturnType(void) const;                                                  //!< Get type of return val
+
+        RevPtr<RevVariable>                         execute(void);                                                              //!< Execute function
+
+    protected:
+
+    };
+
+}
+
+#endif

--- a/src/revlanguage/workspace/RbRegister_Basic.cpp
+++ b/src/revlanguage/workspace/RbRegister_Basic.cpp
@@ -134,6 +134,7 @@
 #include "Func_appendVector.h"
 #include "Func_clear.h"
 #include "Func_exists.h"
+#include "Func_getNumProcesses.h"
 #include "Func_getOption.h"
 #include "Func_getwd.h"
 #include "Func_help.h"
@@ -323,6 +324,7 @@ void RevLanguage::Workspace::initializeBasicGlobalWorkspace(void)
         addFunction( new Func_clear()                       );
         addFunction( new Func_exists()                      );
         addFunction( new Func_getwd()                       );
+        addFunction( new Func_getNumProcesses()             );
         addFunction( new Func_getOption()                   );
         addFunction( new Func_help()                        );
         addFunction( new Func_ifelse<Natural>()             );


### PR DESCRIPTION
## PR Type
- New Feature

## Summary
This PR adds a new function called `getNumProcesses()`, which returns the number of MPI ranks. The returned number is always equal to 1 for non-MPI builds, and to `N` when an MPI build is executed as `mpirun -np N ./rb-mpi`.

## Approach
The function is just a thin Rev wrapper around `MPI_Comm_size(MPI_COMM_WORLD, size)`.

## Testing
I _could_ add a test that simply prints 1, if people really want me to. But I think a test would be more useful when/if we bring back the option of running the test suite using an MPI build (including comparisons against MPI-specific expected output).

## Relevant issues
Closes #1082.

## AI/LLM Assistance
I used Cursor Grok 4.5 to implement this; I wrote the help file myself. I personally understand the submitted changes and take responsibility for their correctness, style, and maintainability.
