### PR TITLE
Small fixes to `getOption()` / `setOption()`

### DIFF
--- a/help/md/setOption.md
+++ b/help/md/setOption.md
@@ -30,7 +30,7 @@ The currently available keys and their associated values are as follows:
 
     tolerance=<numeric>          Tolerance for comparing doubles.
 
-        DEFAULT: 10e-10
+        DEFAULT: 1e-09
 
     debugMCMC=<0,1>              How much work to perform to check MCMC?
 
@@ -57,13 +57,13 @@ Sebastian Hoehna
 ## see_also
 getOption
 ## example
-	# compute the absolute value of a real number
-	getOption("linewidth")
+	# find out what the current line width is
+	getOption("lineWidth")
 	
-	# let us set the linewidth to a new value
-	setOption("linewidth", 200)
+	# let's set the line width to a new value
+	setOption("lineWidth", 200)
 	
 	# now let's check what the value is
-	getOption("linewidth")
+	getOption("lineWidth")
 	
 ## references

--- a/src/core/help/RbHelpDatabase.cpp
+++ b/src/core/help/RbHelpDatabase.cpp
@@ -5085,7 +5085,7 @@ The currently available keys and their associated values are as follows:
 
     tolerance=<numeric>          Tolerance for comparing doubles.
 
-        DEFAULT: 10e-10
+        DEFAULT: 1e-09
 
     debugMCMC=<0,1>              How much work to perform to check MCMC?
 
@@ -5106,14 +5106,14 @@ The currently available keys and their associated values are as follows:
         4: Writes out additional details about the mvSlice move (if present).
 
         DEFAULT: 0)");
-	help_strings[string("setOption")][string("example")] = string(R"(# compute the absolute value of a real number
-getOption("linewidth")
+	help_strings[string("setOption")][string("example")] = string(R"(# find out what the current line width is
+getOption("lineWidth")
 
-# let us set the linewidth to a new value
-setOption("linewidth", 200)
+# let's set the line width to a new value
+setOption("lineWidth", 200)
 
 # now let's check what the value is
-getOption("linewidth"))");
+getOption("lineWidth"))");
 	help_strings[string("setOption")][string("name")] = string(R"(setOption)");
 	help_arrays[string("setOption")][string("see_also")].push_back(string(R"(getOption)"));
 	help_strings[string("setOption")][string("title")] = string(R"(Set a global RevBayes option)");

