### PR TITLE
Fix time-to-completion estimates for analyses with stopping rules

### DIFF
--- a/src/core/analysis/HillClimber.cpp
+++ b/src/core/analysis/HillClimber.cpp
@@ -652,7 +652,7 @@ void HillClimber::setScheduleType(const std::string &s)
 /**
  * Start the monitors which will open the output streams.
  */
-void HillClimber::startMonitors( size_t num_cycles, bool reopen )
+void HillClimber::startMonitors( size_t num_cycles, bool reopen, double max_seconds )
 {
 
     // Open the output file and print headers
@@ -660,7 +660,7 @@ void HillClimber::startMonitors( size_t num_cycles, bool reopen )
     {
 
         // reset the monitor
-        monitors[i].reset( num_cycles );
+        monitors[i].reset( num_cycles, max_seconds );
 
         // if this chain is active, print the header
         if ( process_active == true )

--- a/src/core/analysis/HillClimber.h
+++ b/src/core/analysis/HillClimber.h
@@ -25,9 +25,9 @@ namespace RevBayesCore {
     public:
         HillClimber(const Model &m, const RbVector<Move> &moves, const RbVector<Monitor> &mons);
         HillClimber(const HillClimber &m);
-        virtual                                            ~HillClimber(void);                                                                             //!< Virtual destructor
+        virtual                                            ~HillClimber(void);                                                                      //!< Virtual destructor
         
-        HillClimber&                                        operator=(const HillClimber &m);                                                               //!< Overloaded assignment operator
+        HillClimber&                                        operator=(const HillClimber &m);                                                        //!< Overloaded assignment operator
         
         // public methods
 //        void                                                addFileMonitorExtension(const std::string &s, bool dir);
@@ -53,14 +53,14 @@ namespace RevBayesCore {
         void                                                setModel(Model *m);
         void                                                setNumberOfProcesses(size_t i);                                                         //!< Set the number of processes for this HillClimber simulation.
         void                                                setScheduleType(const std::string &s);                                                  //!< Set the type of the move schedule
-        void                                                startMonitors(size_t num_cycles, bool reopen);                                          //!< Start the monitors
+        void                                                startMonitors(size_t num_cycles, bool reopen, double maxSeconds);                       //!< Start the monitors
         void                                                tune(void);                                                                             //!< Tune the sampler and its moves.
         void                                                writeMonitorHeaders(void);                                                              //!< Write the headers of the monitors
 
     protected:
         void                                                initializeMonitors(void);                                                               //!< Assign model and HillClimber ptrs to monitors
         void                                                replaceDag(const RbVector<Move> &mvs, const RbVector<Monitor> &mons);
-        void                                                setActivePIDSpecialized(size_t i, size_t n);                                                      //!< Set the number of processes for this class.
+        void                                                setActivePIDSpecialized(size_t i, size_t n);                                            //!< Set the number of processes for this class.
         
         
         Model*                                              model;

--- a/src/core/analysis/MaximumLikelihoodEstimation.h
+++ b/src/core/analysis/MaximumLikelihoodEstimation.h
@@ -36,32 +36,32 @@ namespace RevBayesCore {
         
     public:
         MaximumLikelihoodEstimation(void);
-        virtual                                ~MaximumLikelihoodEstimation(void);                            //!< Virtual destructor
+        virtual                                ~MaximumLikelihoodEstimation(void);                                           //!< Virtual destructor
         
         // pure virtual public methods
 //        virtual void                            addFileMonitorExtension(const std::string &s, bool dir) = 0;
 //        virtual void                            addMonitor(const Monitor &m) = 0;
-        virtual void                            disableScreenMonitor(void) = 0;                     //!< Disable/remove all screen monitors
+        virtual void                            disableScreenMonitor(void) = 0;                                              //!< Disable/remove all screen monitors
         virtual MaximumLikelihoodEstimation*    clone(void) const = 0;
-        virtual void                            finishMonitors(void) = 0;                           //!< Finish the monitors
+        virtual void                            finishMonitors(void) = 0;                                                    //!< Finish the monitors
         virtual Model&                          getModel(void) = 0;
         virtual const Model&                    getModel(void) const = 0;
         virtual double                          getModelLnProbability(bool likelihood_only) = 0;
-        virtual std::string                     getStrategyDescription(void) const = 0;             //!< Get the discription of the strategy used for this sampler.
-        virtual bool                            hasConverged(double m) = 0;                         //!< Has the estimator converged to the maximum likelihood value
-        virtual void                            initializeSampler(void) = 0;                        //!< Initialize objects for mcmc sampling
+        virtual std::string                     getStrategyDescription(void) const = 0;                                      //!< Get the discription of the strategy used for this sampler.
+        virtual bool                            hasConverged(double m) = 0;                                                  //!< Has the estimator converged to the maximum likelihood value
+        virtual void                            initializeSampler(void) = 0;                                                 //!< Initialize objects for mcmc sampling
         virtual void                            monitor(std::uint64_t g) = 0;
         virtual void                            nextCycle(void) = 0;
         virtual void                            removeMonitors(void) = 0;
-        virtual void                            reset(void) = 0;                                    //!< Reset the sampler for a new run.
+        virtual void                            reset(void) = 0;                                                             //!< Reset the sampler for a new run.
         virtual void                            setModel(Model *m) = 0;
-        virtual void                            startMonitors(size_t num_cycles, bool reopen) = 0;  //!< Start the monitors
-        virtual void                            tune(void) = 0;                                     //!< Tune the sampler and its moves.
-        virtual void                            writeMonitorHeaders(void) = 0;                      //!< Write the headers of the monitors
+        virtual void                            startMonitors(size_t num_cycles, bool reopen, double maxSeconds = 0.0) = 0;  //!< Start the monitors
+        virtual void                            tune(void) = 0;                                                              //!< Tune the sampler and its moves.
+        virtual void                            writeMonitorHeaders(void) = 0;                                               //!< Write the headers of the monitors
 
         // public methods
-        size_t                                  getCurrentGeneration(void) const;                   //!< Get the current generations number
-        //        void                                    initializeMonitors(void);                         //!< Assign model and mcmc ptrs to monitors
+        size_t                                  getCurrentGeneration(void) const;                                            //!< Get the current generations number
+        //        void                                    initializeMonitors(void);                                          //!< Assign model and mcmc ptrs to monitors
         //        void                                    redrawChainState(void);
         
     protected:
@@ -72,7 +72,7 @@ namespace RevBayesCore {
     };
     
     // Global functions using the class
-    std::ostream&                               operator<<(std::ostream& o, const MaximumLikelihoodEstimation& x);                                //!< Overloaded output operator
+    std::ostream&                               operator<<(std::ostream& o, const MaximumLikelihoodEstimation& x);           //!< Overloaded output operator
     
 }
 

--- a/src/core/analysis/MonteCarloAnalysis.cpp
+++ b/src/core/analysis/MonteCarloAnalysis.cpp
@@ -26,6 +26,7 @@
 #include "RbVectorImpl.h"
 #include "StoppingRule.h"
 #include "MaxIterationStoppingRule.h"
+#include "MaxTimeStoppingRule.h"
 #include "Trace.h"
 
 
@@ -587,6 +588,22 @@ void MonteCarloAnalysis::run( size_t kIterations, RbVector<StoppingRule> rules, 
             }
         }
     }
+
+    // Analogously, extract a wall-clock time target from any srMaxTime rules (again taking the most restrictive in the
+    // unexpected case of having more than one) and pass it to the monitors alongside the iteration target.
+    double max_seconds = 0.0;
+    for (size_t i = 0; i < rules.size(); ++i)
+    {
+        const MaxTimeStoppingRule* max_time = dynamic_cast<const MaxTimeStoppingRule*>( &rules[i] );
+        if ( max_time != NULL )
+        {
+            double rule_max = max_time->getMaxTime();
+            if ( max_seconds == 0.0 || rule_max < max_seconds )
+            {
+                max_seconds = rule_max;
+            }
+        }
+    }
     
     // get the current generation
     size_t gen = 0;
@@ -672,7 +689,7 @@ void MonteCarloAnalysis::run( size_t kIterations, RbVector<StoppingRule> rules, 
                 runs[i]->disableScreenMonitor(true, i);
             }
             
-            runs[i]->startMonitors( kIterations, runs[i]->getCurrentGeneration() > 0 );
+            runs[i]->startMonitors( kIterations, runs[i]->getCurrentGeneration() > 0, max_seconds );
             
         }
         

--- a/src/core/analysis/MonteCarloAnalysis.cpp
+++ b/src/core/analysis/MonteCarloAnalysis.cpp
@@ -671,6 +671,38 @@ void MonteCarloAnalysis::run( size_t kIterations, RbVector<StoppingRule> rules, 
                 ss << "    " << statement;
             }
         }