--- a/src/core/utils/RbSettings.cpp
+++ b/src/core/utils/RbSettings.cpp
@@ -73,7 +73,7 @@ std::string bool_to_string(bool b)
 
 std::string RbSettings::getOption(const std::string &key) const
 {
-    if ( key == "moduledir" )
+    if ( key == "moduleDir" )
     {
         return moduleDir.string();
     }
@@ -89,7 +89,8 @@ std::string RbSettings::getOption(const std::string &key) const
     {
         return StringUtilities::to_string(tolerance);
     }
-    else if ( key == "linewidth" )
+    // maintain the non-camel-case alias for backward compatibility
+    else if ( key == "lineWidth" or key == "linewidth" )
     {
         return StringUtilities::to_string(lineWidth);
     }
@@ -170,11 +171,11 @@ void RbSettings::readUserSettings(void)
 
 void RbSettings::listOptions() const
 {
-    std::cout << "moduledir = " << moduleDir << std::endl;
+    std::cout << "moduleDir = " << moduleDir << std::endl;
     std::cout << "outputPrecision = " << outputPrecision << std::endl;
     std::cout << "printNodeIndex = " << (printNodeIndex ? "true" : "false") << std::endl;
     std::cout << "tolerance = " << tolerance << std::endl;
-    std::cout << "linewidth = " << lineWidth << std::endl;
+    std::cout << "lineWidth = " << lineWidth << std::endl;
     std::cout << "useScaling = " << (useScaling ? "true" : "false") << std::endl;
     std::cout << "scalingDensity = " << scalingDensity << std::endl;
     std::cout << "debugMCMC = " << debugMCMC << std::endl;
@@ -260,7 +261,7 @@ void RbSettings::setOption(const std::string &key, const std::string &v, bool wr
     std::string value = v;
     std::transform(value.begin(), value.end(), value.begin(), ::tolower);
 
-    if ( key == "moduledir" )
+    if ( key == "moduleDir" )
     {
         // Read from stream to handle quotes.
         std::istringstream input(value);
@@ -278,7 +279,8 @@ void RbSettings::setOption(const std::string &key, const std::string &v, bool wr
     {
         tolerance = boost::lexical_cast<double>(value);
     }
-    else if ( key == "linewidth" )
+    // maintain the non-camel-case alias for backward compatibility
+    else if ( key == "lineWidth" or key == "linewidth" )
     {
         lineWidth = boost::lexical_cast<int>(value);
     }
@@ -352,11 +354,11 @@ void RbSettings::writeUserSettings( void )
 
     std::ofstream writeStream( settings_file_name.string() );
     assert( moduleDir == "modules" or is_directory(moduleDir) );
-    writeStream << "moduledir=" << moduleDir << std::endl;
+    writeStream << "moduleDir=" << moduleDir << std::endl;
     writeStream << "outputPrecision=" << outputPrecision << std::endl;
     writeStream << "printNodeIndex=" << (printNodeIndex ? "true" : "false") << std::endl;
     writeStream << "tolerance=" << tolerance << std::endl;
-    writeStream << "linewidth=" << lineWidth << std::endl;
+    writeStream << "lineWidth=" << lineWidth << std::endl;
     writeStream << "useScaling=" << (useScaling ? "true" : "false") << std::endl;
     writeStream << "scalingDensity=" << scalingDensity << std::endl;
 

--- a/src/core/utils/RbSettings.h
+++ b/src/core/utils/RbSettings.h
@@ -46,18 +46,18 @@ public:
     void                        setLogMCMC(int d);                                  //!< How much logging should we perform to check MCMC?
     
 private:
-    RbSettings(void);                                   //!< Default constructor
-    RbSettings(const RbSettings&) = delete;             //!< Prevent copy
-    ~RbSettings(void) {};                               //!< Delete function table
-    RbSettings&                 operator=(const RbSettings& s) = delete;                     //!< Prevent assignment
+    RbSettings(void);                                                               //!< Default constructor
+    RbSettings(const RbSettings&) = delete;                                         //!< Prevent copy
+    ~RbSettings(void) {};                                                           //!< Delete function table
+    RbSettings&                 operator=(const RbSettings& s) = delete;            //!< Prevent assignment
 
     // Variables that have user settings
     size_t                      lineWidth = 160;
     RevBayesCore::path          moduleDir = "modules";
     size_t                      outputPrecision = 7;
-    bool                        printNodeIndex = true;                                     //!< Should the node index of a tree be printed as a comment?
+    bool                        printNodeIndex = true;                              //!< Should the node index of a tree be printed as a comment?
     size_t                      scalingDensity = 1;
-    double                      tolerance=10e-10;                                          //!< Tolerance for comparison of doubles
+    double                      tolerance=1e-9;                                     //!< Tolerance for comparison of doubles
     bool                        useScaling=true;
     int                         debugMCMC = 0;
     int                         logMCMC = 0;


### PR DESCRIPTION
1. Our global help page (i.e., what we get by running `./rb -h`) points to the `setOption` help page for a list of available options. The latter lists `lineWidth` as the very first one, but that doesn't quite work:

    ```
    > getOption("lineWidth")
    Unknown user setting with key 'lineWidth'.
  
    > setOption("lineWidth", 320)
    Unknown user setting with key 'lineWidth'.
    ```
    
    As it turns out, that's because the key needs to be written without camel case, i.e., as `linewidth`. The "Example" section of the `setOption` help page actually shows as much!
    
2. I was confused for more than a quick moment by the fact that in the `setOption` help page, we give the default value of `tolerance` as "10e-10", but `getOption("tolerance")` prints "1e-09". Of course, that's because $10 \times 10^{-10} = 10^{-9}$, but it took me a while to figure that out, and the notation is arguably less than clear.

This PR:

1. Makes sure that the `lineWidth` option given in the `setOption` help file actually works, and that the example uses camel case as well. For backward compatibility (i.e., to make sure that any `.RevBayes.ini` files setting `linewidth` still have the desired effect), the all-lowercase version is retained as an alias.

2. Uses the clearer "1e-09" notation for the `tolerance` default both internally (in [`RbSettings.h`](https://github.com/revbayes/revbayes/blob/development/src/core/utils/RbSettings.h)) and publicly (in the `setOption` help page).