+
+        // If the analysis includes a screen monitor (which prints an ETA column by default) but neither an iteration nor a time target,
+        // (i.e., the 'generations' argument was not specified, and the stopping-rule vector contains neither MaxIteration nor MaxTime),
+        // we point out that ETA is going to be "??:??:??"
+        bool has_iteration_or_time_target = false;
+        for (size_t i = 0; i < rules.size(); ++i)
+        {
+            if ( dynamic_cast<const MaxIterationStoppingRule*>( &rules[i] ) != NULL ||
+                 dynamic_cast<const MaxTimeStoppingRule*>( &rules[i] ) != NULL )
+            {
+                has_iteration_or_time_target = true;
+                break;
+            }
+        }
+
+        bool has_screen_monitor = false;
+        RbVector<Monitor>& mons = runs[0]->getMonitors();
+        for (size_t i = 0; i < mons.size(); ++i)
+        {
+            if ( mons[i].isScreenMonitor() )
+            {
+                has_screen_monitor = true;
+                break;
+            }
+        }
+
+        if ( !has_iteration_or_time_target && has_screen_monitor )
+        {
+            ss << "\n";
+            ss << "NOTE: This run uses only convergence-based stopping rules, so there is no information\n";
+            ss << "      from which to estimate a time to completion (ETA).\n";
+        }
         
         RBOUT( ss.str() );
     }

--- a/src/core/analysis/MonteCarloAnalysis.cpp
+++ b/src/core/analysis/MonteCarloAnalysis.cpp
@@ -25,6 +25,7 @@
 #include "RbVector.h"
 #include "RbVectorImpl.h"
 #include "StoppingRule.h"
+#include "MaxIterationStoppingRule.h"
 #include "Trace.h"
 
 
@@ -566,6 +567,26 @@ void MonteCarloAnalysis::run( size_t kIterations, RbVector<StoppingRule> rules, 
 void MonteCarloAnalysis::run( size_t kIterations, RbVector<StoppingRule> rules, size_t tuning_interval, const path &checkpoint_file, size_t checkpoint_interval, int verbose )
 #endif
 {
+    
+    // When the 'generations' argument was omitted but the user supplied at least one srMaxIteration stopping rule, use it
+    // as the planned run length so that monitors (especially the "ETA" column of mnScreen) treat it as equivalent to
+    // .run(generations=N). We would not expect more than one srMaxIteration rule to be supplied, but if it does happen for
+    // whatever reason, we will use the most restrictive rule (i.e., the one specifying the shortest run).
+    if ( kIterations == 0 )
+    {
+        for (size_t i = 0; i < rules.size(); ++i)
+        {
+            const MaxIterationStoppingRule* max_iter = dynamic_cast<const MaxIterationStoppingRule*>( &rules[i] );
+            if ( max_iter != NULL )
+            {
+                size_t rule_max = max_iter->getMaxGenerations();
+                if ( kIterations == 0 || rule_max < kIterations )
+                {
+                    kIterations = rule_max;
+                }
+            }
+        }
+    }
     
     // get the current generation
     size_t gen = 0;

--- a/src/core/analysis/mcmc/Mcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmc.cpp
@@ -1135,7 +1135,7 @@ void Mcmc::setScheduleType(const std::string &s)
 /**
  * Start the monitors which will open the output streams.
  */
-void Mcmc::startMonitors( size_t num_cycles, bool reopen )
+void Mcmc::startMonitors( size_t num_cycles, bool reopen, double max_seconds )
 {
     
     // Open the output file and print headers
@@ -1146,7 +1146,7 @@ void Mcmc::startMonitors( size_t num_cycles, bool reopen )
         monitors[i].openStream( reopen );
         
         // reset the monitor
-        monitors[i].reset( num_cycles );
+        monitors[i].reset( num_cycles, max_seconds );
         
     }
     

--- a/src/core/analysis/mcmc/Mcmc.h
+++ b/src/core/analysis/mcmc/Mcmc.h
@@ -76,7 +76,7 @@ namespace RevBayesCore {
         void                                                setMoves(const RbVector<Move> &mvs);
         void                                                setMovesTuningInfo(const std::vector<tuningInfo> &mvs_ti);
         void                                                setScheduleType(const std::string &s);                                                  //!< Set the type of the move schedule
-        void                                                startMonitors(size_t numCycles, bool reopen) override;                                  //!< Start the monitors
+        void                                                startMonitors(size_t numCycles, bool reopen, double maxSeconds) override;               //!< Start the monitors
         void                                                tune(void) override;                                                                    //!< Tune the sampler and its moves.
         void                                                writeMonitorHeaders(bool screen_only) override;                                         //!< Write the headers of the monitors
         

--- a/src/core/analysis/mcmc/Mcmcmc.cpp
+++ b/src/core/analysis/mcmc/Mcmcmc.cpp
@@ -1357,7 +1357,7 @@ void Mcmcmc::setActivePIDSpecialized(size_t i, size_t n)
 /**
  * Start the monitors at the beginning of a run which will simply delegate this call to each chain.
  */
-void Mcmcmc::startMonitors(size_t num_cycles, bool reopen)
+void Mcmcmc::startMonitors(size_t num_cycles, bool reopen, double max_seconds)
 {
     
     // Monitor
@@ -1366,7 +1366,7 @@ void Mcmcmc::startMonitors(size_t num_cycles, bool reopen)
         
         if ( chains[i] != NULL )
         {
-            chains[i]->startMonitors( num_cycles, reopen );
+            chains[i]->startMonitors( num_cycles, reopen, max_seconds );
         }
         
     }

--- a/src/core/analysis/mcmc/Mcmcmc.h
+++ b/src/core/analysis/mcmc/Mcmcmc.h
@@ -69,7 +69,7 @@ namespace RevBayesCore {
         void                                    setSwapInterval2(const size_t &si2);
         void                                    setLikelihoodHeat(double h) override;                                                   //!< Set the heat of the likelihood function.
         void                                    setModel(Model *m, bool redraw) override;
-        void                                    startMonitors(size_t numCycles, bool reopen) override;                                  //!< Start the monitors
+        void                                    startMonitors(size_t numCycles, bool reopen, double maxSeconds) override;               //!< Start the monitors
         void                                    tune(void) override;                                                                    //!< Tune the sampler and its moves.
         void                                    writeMonitorHeaders(bool screen_only) override;                                         //!< Write the headers of the monitors.
 

--- a/src/core/analysis/mcmc/MonteCarloSampler.h
+++ b/src/core/analysis/mcmc/MonteCarloSampler.h
@@ -38,12 +38,12 @@ namespace RevBayesCore {
     public:
         MonteCarloSampler(void);
         MonteCarloSampler(const MonteCarloSampler &m);
-        virtual                                ~MonteCarloSampler(void);                                    //!< Virtual destructor
+        virtual                                ~MonteCarloSampler(void);                                                    //!< Virtual destructor
                 
         // pure virtual public methods
         virtual void                            addFileMonitorExtension(const std::string &s, bool dir) = 0;
         virtual void                            addMonitor(const Monitor &m) = 0;
-        virtual void                            disableScreenMonitor(bool all, size_t rep) = 0;             //!< Disable/remove all screen monitors
+        virtual void                            disableScreenMonitor(bool all, size_t rep) = 0;                             //!< Disable/remove all screen monitors
         virtual MonteCarloSampler*              clone(void) const = 0;
 //        virtual void                            run(size_t g) = 0;
         virtual void                            finishMonitors(size_t n, MonteCarloAnalysisOptions::TraceCombinationTypes ct) = 0; //!< Finish the monitors
@@ -51,31 +51,31 @@ namespace RevBayesCore {
         virtual double                          getModelLnProbability(bool like_only) = 0;
         virtual RbVector<Monitor>&              getMonitors(void) = 0;
         virtual RbVector<Move>&                 getMoves(void) = 0;
-        virtual std::string                     getStrategyDescription(void) const = 0;                     //!< Get the discription of the strategy used for this sampler.
-        virtual void                            initializeSampler() = 0;                                    //!< Initialize objects for mcmc sampling
+        virtual std::string                     getStrategyDescription(void) const = 0;                                     //!< Get the discription of the strategy used for this sampler.
+        virtual void                            initializeSampler() = 0;                                                    //!< Initialize objects for mcmc sampling
         virtual void                            monitor(std::uint64_t g) = 0;
         virtual void                            nextCycle(bool advanceCycle) = 0;
         virtual void                            printOperatorSummary(bool current_period) = 0;
-        virtual void                            redrawStartingValues(void) = 0;                             //!< Redraw the starting values.
+        virtual void                            redrawStartingValues(void) = 0;                                             //!< Redraw the starting values.
         virtual void                            removeMonitors(void) = 0;
-        virtual void                            reset(void) = 0;                                            //!< Reset the sampler for a new run.
+        virtual void                            reset(void) = 0;                                                            //!< Reset the sampler for a new run.
         virtual void                            setCheckpointFile(const path &f) = 0;
-        virtual void                            setLikelihoodHeat(double v) = 0;                            //!< Set the heating temparature of the likelihood of the chain
-//        virtual void                            setMasterSampler(bool tf) = 0;                              //!< Set whether this one is the master.
+        virtual void                            setLikelihoodHeat(double v) = 0;                                            //!< Set the heating temparature of the likelihood of the chain
+//        virtual void                            setMasterSampler(bool tf) = 0;                                            //!< Set whether this one is the master.
         virtual void                            setModel(Model *m, bool redraw) = 0;
-        virtual void                            startMonitors(size_t numCycles, bool reopen) = 0;           //!< Start the monitors
-        virtual void                            tune(void) = 0;                                             //!< Tune the sampler and its moves.
-        virtual void                            writeMonitorHeaders(bool screen_only) = 0;                  //!< Write the headers of the monitors
+        virtual void                            startMonitors(size_t numCycles, bool reopen, double maxSeconds = 0.0) = 0;  //!< Start the monitors
+        virtual void                            tune(void) = 0;                                                             //!< Tune the sampler and its moves.
+        virtual void                            writeMonitorHeaders(bool screen_only) = 0;                                  //!< Write the headers of the monitors
 
         // public methods
-        size_t                                  getCurrentGeneration(void) const;                           //!< Get the current generations number
+        size_t                                  getCurrentGeneration(void) const;                                           //!< Get the current generations number
         void                                    setCurrentGeneration(size_t g);
-//        void                                    initializeMonitors(void);                                   //!< Assign model and mcmc ptrs to monitors
+//        void                                    initializeMonitors(void);                                                 //!< Assign model and mcmc ptrs to monitors
 //        void                                    redrawChainState(void);
-        virtual void                            checkpoint(void);                                           //!< Perform checkpointing: base files + derived-class supplementary files (e.g. *_mcmc).
-        void                                    baseCheckpoint(void);                                       //!< Base portion only: write variable values and *_moves; no derived-class dispatch (e.g. burnin avoids *_mcmc/monitors).
-        virtual void                            initializeSamplerFromCheckpoint(void);                      //!< Restore from checkpoint: base files + derived-class supplementary files.
-        void                                    baseInitializeSamplerFromCheckpoint(void);                  //!< Base portion only: load variables and *_moves; no derived-class dispatch (e.g. burnin avoids *_mcmc/monitors).
+        virtual void                            checkpoint(void);                                                           //!< Perform checkpointing: base files + derived-class supplementary files (e.g. *_mcmc).
+        void                                    baseCheckpoint(void);                                                       //!< Base portion only: write variable values and *_moves; no derived-class dispatch (e.g. burnin avoids *_mcmc/monitors).
+        virtual void                            initializeSamplerFromCheckpoint(void);                                      //!< Restore from checkpoint: base files + derived-class supplementary files.
+        void                                    baseInitializeSamplerFromCheckpoint(void);                                  //!< Base portion only: load variables and *_moves; no derived-class dispatch (e.g. burnin avoids *_mcmc/monitors).
         
     protected:
         
@@ -90,7 +90,7 @@ namespace RevBayesCore {
     };
 
     // Global functions using the class
-    std::ostream&                               operator<<(std::ostream& o, const MonteCarloSampler& x);    //!< Overloaded output operator
+    std::ostream&                               operator<<(std::ostream& o, const MonteCarloSampler& x);                    //!< Overloaded output operator
 
 }
 

--- a/src/core/analysis/stoppingRule/MaxIterationStoppingRule.cpp
+++ b/src/core/analysis/stoppingRule/MaxIterationStoppingRule.cpp
@@ -45,6 +45,15 @@ MaxIterationStoppingRule* MaxIterationStoppingRule::clone( void ) const
 
 
 /**
+ * Get the generation number at which this rule stops the run.
+ */
+size_t MaxIterationStoppingRule::getMaxGenerations( void ) const
+{
+    return maxGenerations;
+}
+
+
+/**
  * Is this a stopping rule? No, this is a threshold rule.
  */
 bool MaxIterationStoppingRule::isConvergenceRule( void ) const

--- a/src/core/analysis/stoppingRule/MaxIterationStoppingRule.h
+++ b/src/core/analysis/stoppingRule/MaxIterationStoppingRule.h
@@ -31,6 +31,7 @@ namespace RevBayesCore {
         // public methods
         bool                                                checkAtIteration(size_t g) const;                           //!< Should we check for convergence at the given iteration?
         MaxIterationStoppingRule*                           clone(void) const;                                          //!< Clone function. This is similar to the copy constructor but useful in inheritance.
+        size_t                                              getMaxGenerations(void) const;                              //!< Get the generation at which this rule stops.
         bool                                                isConvergenceRule(void) const;                              //!< No, this is a threshold rule.
         void                                                runStarted(void);                                           //!< The run just started. Here we do not need to do anything.
         void                                                setNumberOfRuns(size_t n);                                  //!< Set how many runs/replicates there are.

--- a/src/core/analysis/stoppingRule/MaxTimeStoppingRule.cpp
+++ b/src/core/analysis/stoppingRule/MaxTimeStoppingRule.cpp
@@ -47,6 +47,15 @@ MaxTimeStoppingRule* MaxTimeStoppingRule::clone( void ) const
 
 
 /**
+ * Get the maximum allowed wall-clock time in seconds.
+ */
+double MaxTimeStoppingRule::getMaxTime( void ) const
+{
+    return maxTime;
+}
+
+
+/**
  * Is this a stopping rule? No, this is a threshold rule.
  */
 bool MaxTimeStoppingRule::isConvergenceRule( void ) const

--- a/src/core/analysis/stoppingRule/MaxTimeStoppingRule.h
+++ b/src/core/analysis/stoppingRule/MaxTimeStoppingRule.h
@@ -30,6 +30,7 @@ namespace RevBayesCore {
         // public methods
         bool                                                checkAtIteration(size_t g) const;                           //!< Should we check for convergence at the given iteration?
         MaxTimeStoppingRule*                                clone(void) const;                                          //!< Clone function. This is similar to the copy constructor but useful in inheritance.
+        double                                              getMaxTime(void) const;                                     //!< Get the maximum allowed wall-clock time in seconds.
         bool                                                isConvergenceRule(void) const;                              //!< No, this is a threshold rule.
         void                                                runStarted(void);                                           //!< The run just started. Here we do not need to do anything.
         void                                                setNumberOfRuns(size_t n);                                  //!< Set how many runs/replicates there are.

--- a/src/core/monitors/Monitor.cpp
+++ b/src/core/monitors/Monitor.cpp
@@ -435,11 +435,13 @@ void Monitor::swapNode(DagNode *oldN, DagNode *newN)
 
 /**
  * Reset the variables for the monitor.
- * Overwrite this method for specialized behavior.
+ * This is a no-op that never uses its own arguments; we keep the types to match the signature, but suppress the names
+ * to avoid compiler warnings under -Wunused-parameter. Overwrite this method for specialized behavior.
  *
- * @param numCycles target number of iterations
+ * @param numCycles target number of iterations (0 if unknown)
+ * @param maxSeconds maximum wall-clock time in seconds (0 if unknown)
  */
-void Monitor::reset(size_t numCycles)
+void Monitor::reset(size_t /*numCycles*/, double /*maxSeconds*/)
 {}
 
 

--- a/src/core/monitors/Monitor.h
+++ b/src/core/monitors/Monitor.h
@@ -49,7 +49,7 @@ namespace RevBayesCore {
         virtual void                                printHeader(void);  //!< Print header
         virtual void                                swapNode(DagNode *oldN, DagNode *newN);  //!< Replace attached node
         virtual void                                removeVariable(DagNode *n);  //!< Stop monitoring variable
-        virtual void                                reset(size_t numCycles);  //!< Reset the monitored variables.
+        virtual void                                reset(size_t numCycles, double maxSeconds = 0.0);  //!< Reset the monitored variables.
 
         // getters and setters
         virtual void                                setModel(Model* m);

--- a/src/core/monitors/ScreenMonitor.cpp
+++ b/src/core/monitors/ScreenMonitor.cpp
@@ -1,5 +1,6 @@
 #include "ScreenMonitor.h"
 
+#include <algorithm>
 #include <cmath>
 #include <iomanip>
 #include <iostream>
@@ -185,28 +186,70 @@ void ScreenMonitor::monitor(std::uint64_t gen)
             
             if ( printWaitingTime )
             {
+                // "--:--:--" = too early to extrapolate from generations
+                // "??:??:??" = no iteration or time target to calculate ETA from
+                bool too_early = (gen - startGen) <= samplingFrequency;
+                size_t timeUsed = time(NULL) - startTime;
+                bool have_iter_target = numCycles > startGen;
+                bool have_time_target = maxSeconds > 0.0;
 
-                if ( (gen-startGen) <= samplingFrequency )
+                bool have_eta = false;
+                size_t waitTime = 0;
+
+                if ( have_iter_target && !too_early )
                 {
-                    std::cout << prefixSeparator << "--:--:--" << suffixSeparator;
+                    double done = double(gen - startGen);
+                    double total = double(numCycles - startGen);
+                    double progress = done / total;
+                    waitTime = size_t( double(timeUsed) / progress - double(timeUsed) );
+                    have_eta = true;
+                }
+
+                if ( have_time_target )
+                {
+                    size_t time_eta = size_t( std::max(0.0, maxSeconds - double(timeUsed)) );
+
+                    if ( have_eta )
+                    {
+                        // If we have both an iteration and a wall-clock time target, use the more restrictive of the two
+                        if ( time_eta < waitTime )
+                        {
+                            waitTime = time_eta;
+                        }
+                    }
+                    else if ( !have_iter_target )
+                    {
+                        // Time target only: the remaining wall-clock time is exact, so use it even before we would be
+                        // willing to extrapolate from generations
+                        waitTime = time_eta;
+                        have_eta = true;
+                    }
+                    
+                    // else: we have an iteration target, but it is still too early to extrapolate. We do not print the
+                    // (possibly much larger) time target alone, but fall through to "--:--:--" until both can be compared.
+                }
+
+                if ( !have_eta )
+                {
+                    if ( too_early )
+                    {
+                        std::cout << prefixSeparator << "--:--:--" << suffixSeparator;
+                    }
+                    else
+                    {
+                        std::cout << prefixSeparator << "??:??:??" << suffixSeparator;
+                    }
                 }
                 else
                 {
-                    double done = gen - startGen;
-                    double total = numCycles - startGen;
-                    double progress = done / total;
-                    size_t timeUsed = time(NULL) - startTime;
-                
-                    size_t waitTime = double( timeUsed ) / progress - double( timeUsed );
-                    
                     size_t hours   = waitTime / 3600;
                     size_t minutes = waitTime / 60 - hours * 60;
                     size_t seconds = waitTime - minutes * 60 - hours * 3600;
-                
+
                     ss << std::setw( 2 ) << std::setfill( '0' ) << hours << ":";
                     ss << std::setw( 2 ) << std::setfill( '0' ) << minutes << ":";
                     ss << std::setw( 2 ) << std::setfill( '0' ) << seconds;
-                
+
                     std::cout << prefixSeparator << ss.str() << suffixSeparator;
                 }
             

--- a/src/core/monitors/ScreenMonitor.cpp
+++ b/src/core/monitors/ScreenMonitor.cpp
@@ -24,6 +24,7 @@ ScreenMonitor::ScreenMonitor(DagNode *n, std::uint64_t g, bool pp, bool l, bool 
     headerPrintingInterval( 20 ),
     startTime( 0 ),
     numCycles( 0 ),
+    maxSeconds( 0.0 ),
     currentGen( 0 ),
     startGen( 0 ),
     replicateIndex( 0 )
@@ -41,6 +42,7 @@ ScreenMonitor::ScreenMonitor(const std::vector<DagNode *> &n, std::uint64_t g, b
     headerPrintingInterval( 20 ),
     startTime( 0 ),
     numCycles( 0 ),
+    maxSeconds( 0.0 ),
     currentGen( 0 ),
     startGen( 0 ),
     replicateIndex( 0 )
@@ -316,10 +318,11 @@ void ScreenMonitor::printHeader( void )
 }
 
 
-void ScreenMonitor::reset( size_t n )
+void ScreenMonitor::reset( size_t n, double max_seconds )
 {
     startGen = currentGen;
     numCycles = n;
+    maxSeconds = max_seconds;
     startTime = time( NULL );
     printWaitingTime = true;
 }

--- a/src/core/monitors/ScreenMonitor.h
+++ b/src/core/monitors/ScreenMonitor.h
@@ -27,7 +27,7 @@ class DagNode;
         // Monitor functions
         bool                                isScreenMonitor(void) const;
         void                                monitor(std::uint64_t gen);
-        void                                reset(size_t numCycles);
+        void                                reset(size_t numCycles, double maxSeconds) override;
         void                                setReplicateIndex(size_t idx);
         
         // ScreenMonitor functions
@@ -46,6 +46,7 @@ class DagNode;
         size_t                              headerPrintingInterval; //!< print the header each n iterations
         time_t                              startTime; //!< time of start of the run
         size_t                              numCycles; //!< planned number of iterations                                                       //!< Total number of cycles to monitor
+        double                              maxSeconds; //!< planned wall-clock time in seconds (0 if unknown)
         size_t                              currentGen; //!< current generation of the run
         size_t                              startGen; //!< start generation of the run
         size_t                              replicateIndex; //!< replicate index of the monitored run


### PR DESCRIPTION
## PR Type
-  Bug Fix

## Summary, Approach, & Additional Notes

As a brief review, we currently have six stopping rules that we can use to determine when to terminate an MCMC(MC) run: `srMaxIteration`, `srMaxTime`, and four convergence-based rules. All of these can be freely combined with one another, as well as with the `generations` argument of the `.run()` method.

On two different occasions (#542, #1013), users have tried to use a stopping-rule vector containing `srMaxIteration` plus one other rule, and got absurdly large time-to-completion estimates (ETA) in the screen monitor as a result.

I cannot reproduce this problem with my setup – I'm getting `00:00:00` instead, which goes to show that this is yet another problem where Clang manages to optimize away a division by zero (see #794, #1049). However, the exact failure mode is not of interest here. The larger problem is that we can get reasonable ETA values by specifying the `generations` argument but not by supplying an `srMaxIteration` stopping rule, even though these should be strictly equivalent. In fact, `generations` even gets converted to `srMaxIteration` under the hood:

https://github.com/revbayes/revbayes/blob/ace3b793a4564e478c819e83af245a653f0eda5c/src/revlanguage/analysis/mcmc/RlMonteCarloAnalysis.cpp#L121-L126

This problem also made me think about how we should estimate the ETA in other scenarios where `generations` is not set – a problem that basically reduces to exposing the information from the stopping rules to the analysis, which can then pass it on to its monitors. I ended up implementing the following system:

- `srMaxIteration` (and possibly some convergence rules) specified: we extract its value and set `kIterations`  to it, which renders it equivalent to `generations` for all intents and purposes.

- `srMaxTime` (and possibly some convergence rules) specified: we extract its value and pass it to the monitors via a new argument added to the latter. The ETA is then obtained simply by subtracting the elapsed time from the time specified by the stopping rule, exactly as one would expect.

- `srMaxIteration` and `srMaxTime` both specified (possibly along with some convergence rules): the screen monitor compares the two time-to-completion estimates, and prints the smaller one to the ETA column. E.g., if your analysis takes 2 hours to complete 50,000 generations, and your stopping-rule vector looks like this:

    ```r
    stopping_rules = [ srMaxIteration(50000), srMaxTime(5, "hours") ]
    ```
    
    then your ETA will be about 2 hours, but if your stopping-rule vector instead looks like this:
    
    ```r
    stopping_rules = [ srMaxIteration(50000), srMaxTime(1, "hours") ]
    ```
    
    your ETA will be 1 hour.
    
- Only convergence rules specified: we just print `??:??:??` in the ETA column, and explicitly alert the user to the fact that no estimates are available. There are two problems with estimating a time to completion in this scenario. First, we'd have to evaluate the convergence rules not just at their own `frequency`, but also at the `printgen` frequency of the screen monitor. Second, while we could naïvely estimate the time needed to attain a specified ESS target (if it took time _t_ to attain an ESS of _x_, then reaching the target _y_ will require _ty_ / _x_), it's much less clear what the calculation should look like for the other rules (PSRF, Geweke, stationarity).

## Testing
Unfortunately, the ETA values produced by `mnScreen` are non-reproducible, so I couldn't add a test for these changes.

## Relevant issues
Fixes #542.

## AI/LLM Assistance
- I used Cursor Grok 4.5 for this PR. I personally understand the submitted changes and take responsibility for their correctness, style, and maintainability.
