### PR TITLE
Extract non-template DAG node implementation bases

### DIFF
--- a/src/core/analysis/PosteriorPredictiveSimulation.cpp
+++ b/src/core/analysis/PosteriorPredictiveSimulation.cpp
@@ -23,6 +23,7 @@
 #include "RbVector.h"
 #include "RbVectorImpl.h"
 #include "StringUtilities.h"
+#include "StochasticNodeBase.h"
 #include "Taxon.h"
 #include "Trace.h"
 #include "Tree.h"

--- a/src/core/analysis/ValidationAnalysis.cpp
+++ b/src/core/analysis/ValidationAnalysis.cpp
@@ -25,7 +25,7 @@
 #include "RbVector.h"
 #include "RbVectorImpl.h"
 #include "StoppingRule.h"
-#include "StochasticNode.h"
+#include "StochasticNodeBase.h"
 #include "StringUtilities.h"
 
 
@@ -540,4 +540,3 @@ void ValidationAnalysis::summarizeSim(double credible_interval_size, size_t idx)
     }
     
 }
-

--- a/src/core/dag/DeterministicNode.h
+++ b/src/core/dag/DeterministicNode.h
@@ -1,358 +1,238 @@
 #ifndef DeterministicNode_H
 #define DeterministicNode_H
 
+#include "DeterministicNodeBase.h"
 #include "DynamicNode.h"
+#include "RbException.h"
 #include "TypedFunction.h"
 
 namespace RevBayesCore {
 
     template<class valueType>
-    class DeterministicNode : public DynamicNode<valueType> {
+    class DeterministicNode : public DynamicNode<valueType>, protected DeterministicNodeBase {
 
     public:
         DeterministicNode(const std::string &n, TypedFunction<valueType> *f);
         DeterministicNode(const DeterministicNode<valueType> &n);                                                                       //!< Copy constructor
         virtual                                            ~DeterministicNode(void);                                                    //!< Virtual destructor
 
-        DeterministicNode&                                  operator=(const DeterministicNode& n);                                      //!< Assignment operator
+        DeterministicNode&                                 operator=(const DeterministicNode &n);                                       //!< Assignment operator
 
         // public methods
-        void                                                bootstrap(void);                                                            //!< Bootstrap the current value of the node (applies only to stochastic nodes)
-        virtual DeterministicNode<valueType>*               clone(void) const;
-        virtual TypedFunction<valueType>&                   getFunction(void);
-        virtual const TypedFunction<valueType>&             getFunction(void) const;
-        void                                                getIntegratedParents(RbOrderedSet<DagNode *>& ip) const;
-        double                                              getLnProbability(void);
-        double                                              getLnProbabilityRatio(void);
-        valueType&                                          getValue(void);
-        const valueType&                                    getValue(void) const;
-        bool                                                isConstant(void) const;                                                     //!< Is this DAG node constant?
-        virtual void                                        printStructureInfo(std::ostream &o, bool verbose=false) const;              //!< Print the structural information (e.g. name, value-type, distribution/function, children, parents, etc.)
-        void                                                redraw(SimulationCondition c = SimulationCondition::MCMC);
-        void                                                reInitializeMe(void);                                                       //!< The DAG was re-initialized so maybe you want to reset some stuff (delegate to distribution)
-        void                                                setMcmcMode(bool tf);                                                       //!< Set the modus of the DAG node to MCMC mode.
-        void                                                setValueFromFile(const path &dir);                                          //!< Set value from string.
-        void                                                setValueFromString(const std::string &v);                                   //!< Set value from string.
+        void                                               bootstrap(void);                                                             //!< Bootstrap the current value of the node (applies only to stochastic nodes)
+        virtual DeterministicNode<valueType>*              clone(void) const;
+        virtual TypedFunction<valueType>&                  getFunction(void);
+        virtual const TypedFunction<valueType>&            getFunction(void) const;
+        void                                               getIntegratedParents(RbOrderedSet<DagNode*> &ip) const;
+        double                                             getLnProbability(void);
+        double                                             getLnProbabilityRatio(void);
+        valueType&                                         getValue(void);
+        const valueType&                                   getValue(void) const;
+        bool                                               isConstant(void) const;                                                      //!< Is this DAG node constant?
+        virtual void                                       printStructureInfo(std::ostream &o, bool verbose=false) const;               //!< Print the structural information (e.g. name, value-type, distribution/function, children, parents, etc.)
+        void                                               redraw(SimulationCondition c = SimulationCondition::MCMC);
+        void                                               reInitializeMe(void);                                                        //!< The DAG was re-initialized so maybe you want to reset some stuff (delegate to distribution)
+        void                                               setMcmcMode(bool tf);                                                        //!< Set the modus of the DAG node to MCMC mode.
+        void                                               setValueFromFile(const path &dir);                                           //!< Set value from string.
+        void                                               setValueFromString(const std::string &v);                                    //!< Set value from string.
 
         // Parent DAG nodes management functions
-        virtual std::vector<const DagNode*>                 getParents(void) const;                                                     //!< Get the set of parents
-        virtual void                                        swapParent(const DagNode *oldParent, const DagNode *newParent);             //!< Exchange the parent (function parameter)
+        virtual std::vector<const DagNode*>                getParents(void) const;                                                      //!< Get the set of parents
+        virtual void                                       swapParent(const DagNode *oldParent, const DagNode *newParent);              //!< Exchange the parent (function parameter)
 
     protected:
-        void                                                getAffected(RbOrderedSet<DagNode *>& affected, const DagNode* affecter);    //!< Mark and get affected nodes
-        void                                                keepMe(const DagNode* affecter);                                            //!< Keep value of this and affected nodes
-        void                                                restoreMe(const DagNode *restorer);                                         //!< Restore value of this nodes
-        void                                                swapParameter(const DagNode *oldP, const DagNode *newP);                    //!< Swap the parameter of this node (needs overwriting in deterministic and stochastic nodes)
-        virtual void                                        touchMe(const DagNode *toucher, bool touchAll);                             //!< Touch myself and tell affected nodes value is reset
-
-    private:
-
-        TypedFunction<valueType>*                           function;
-        mutable bool                                        needs_update;
-        bool                                                force_update;
+        void                                               getAffected(RbOrderedSet<DagNode*> &affected, const DagNode *affecter);      //!< Mark and get affected nodes
+        void                                               keepMe(const DagNode *affecter);                                             //!< Keep value of this and affected nodes
+        void                                               restoreMe(const DagNode *restorer);                                          //!< Restore value of this nodes
+        void                                               swapParameter(const DagNode *oldParent, const DagNode *newParent);           //!< Swap the parameter of this node (needs overwriting in deterministic and stochastic nodes)
+        virtual void                                       touchMe(const DagNode *toucher, bool touchAll);                              //!< Touch myself and tell affected nodes value is reset
     };
 
 }
 
-#include <cassert>
-#include "RbOptions.h"
 
-
+/** Construct a typed deterministic node and attach it to its function parameters. */
 template<class valueType>
-RevBayesCore::DeterministicNode<valueType>::DeterministicNode( const std::string &n, TypedFunction<valueType> *f ) :
+RevBayesCore::DeterministicNode<valueType>::DeterministicNode(const std::string &n, TypedFunction<valueType> *f) :
     DynamicNode<valueType>( n ),
-    function( f ),
-    needs_update( true ),
-    force_update( f->forceUpdates() )
+    DeterministicNodeBase( f )
 {
     this->type = DagNode::DETERMINISTIC;
-
-    // Get the parameters from the function and add us as a child of them in the DAG
-    const std::vector<const DagNode*>& funcParents = function->getParameters();
-    for (std::vector<const DagNode*>::const_iterator it = funcParents.begin(); it != funcParents.end(); ++it)
-    {
-        (*it)->addChild( this );
-
-        // Increment the reference count
-        // We don't want this parent to get deleted while we are still alive
-        (*it)->incrementReferenceCount();
-    }
+    this->attachToFunctionParameters( *this );
 
     // Set us as the DAG node of the function
-    function->setDeterministicNode( this );
+    f->setDeterministicNode( this );
 }
 
 
+/** Copy a deterministic node, attach its cloned function, and restore the typed back-pointer. */
 template<class valueType>
-RevBayesCore::DeterministicNode<valueType>::DeterministicNode( const DeterministicNode<valueType> &n ) :
+RevBayesCore::DeterministicNode<valueType>::DeterministicNode(const DeterministicNode<valueType> &n) :
     DynamicNode<valueType>( n ),
-    function( n.function->clone() ),
-    needs_update( true ),
-    force_update( n.function->forceUpdates() )
+    DeterministicNodeBase( n )
 {
     this->type = DagNode::DETERMINISTIC;
-
-    // Get the parameters from the function and add us as a child of them in the DAG
-    const std::vector<const DagNode*>& funcParents = function->getParameters();
-    for (std::vector<const DagNode*>::const_iterator it = funcParents.begin(); it != funcParents.end(); ++it)
-    {
-        (*it)->addChild( this );
-
-        // Increment the reference count
-        // We don't want this parent to get deleted while we are still alive
-        (*it)->incrementReferenceCount();
-    }
+    this->attachToFunctionParameters( *this );
 
     // Set us as the DAG node of the function
-    function->setDeterministicNode( this );
+    static_cast<TypedFunction<valueType>*>( this->function )->setDeterministicNode( this );
 }
 
 
+/** Detach the node before the implementation base destroys its function. */
 template<class valueType>
-RevBayesCore::DeterministicNode<valueType>::~DeterministicNode( void )
+RevBayesCore::DeterministicNode<valueType>::~DeterministicNode(void)
 {
-
-    // Remove us as the child of the function parameters
-    std::vector<const DagNode*> funcParents = function->getParameters();
-    for (std::vector<const DagNode*>::iterator it = funcParents.begin(); it != funcParents.end(); ++it)
-    {
-        (*it)->removeChild( this );
-
-        // Decrement the reference count and check whether we need to delete the DAG node
-        if ( (*it)->decrementReferenceCount() == 0)
-        {
-            delete (*it);
-        }
-
-    }
-
-    // free the memory of the function
-    delete function;
-
+    this->detachFromFunctionParameters( *this );
 }
 
 
-/**
- * Assignment operator. Make sure we deal with parent nodes correctly here.
- */
+/** Assignment operator. Make sure we deal with parent nodes correctly here. */
 template<class valueType>
-RevBayesCore::DeterministicNode<valueType>& RevBayesCore::DeterministicNode<valueType>::operator=( const DeterministicNode<valueType>& n )
+RevBayesCore::DeterministicNode<valueType>& RevBayesCore::DeterministicNode<valueType>::operator=(const DeterministicNode<valueType> &n)
 {
-
     if ( &n != this )
     {
         // Call base class assignment operator
         DynamicNode<valueType>::operator=( n );
-
-        // Remove us as the child of the function parameters
-        const std::set<const DagNode*>& funcParents = function->getParameters();
-        for (std::set<const DagNode*>::iterator it = funcParents.begin(); it != funcParents.end(); ++it)
-        {
-            (*it)->removeChild( this );
-
-            // Decrement the reference count and check whether we need to delete the DAG node
-            // The function does not do this for us
-            if ( (*it)->decrementReferenceCount() == 0)
-                delete (*it);
-        }
-
-        // Delete the function
-        delete function;
-
-        // Recreate the function
-        function = n.function->clone();
-
-        // Get the parameters from the new function and add us as child of them in the DAG
-        funcParents = function->getParameters();
-        for (std::set<const DagNode*>::iterator it = funcParents.begin(); it != funcParents.end(); ++it)
-        {
-            (*it)->addChild( this );
-
-            // Increment the reference count
-            // We don't want this parent to get deleted while we are still alive
-            (*it)->incrementReferenceCount();
-        }
+        DeterministicNodeBase::assign( n, *this );
 
         // Set us as the DAG node of the new function
-        function->setDeterministicNode( this );
-
-        needs_update = true;
-        force_update = function->forceUpdates();
+        static_cast<TypedFunction<valueType>*>( this->function )->setDeterministicNode( this );
     }
 
     return *this;
 }
 
 
+/** Deterministic nodes have no bootstrap action. */
 template<class valueType>
-void RevBayesCore::DeterministicNode<valueType>::bootstrap( void )
+void RevBayesCore::DeterministicNode<valueType>::bootstrap(void)
 {
     // nothing to do
 }
 
 
+/** Clone this typed deterministic node. */
 template<class valueType>
-RevBayesCore::DeterministicNode<valueType>* RevBayesCore::DeterministicNode<valueType>::clone( void ) const
+RevBayesCore::DeterministicNode<valueType>* RevBayesCore::DeterministicNode<valueType>::clone(void) const
 {
-
     return new DeterministicNode<valueType>( *this );
 }
+
 
 /**
  * Get the affected nodes.
  * This call is started by the parent. We need to delegate this call to all our children.
  */
 template<class valueType>
-void RevBayesCore::DeterministicNode<valueType>::getAffected(RbOrderedSet<DagNode *> &affected, const DagNode* affecter)
+void RevBayesCore::DeterministicNode<valueType>::getAffected(RbOrderedSet<DagNode*> &affected, const DagNode* /*affecter*/)
 {
-
-    this->getAffectedNodes( affected );
-
+    DeterministicNodeBase::getAffected( *this, affected );
 }
 
 
+/** Return the owned function through its typed interface. */
 template<class valueType>
-RevBayesCore::TypedFunction<valueType>& RevBayesCore::DeterministicNode<valueType>::getFunction( void )
+RevBayesCore::TypedFunction<valueType>& RevBayesCore::DeterministicNode<valueType>::getFunction(void)
 {
-
-    return *function;
+    return *static_cast<TypedFunction<valueType>*>( this->function );
 }
 
 
+/** Return the owned function through its const typed interface. */
 template<class valueType>
-const RevBayesCore::TypedFunction<valueType>& RevBayesCore::DeterministicNode<valueType>::getFunction( void ) const
+const RevBayesCore::TypedFunction<valueType>& RevBayesCore::DeterministicNode<valueType>::getFunction(void) const
 {
-
-    return *function;
+    return *static_cast<const TypedFunction<valueType>*>( this->function );
 }
 
 
+/** Forward integrated-parent discovery to the non-template implementation. */
 template<class valueType>
-void RevBayesCore::DeterministicNode<valueType>::getIntegratedParents(RbOrderedSet<DagNode *>& integrated_parents) const
+void RevBayesCore::DeterministicNode<valueType>::getIntegratedParents(RbOrderedSet<DagNode*> &integratedParents) const
 {
-    std::vector<const DagNode*> parents = this->getParents();                                                                     //!< Get the set of parents (empty set here)
-
-    // delegate up the DAG
-    for (size_t i=0; i<parents.size(); ++i)
-    {
-        const DagNode *the_parent = parents[i];
-        the_parent->getIntegratedParents( integrated_parents );
-    }
+    DeterministicNodeBase::getIntegratedParents( *this, integratedParents );
 }
 
-template<class valueType>
-double RevBayesCore::DeterministicNode<valueType>::getLnProbability( void )
-{
 
+/** Deterministic nodes contribute no direct log probability. */
+template<class valueType>
+double RevBayesCore::DeterministicNode<valueType>::getLnProbability(void)
+{
     return 0.0;
 }
 
 
+/** Deterministic nodes contribute no direct log-probability ratio. */
 template<class valueType>
-double RevBayesCore::DeterministicNode<valueType>::getLnProbabilityRatio( void )
+double RevBayesCore::DeterministicNode<valueType>::getLnProbabilityRatio(void)
 {
-
     return 0.0;
 }
 
 
-/**
- * Get the parents of this node. Simply ask the function to provide its parameters,
- * no need to keep parents here.
- */
+/** Return the function parameters as the node's parents. */
 template<class valueType>
-std::vector<const RevBayesCore::DagNode*> RevBayesCore::DeterministicNode<valueType>::getParents( void ) const
+std::vector<const RevBayesCore::DagNode*> RevBayesCore::DeterministicNode<valueType>::getParents(void) const
 {
-    return function->getParameters();
+    return DeterministicNodeBase::getParents();
 }
 
 
+/** Lazily update the function and return its typed value. */
 template<class valueType>
-valueType& RevBayesCore::DeterministicNode<valueType>::getValue( void )
+valueType& RevBayesCore::DeterministicNode<valueType>::getValue(void)
 {
+    TypedFunction<valueType> *typedFunction = static_cast<TypedFunction<valueType>*>( this->function );
 
     // lazy evaluation
-    if ( needs_update == true || force_update == true )
+    if ( this->needs_update == true || this->force_update == true )
     {
-        function->update();
-        needs_update = false;
+        typedFunction->update();
+        this->needs_update = false;
     }
 
-    return function->getValue();
+    return typedFunction->getValue();
 }
 
 
+/** Lazily update the function and return its typed value through a const node. */
 template<class valueType>
-const valueType& RevBayesCore::DeterministicNode<valueType>::getValue( void ) const
+const valueType& RevBayesCore::DeterministicNode<valueType>::getValue(void) const
 {
+    TypedFunction<valueType> *typedFunction = static_cast<TypedFunction<valueType>*>( this->function );
 
     // lazy evaluation
-    if ( needs_update == true || force_update == true )
+    if ( this->needs_update == true || this->force_update == true )
     {
-        const_cast<TypedFunction<valueType> *>(function)->update();
-        needs_update = false;
+        typedFunction->update();
+        this->needs_update = false;
     }
 
-    return function->getValue();
+    return typedFunction->getValue();
 }
 
 
+/** Report whether every function parameter is constant. */
 template<class valueType>
-bool RevBayesCore::DeterministicNode<valueType>::isConstant( void ) const
+bool RevBayesCore::DeterministicNode<valueType>::isConstant(void) const
 {
-
-    // iterate over all parents and only if all parents are constant then this node is constant too
-    const std::vector<const DagNode*>& parents = function->getParameters();
-    for (std::vector<const DagNode*>::const_iterator it = parents.begin(); it != parents.end(); ++it)
-    {
-        if ( (*it)->isConstant() == false )
-        {
-            return false;
-        }
-    }
-
-    return true;
+    return DeterministicNodeBase::isConstant();
 }
 
 
-/**
- * Keep the current value of the node.
- * At this point, we just delegate to the children.
- */
+/** Print struct for user. */
 template<class valueType>
-void RevBayesCore::DeterministicNode<valueType>::keepMe( const DagNode* affecter )
+void RevBayesCore::DeterministicNode<valueType>::printStructureInfo(std::ostream &o, bool verbose) const
 {
-
-    // delegate call to base class
-    // this will unset the touched flag if it was set
-    DynamicNode<valueType>::keepMe( affecter );
-
-    // allow specialized recovery in functions
-    function->keep( affecter );
-
-    // delegate call
-    this->keepAffected();
-
-    // clear the list of touched element indices
-    this->touched_elements.clear();
-
-}
-
-
-/** Print struct for user */
-template<class valueType>
-void RevBayesCore::DeterministicNode<valueType>::printStructureInfo( std::ostream& o, bool verbose ) const
-{
-
     o << "_dagType      = Deterministic node (function)" << std::endl;
-    o << "_function     = <" << function << ">" << std::endl;
-
+    o << "_function     = <" << this->function << ">" << std::endl;
     o << "_parents      = ";
-    this->printParents(o, 16, 70, verbose);
+    this->printParents( o, 16, 70, verbose );
     o << std::endl;
-
     o << "_children     = ";
-    this->printChildren(o, 16, 70, verbose);
+    this->printChildren( o, 16, 70, verbose );
     o << std::endl;
 
     if ( verbose == true )
@@ -364,145 +244,76 @@ void RevBayesCore::DeterministicNode<valueType>::printStructureInfo( std::ostrea
 }
 
 
-
+/** Deterministic nodes have no redraw action. */
 template<class valueType>
-void RevBayesCore::DeterministicNode<valueType>::redraw( SimulationCondition c )
+void RevBayesCore::DeterministicNode<valueType>::redraw(SimulationCondition /*c*/)
 {
     // nothing to do
     // the touch should have called our update
 }
 
 
+/** Forward model reinitialization to the owned function. */
 template<class valueType>
-void RevBayesCore::DeterministicNode<valueType>::reInitializeMe( void )
+void RevBayesCore::DeterministicNode<valueType>::reInitializeMe(void)
 {
-
-    function->reInitialized();
-
+    DeterministicNodeBase::reInitializeMe();
 }
 
 
-/** Restore the old value of the node and tell affected */
+/** Commit deterministic and dynamic state through the implementation bases. */
 template<class valueType>
-void RevBayesCore::DeterministicNode<valueType>::restoreMe( const DagNode *restorer )
+void RevBayesCore::DeterministicNode<valueType>::keepMe(const DagNode *affecter)
 {
-
-    // the value has been changed so we need to flag for recomputing the value
-    // we need to do that even if the touched flag is unset because it can already have been unset
-    // by a reset call from one of our parameter while another of our parameters wasn't unset
-    // that means we need to guarantee that either all of our parameters are restore first (which we cannot guarantee currently)
-    // or we need to update our value every time one of our parameters is restored.
-    needs_update = true;
-
-    // we just mark ourselves as clean, albeit perhaps not being updated
-    DynamicNode<valueType>::restoreMe( restorer );
-
-    // call for potential specialized handling (e.g. internal flags)
-    function->restore(restorer);
-
-    // clear the list of touched element indices
-    this->touched_elements.clear();
-
-    // delegate call
-    this->restoreAffected();
-
+    DeterministicNodeBase::keepMe( *this, *this, affecter );
 }
 
 
-
+/** Restore deterministic and dynamic state through the implementation bases. */
 template<class valueType>
-void RevBayesCore::DeterministicNode<valueType>::setMcmcMode(bool tf)
+void RevBayesCore::DeterministicNode<valueType>::restoreMe(const DagNode *restorer)
 {
+    DeterministicNodeBase::restoreMe( *this, *this, restorer );
+}
 
+
+/** Deterministic nodes do not propagate an MCMC mode to functions. */
+template<class valueType>
+void RevBayesCore::DeterministicNode<valueType>::setMcmcMode(bool /*tf*/)
+{
     // nothing to do
-
 }
 
 
+/** Reject attempts to deserialize a deterministic value from a file. */
 template<class valueType>
-void RevBayesCore::DeterministicNode<valueType>::setValueFromFile(const RevBayesCore::path &dir)
+void RevBayesCore::DeterministicNode<valueType>::setValueFromFile(const RevBayesCore::path & /*dir*/)
 {
-
-    throw RbException("Cannot set a deterministic node from a file.");
+    throw RbException( "Cannot set a deterministic node from a file." );
 }
 
 
+/** Reject attempts to deserialize a deterministic value from a string. */
 template<class valueType>
-void RevBayesCore::DeterministicNode<valueType>::setValueFromString(const std::string &v)
+void RevBayesCore::DeterministicNode<valueType>::setValueFromString(const std::string & /*v*/)
 {
-
-    throw RbException("Cannot set a deterministic node from a string.");
+    throw RbException( "Cannot set a deterministic node from a string." );
 }
 
 
-/**
- * This function replaces the earlier swapParameter function. If we rely on the
- * internal RevBayesCore::Function to manage our parents, we simply need to ask
- * the function to swap its parameters, and then manage the connection of the
- * parents (parameters) to this node.
- */
-template <class valueType>
-void RevBayesCore::DeterministicNode<valueType>::swapParent( const RevBayesCore::DagNode *oldParent, const RevBayesCore::DagNode *newParent )
-{
-    // We are sure to get into trouble if either one of these is NULL
-    if ( oldParent == NULL || newParent == NULL )
-    {
-        throw RbException( "Attempt to swap NULL function parameter of RevBayesCore::DeterministicNode" );
-    }
-
-    // This throws an error if the oldParent cannot be found
-    function->swapParameter( oldParent, newParent );
-
-    oldParent->removeChild( this );
-    if ( oldParent->decrementReferenceCount() == 0 )
-    {
-        delete ( oldParent );
-    }
-
-    newParent->addChild( this );
-    newParent->incrementReferenceCount();
-
-    this->touch();
-}
-
-
-/**
- * Touch this node for recalculation.
- *
- *
- */
+/** Forward function-parameter replacement to the implementation base. */
 template<class valueType>
-void RevBayesCore::DeterministicNode<valueType>::touchMe( const DagNode *toucher, bool touchAll )
+void RevBayesCore::DeterministicNode<valueType>::swapParent(const DagNode *oldParent, const DagNode *newParent)
 {
-
-    // store if the state of the variable was dirty (needed an update)
-    bool needed_update = needs_update;
-    bool was_touched = this->touched;
-
-
-    // delegate call to base class
-    // this will set the touched flag if it wasn't set already
-    DynamicNode<valueType>::touchMe( toucher, touchAll );
-
-
-    // We need to touch the function always because of specialized touch functionality in some functions, like vector functions.
-    // In principle, it would sufficient to do the touch once for each toucher, but we do not keep track of the touchers here.
-    // call for potential specialized handling (e.g. internal flags), we might have been touched already by someone else, so we need to delegate regardless
-    // This is essential for lazy evaluation
-    function->touch( toucher );
-
-
-    // mark for update
-    needs_update = true;
-
-    // only if this function did not need an update we delegate the touch affected
-    if ( needed_update == false || was_touched == false || true )
-    {
-        // Dispatch the touch message to downstream nodes
-        this->touchAffected( touchAll );
-    }
-
+    DeterministicNodeBase::swapParent( *this, oldParent, newParent );
 }
 
+
+/** Forward deterministic invalidation to the implementation bases. */
+template<class valueType>
+void RevBayesCore::DeterministicNode<valueType>::touchMe(const DagNode *toucher, bool touchAll)
+{
+    DeterministicNodeBase::touchMe( *this, *this, toucher, touchAll );
+}
 
 #endif

--- a/src/core/dag/DeterministicNodeBase.cpp
+++ b/src/core/dag/DeterministicNodeBase.cpp
@@ -1,0 +1,239 @@
+#include "DeterministicNodeBase.h"
+
+#include "DagNode.h"
+#include "DynamicNodeBase.h"
+#include "Function.h"
+#include "RbException.h"
+
+using namespace RevBayesCore;
+
+/** Take ownership of a function and initialize its lazy-update state. */
+DeterministicNodeBase::DeterministicNodeBase(Function *f) :
+    function( f ),
+    needs_update( true ),
+    force_update( f->forceUpdates() )
+{
+}
+
+
+/** Clone the owned function but leave graph attachment to the typed node. */
+DeterministicNodeBase::DeterministicNodeBase(const DeterministicNodeBase &n) :
+    function( n.function->clone() ),
+    needs_update( true ),
+    force_update( n.function->forceUpdates() )
+{
+}
+
+
+/** Destroy the function owned by this implementation base. */
+DeterministicNodeBase::~DeterministicNodeBase(void)
+{
+    delete function;
+}
+
+
+/** Replace the owned function and rebuild its incoming DAG edges for the existing node. */
+void DeterministicNodeBase::assign(const DeterministicNodeBase &n, DagNode &owner)
+{
+    // Remove us as the child of the function parameters
+    detachFromFunctionParameters( owner );
+
+    // Delete the function
+    delete function;
+
+    // Recreate the function
+    function = n.function->clone();
+
+    // Get the parameters from the new function and add us as child of them in the DAG
+    attachToFunctionParameters( owner );
+
+    needs_update = true;
+    force_update = function->forceUpdates();
+}
+
+
+/** Register the deterministic node as a child of every function parameter. */
+void DeterministicNodeBase::attachToFunctionParameters(DagNode &owner) const
+{
+    // Get the parameters from the function and add us as a child of them in the DAG
+    const std::vector<const DagNode*> &parents = function->getParameters();
+    for ( std::vector<const DagNode*>::const_iterator it = parents.begin(); it != parents.end(); ++it )
+    {
+        (*it)->addChild( &owner );
+
+        // Increment the reference count
+        // We don't want this parent to get deleted while we are still alive
+        (*it)->incrementReferenceCount();
+    }
+}
+
+
+/** Remove the deterministic node's incoming edges and release its references to its parameters. */
+void DeterministicNodeBase::detachFromFunctionParameters(DagNode &owner) const
+{
+    // Remove us as the child of the function parameters
+    // Copy the vector because releasing a parameter may delete it and invalidate related storage.
+    std::vector<const DagNode*> parents = function->getParameters();
+    for ( std::vector<const DagNode*>::const_iterator it = parents.begin(); it != parents.end(); ++it )
+    {
+        (*it)->removeChild( &owner );
+
+        // Decrement the reference count and check whether we need to delete the DAG node
+        if ( (*it)->decrementReferenceCount() == 0 )
+        {
+            delete *it;
+        }
+    }
+}
+
+
+/** A deterministic node passes affected-node discovery directly to its descendants. */
+void DeterministicNodeBase::getAffected(DagNode &owner, RbOrderedSet<DagNode*> &affected) const
+{
+    owner.getAffectedNodes( affected );
+}
+
+
+/** Collect integrated stochastic ancestors by delegating through every current parent. */
+void DeterministicNodeBase::getIntegratedParents(const DagNode &owner, RbOrderedSet<DagNode*> &integratedParents) const
+{
+    std::vector<const DagNode*> parents = owner.getParents();                                                                     //!< Get the set of parents (empty set here)
+
+    // delegate up the DAG
+    for ( std::vector<const DagNode*>::const_iterator it = parents.begin(); it != parents.end(); ++it )
+    {
+        (*it)->getIntegratedParents( integratedParents );
+    }
+}
+
+
+/**
+ * Get the parents of this node. Simply ask the function to provide its parameters,
+ * no need to keep parents here.
+ */
+std::vector<const DagNode*> DeterministicNodeBase::getParents(void) const
+{
+    return function->getParameters();
+}
+
+
+/** A deterministic node is constant exactly when every function parameter is constant. */
+bool DeterministicNodeBase::isConstant(void) const
+{
+    // iterate over all parents and only if all parents are constant then this node is constant too
+    const std::vector<const DagNode*> &parents = function->getParameters();
+    for ( std::vector<const DagNode*>::const_iterator it = parents.begin(); it != parents.end(); ++it )
+    {
+        if ( (*it)->isConstant() == false )
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+
+/**
+ * Keep the current value of the node.
+ * At this point, we just delegate to the children.
+ */
+void DeterministicNodeBase::keepMe(DagNode &owner, DynamicNodeBase &dynamicState, const DagNode *affecter)
+{
+    // delegate call to base class
+    // this will unset the touched flag if it was set
+    dynamicState.keepMe();
+
+    // allow specialized recovery in functions
+    function->keep( affecter );
+
+    // delegate call
+    owner.keepAffected();
+
+    // clear the list of touched element indices
+    owner.clearTouchedElementIndices();
+}
+
+
+/** Notify the function that its model has been reinitialized. */
+void DeterministicNodeBase::reInitializeMe(void)
+{
+    function->reInitialized();
+}
+
+
+/** Restore the old value of the node and tell affected. */
+void DeterministicNodeBase::restoreMe(DagNode &owner, DynamicNodeBase &dynamicState, const DagNode *restorer)
+{
+    // The value has been changed so we need to flag for recomputing the value. We need to do that even
+    // if the touched flag is unset because a reset call from one parameter may have unset it before
+    // another parameter was restored. We therefore update our value whenever a parameter is restored.
+    needs_update = true;
+
+    // we just mark ourselves as clean, albeit perhaps not being updated
+    dynamicState.restoreMe();
+
+    // call for potential specialized handling (e.g. internal flags)
+    function->restore( restorer );
+
+    // clear the list of touched element indices
+    owner.clearTouchedElementIndices();
+
+    // delegate call
+    owner.restoreAffected();
+}
+
+
+/**
+ * This function replaces the earlier swapParameter function. If we rely on the
+ * internal RevBayesCore::Function to manage our parents, we simply need to ask
+ * the function to swap its parameters, and then manage the connection of the
+ * parents (parameters) to this node.
+ */
+void DeterministicNodeBase::swapParent(DagNode &owner, const DagNode *oldParent, const DagNode *newParent)
+{
+    // We are sure to get into trouble if either one of these is NULL
+    if ( oldParent == NULL || newParent == NULL )
+    {
+        throw RbException( "Attempt to swap NULL function parameter of RevBayesCore::DeterministicNode" );
+    }
+
+    // This throws an error if the oldParent cannot be found
+    function->swapParameter( oldParent, newParent );
+
+    oldParent->removeChild( &owner );
+    if ( oldParent->decrementReferenceCount() == 0 )
+    {
+        delete oldParent;
+    }
+
+    newParent->addChild( &owner );
+    newParent->incrementReferenceCount();
+    owner.touch();
+}
+
+
+/** Touch this node for recalculation. */
+void DeterministicNodeBase::touchMe(DagNode &owner, DynamicNodeBase &dynamicState, const DagNode *toucher, bool touchAll)
+{
+    // store if the state of the variable was dirty (needed an update)
+    bool needed_update = needs_update;
+    bool was_touched = dynamicState.isTouched();
+
+    // delegate call to base class; this will set the touched flag if it wasn't set already
+    dynamicState.touchMe();
+
+    // We need to touch the function always because of specialized touch functionality in some
+    // functions, like vector functions. This is essential for lazy evaluation.
+    function->touch( toucher );
+
+    // mark for update
+    needs_update = true;
+
+    // The condition is historically always true; retaining it preserves the current propagation structure.
+    if ( needed_update == false || was_touched == false || true )
+    {
+        // Dispatch the touch message to downstream nodes
+        owner.touchAffected( touchAll );
+    }
+}

--- a/src/core/dag/DeterministicNodeBase.h
+++ b/src/core/dag/DeterministicNodeBase.h
@@ -1,0 +1,44 @@
+#ifndef DeterministicNodeBase_H
+#define DeterministicNodeBase_H
+
+#include "RbOrderedSet.h"
+
+#include <vector>
+
+namespace RevBayesCore {
+
+    class DagNode;
+    class DynamicNodeBase;
+    class Function;
+
+    /** Implements deterministic-node behavior that does not depend on the node's value type. */
+    class DeterministicNodeBase {
+
+    public:
+        explicit DeterministicNodeBase(Function *f);
+        DeterministicNodeBase(const DeterministicNodeBase &n);
+                                                           ~DeterministicNodeBase(void);
+
+    protected:
+        void                                               assign(const DeterministicNodeBase &n, DagNode &owner);
+        void                                               attachToFunctionParameters(DagNode &owner) const;
+        void                                               detachFromFunctionParameters(DagNode &owner) const;
+        void                                               getAffected(DagNode &owner, RbOrderedSet<DagNode*> &affected) const;
+        void                                               getIntegratedParents(const DagNode &owner, RbOrderedSet<DagNode*> &integratedParents) const;
+        std::vector<const DagNode*>                        getParents(void) const;
+        bool                                               isConstant(void) const;
+        void                                               keepMe(DagNode &owner, DynamicNodeBase &dynamicState, const DagNode *affecter);
+        void                                               reInitializeMe(void);
+        void                                               restoreMe(DagNode &owner, DynamicNodeBase &dynamicState, const DagNode *restorer);
+        void                                               swapParent(DagNode &owner, const DagNode *oldParent, const DagNode *newParent);
+        void                                               touchMe(DagNode &owner, DynamicNodeBase &dynamicState, const DagNode *toucher, bool touchAll);
+
+        // members
+        Function                                          *function;
+        mutable bool                                       needs_update;
+        bool                                               force_update;
+    };
+
+}
+
+#endif

--- a/src/core/dag/DynamicNode.h
+++ b/src/core/dag/DynamicNode.h
@@ -1,202 +1,92 @@
 #ifndef DynamicNode_H
 #define DynamicNode_H
 
+#include "DynamicNodeBase.h"
 #include "TypedDagNode.h"
-#include "DagNodeMap.h"
-#include <set>
 
 namespace RevBayesCore {
-    
+
     template<class valueType>
-    class DynamicNode : public TypedDagNode<valueType> {
-        
+    class DynamicNode : public TypedDagNode<valueType>, protected DynamicNodeBase {
+
     public:
-        
         DynamicNode(const std::string &n);
         DynamicNode(const DynamicNode &n);
-        virtual                                            ~DynamicNode(void);                                                              //!< Virtual destructor
-        
+        virtual                                            ~DynamicNode(void) = default;                                                //!< Virtual destructor
+
         // pure virtual methods
-        virtual DynamicNode<valueType>*                     clone(void) const = 0;
-        
+        virtual DynamicNode<valueType>*                    clone(void) const = 0;
+
         // public methods
-        virtual DagNode*                                    cloneDAG(DagNodeMap &nodesMap, std::map<std::string, const DagNode* > &names) const; //!< Clone the entire DAG which is connected to this node
-        
+        virtual DagNode*                                   cloneDAG(DagNodeMap &nodesMap, std::map<std::string, const DagNode*> &names) const; //!< Clone the entire DAG which is connected to this node
+
         // this function provided for derived classes used in the language layer, which need to override it
-        virtual const std::string&                          getRevTypeOfValue(void);                                                        //!< Get Rev language type of value
-        
+        virtual const std::string&                         getRevTypeOfValue(void);                                                     //!< Get Rev language type of value
+
     protected:
-        virtual void                                        keepMe(const DagNode* affecter);                                                //!< Keep value of this and affected nodes
-        virtual void                                        restoreMe(const DagNode *restorer);                                             //!< Restore value of this node
-        virtual void                                        touchMe(const DagNode *toucher, bool touchAll);                                 //!< Tell affected nodes value is reset
-        
-        
-        // members
-        bool                                                touched;
-        
+        virtual void                                       keepMe(const DagNode* affecter);                                             //!< Keep value of this and affected nodes
+        virtual void                                       restoreMe(const DagNode *restorer);                                          //!< Restore value of this node
+        virtual void                                       touchMe(const DagNode *toucher, bool touchAll);                              //!< Tell affected nodes value is reset
     };
-    
+
 }
 
-#include "RbException.h"
-#include "RbOptions.h"
 
+/** Initialize the typed and type-independent portions of a dynamic node. */
 template<class valueType>
-RevBayesCore::DynamicNode<valueType>::DynamicNode( const std::string &n ) : TypedDagNode<valueType>( n ),
-    touched( true )
+RevBayesCore::DynamicNode<valueType>::DynamicNode(const std::string &n) : TypedDagNode<valueType>( n ),
+    DynamicNodeBase()
 {
     // nothing to do here
 }
 
 
+/** Copy the typed node while starting the dynamic state as touched. */
 template<class valueType>
-RevBayesCore::DynamicNode<valueType>::DynamicNode( const DynamicNode<valueType> &n ) : TypedDagNode<valueType>( n ),
-    touched( true )
+RevBayesCore::DynamicNode<valueType>::DynamicNode(const DynamicNode<valueType> &n) : TypedDagNode<valueType>( n ),
+    DynamicNodeBase( n )
 {
     // nothing to do here
 }
 
 
+/** Delegate type-independent graph cloning to the non-template implementation base. */
 template<class valueType>
-RevBayesCore::DynamicNode<valueType>::~DynamicNode( void )
+RevBayesCore::DagNode* RevBayesCore::DynamicNode<valueType>::cloneDAG(DagNodeMap &nodesMap, std::map<std::string, const DagNode*> &names) const
 {
-    // We don't own the parents and hence we don't delete them. The owner of the graph needs to do that. Just tell them we are gone forever ... :(
+    return DynamicNodeBase::cloneDAG( *this, nodesMap, names );
 }
 
 
-/** Clone the entire graph: clone children, swap parents */
-template<class valueType>
-RevBayesCore::DagNode* RevBayesCore::DynamicNode<valueType>::cloneDAG( DagNodeMap& new_nodes, std::map<std::string, const DagNode* > &names ) const
-{
-    
-    // Return our clone if we have already been cloned
-    if ( new_nodes.find( this ) != new_nodes.end() )
-    {
-        return ( new_nodes[ this ] );
-    }
-    
-    // just for self checking purposes we keep track of the names for the variables we already cloned
-    if ( this->name != "" )
-    {
-        // check if we already added a variable with this name
-        std::map<std::string, const DagNode* >::const_iterator n = names.find( this->name );
-        if ( n == names.end() )
-        {
-            // no, we haven't cloned a variable with this name before
-            names[ this->name ] = this;
-        }
-        else
-        {
-#ifdef DEBUG_SEBASTIAN
-            const DagNode *orgCopy = n->second;
-            std::cerr << "Ptr to org:\t" << orgCopy << "\t\t --- \t\t Ptr to desc:\t" << this << std::endl;
-            std::cerr << "Cloning a DAG node with name '" << this->name << "' again, doh! Please tell this to Sebastian because it's most likely a bug." << std::endl;
-#endif
-        }
-    }
-    
-    // Get a shallow copy
-    DynamicNode* copy = clone();
-    
-    // Add this node and its copy to the map
-    new_nodes[ this ] = copy;
-    
-    // Parent management is delegated to derived classes, so get the parents through their getParents function
-    std::vector<const DagNode*> my_parents = this->getParents();
-    
-    // We need to remove the copy as a child of our parents in order to stop recursive calls to
-    // cloneDAG on our copy, its copy, etc, when we call cloneDAG on our parents
-    for ( std::vector<const DagNode*>::const_iterator i = my_parents.begin(); i != my_parents.end(); ++i )
-    {
-        const DagNode *the_param = (*i);
-        
-        the_param->removeChild( copy );
-        
-        the_param->decrementReferenceCount();
-    }
-    
-    // Now replace the parents of the copy (which are now the same as our parents) with the parent clones
-    for ( std::vector<const DagNode*>::const_iterator i = my_parents.begin(); i != my_parents.end(); ++i )
-    {
-        // Get the i-th parent
-        const DagNode *the_param = (*i);
-        
-        // Get its clone. If we already have cloned this parent (parameter), then we will get the previously created clone
-        DagNode* the_param_clone = the_param->cloneDAG( new_nodes, names );
-        
-        // Add the copy back as a child of this parent so that the swapping works
-        the_param->addChild( copy );
-        the_param->incrementReferenceCount();
-        
-        // Swap the parent of the copy with its clone. This will remove the copy again as the child of our parent.
-        copy->swapParent( the_param, the_param_clone);
-    }
-    
-    // Make sure the children clone themselves
-    std::vector<DagNode*> children_to_clone = this->getChildren();
-    for ( std::vector<DagNode* >::const_iterator i = children_to_clone.begin(); i != children_to_clone.end(); i++ )
-    {
-        DagNode *the_node = *i;
-        the_node->cloneDAG( new_nodes, names );
-    }
-    
-    return copy;
-}
-
-
-/**
- * This function returns the Rev language type of the value. When used in the Rev
- * language layer, a DAG node must know the Rev language type of its value, or
- * construction of dynamic variables will not be safe. Here we just throw an
- * error, as a core DAG node need not know and should not know the language type
- * of its value.
- */
+/** Return the default type-erased error for core dynamic nodes. */
 template<class valueType>
 const std::string& RevBayesCore::DynamicNode<valueType>::getRevTypeOfValue(void)
 {
-    throw RbException( "Rev language type of dynamic DAG node value not known" );
+    return DynamicNodeBase::getRevTypeOfValue();
 }
 
 
-/**
- * Keep the current value of the node.
- * At this point, we also need to make sure we update the stored ln probability.
- */
+/** Forward keep-state bookkeeping to the implementation base. */
 template<class valueType>
-void RevBayesCore::DynamicNode<valueType>::keepMe( const DagNode* /*affecter*/ )
+void RevBayesCore::DynamicNode<valueType>::keepMe(const DagNode* /*affecter*/)
 {
-    
-    // unset the touched flag
-    touched = false;
-    
+    DynamicNodeBase::keepMe();
 }
 
 
-/** 
- * Restore the old value of the node and tell affected 
- */
+/** Forward restore-state bookkeeping to the implementation base. */
 template<class valueType>
-void RevBayesCore::DynamicNode<valueType>::restoreMe( const DagNode * /*restorer*/)
+void RevBayesCore::DynamicNode<valueType>::restoreMe(const DagNode* /*restorer*/)
 {
-
-    // unset the touched flag
-    touched = false;
-    
+    DynamicNodeBase::restoreMe();
 }
 
-/** 
- * Touch this node for recalculation 
- */
+
+/** Forward touch-state bookkeeping to the implementation base. */
 template<class valueType>
-void RevBayesCore::DynamicNode<valueType>::touchMe( const DagNode * /*toucher*/, bool /*touchAll*/ )
+void RevBayesCore::DynamicNode<valueType>::touchMe(const DagNode* /*toucher*/, bool /*touchAll*/)
 {
-
-    // set the touched flag
-    touched = true;
-    
+    DynamicNodeBase::touchMe();
 }
-
-
 
 #endif
-

--- a/src/core/dag/DynamicNodeBase.cpp
+++ b/src/core/dag/DynamicNodeBase.cpp
@@ -1,0 +1,143 @@
+#include "DynamicNodeBase.h"
+
+#include "DagNode.h"
+#include "DagNodeMap.h"
+#include "RbException.h"
+
+#include <iostream>
+
+using namespace RevBayesCore;
+
+/** Initialize a new dynamic node in the touched state. */
+DynamicNodeBase::DynamicNodeBase(void) :
+    touched( true )
+{
+}
+
+
+/** Copies intentionally begin touched, matching the historical dynamic-node copy behavior. */
+DynamicNodeBase::DynamicNodeBase(const DynamicNodeBase & /*n*/) :
+    touched( true )
+{
+}
+
+
+/** Clone the entire graph: clone children, swap parents. */
+DagNode* DynamicNodeBase::cloneDAG(const DagNode &owner, DagNodeMap &new_nodes, std::map<std::string, const DagNode*> &names) const
+{
+    // Return our clone if we have already been cloned
+    if ( new_nodes.find( &owner ) != new_nodes.end() )
+    {
+        return new_nodes[ &owner ];
+    }
+
+    // just for self checking purposes we keep track of the names for the variables we already cloned
+    if ( owner.getName() != "" )
+    {
+        // check if we already added a variable with this name
+        std::map<std::string, const DagNode* >::const_iterator n = names.find( owner.getName() );
+        if ( n == names.end() )
+        {
+            // no, we haven't cloned a variable with this name before
+            names[ owner.getName() ] = &owner;
+        }
+        else
+        {
+#ifdef DEBUG_SEBASTIAN
+            const DagNode *orgCopy = n->second;
+            std::cerr << "Ptr to org:\t" << orgCopy << "\t\t --- \t\t Ptr to desc:\t" << &owner << std::endl;
+            std::cerr << "Cloning a DAG node with name '" << owner.getName() << "' again, doh! Please tell this to Sebastian because it's most likely a bug." << std::endl;
+#endif
+        }
+    }
+
+    // Get a shallow copy
+    DagNode *copy = owner.clone();
+
+    // Add this node and its copy to the map
+    new_nodes[ &owner ] = copy;
+
+    // Parent management is delegated to derived classes, so get the parents through their getParents function
+    std::vector<const DagNode*> my_parents = owner.getParents();
+
+    // We need to remove the copy as a child of our parents in order to stop recursive calls to
+    // cloneDAG on our copy, its copy, etc, when we call cloneDAG on our parents
+    for ( std::vector<const DagNode*>::const_iterator i = my_parents.begin(); i != my_parents.end(); ++i )
+    {
+        const DagNode *the_param = *i;
+        the_param->removeChild( copy );
+        the_param->decrementReferenceCount();
+    }
+
+    // Now replace the parents of the copy (which are now the same as our parents) with the parent clones
+    for ( std::vector<const DagNode*>::const_iterator i = my_parents.begin(); i != my_parents.end(); ++i )
+    {
+        const DagNode *the_param = *i;
+
+        // Get its clone. If we already have cloned this parent (parameter), then we will get the previously created clone
+        DagNode *the_param_clone = the_param->cloneDAG( new_nodes, names );
+
+        // Add the copy back as a child of this parent so that the swapping works
+        the_param->addChild( copy );
+        the_param->incrementReferenceCount();
+
+        // Swap the parent of the copy with its clone. This will remove the copy again as the child of our parent.
+        copy->swapParent( the_param, the_param_clone );
+    }
+
+    // Make sure the children clone themselves
+    std::vector<DagNode*> children_to_clone = owner.getChildren();
+    for ( std::vector<DagNode*>::const_iterator i = children_to_clone.begin(); i != children_to_clone.end(); ++i )
+    {
+        (*i)->cloneDAG( new_nodes, names );
+    }
+
+    return copy;
+}
+
+
+/**
+ * This function returns the Rev language type of the value. When used in the Rev
+ * language layer, a DAG node must know the Rev language type of its value, or
+ * construction of dynamic variables will not be safe. Here we just throw an
+ * error, as a core DAG node need not know and should not know the language type
+ * of its value.
+ */
+const std::string& DynamicNodeBase::getRevTypeOfValue(void) const
+{
+    throw RbException( "Rev language type of dynamic DAG node value not known" );
+}
+
+
+/** Report whether the dynamic node currently requires processing. */
+bool DynamicNodeBase::isTouched(void) const
+{
+    return touched;
+}
+
+
+/**
+ * Keep the current value of the node.
+ * At this point, we also need to make sure we update the stored ln probability.
+ */
+void DynamicNodeBase::keepMe(void)
+{
+    // unset the touched flag
+    touched = false;
+}
+
+
+/** Restore the old value of the node and tell affected. */
+void DynamicNodeBase::restoreMe(void)
+{
+    // unset the touched flag
+    touched = false;
+}
+
+
+/** Touch this node for recalculation. */
+void DynamicNodeBase::touchMe(void)
+{
+    // set the touched flag
+    touched = true;
+}

--- a/src/core/dag/DynamicNodeBase.h
+++ b/src/core/dag/DynamicNodeBase.h
@@ -1,0 +1,39 @@
+#ifndef DynamicNodeBase_H
+#define DynamicNodeBase_H
+
+#include <map>
+#include <string>
+
+namespace RevBayesCore {
+
+    class DagNode;
+    class DagNodeMap;
+    class DeterministicNodeBase;
+    class StochasticNodeBase;
+
+    /** Implements dynamic-node behavior that does not depend on the node's value type. */
+    class DynamicNodeBase {
+
+        friend class DeterministicNodeBase;
+        friend class StochasticNodeBase;
+
+    public:
+        DynamicNodeBase(void);
+        DynamicNodeBase(const DynamicNodeBase &n);
+                                                           ~DynamicNodeBase(void) = default;
+
+    protected:
+        DagNode*                                           cloneDAG(const DagNode &owner, DagNodeMap &nodesMap, std::map<std::string, const DagNode*> &names) const;
+        const std::string&                                 getRevTypeOfValue(void) const;
+        bool                                               isTouched(void) const;
+        void                                               keepMe(void);
+        void                                               restoreMe(void);
+        void                                               touchMe(void);
+
+        // members
+        bool                                               touched;
+    };
+
+}
+
+#endif

--- a/src/core/dag/StochasticNode.h
+++ b/src/core/dag/StochasticNode.h
@@ -1,332 +1,173 @@
 #ifndef StochasticNode_H
 #define StochasticNode_H
 
+#include "Cloner.h"
 #include "DynamicNode.h"
+#include "IsDerivedFrom.h"
 #include "RbException.h"
-
-namespace RevBayesCore {
-    
-    
-    template <class valueType>
-    class TypedDistribution;
-    
-    // Put StochasticNode-specific stuff that doesn't depend on valueType here.
-    // Ideally this would inherit from DagNode
-    class StochasticNodeBase
-    {
-    protected:
-        bool clamped = false;
-    public:
-        /**
-         * Set directly the flag whether this node is clamped.
-         * The caller needs to be responsible enough to know that we will assume
-         * that the current value is the observed value.
-         * We could use instead as well a call: clamp( getValue() );
-        */
-        void setClamped(bool tf)
-        {
-            clamped = tf;
-        }        
-
-        /**
-         * Unclamp this node. If I understand this correctly, we
-         * can just set the clamped flag to false if we keep the
-         * current value. We do not need to tell anyone that we
-         * have changed value because we really haven't.
-         */
-        void unclamp(void)
-        {
-            clamped = false;
-        }
-    };
-
-    template <class valueType>
-    class StochasticNode : public DynamicNode<valueType>, public MemberObject< RbVector<double> >, public StochasticNodeBase {
-        
-    public:
-        
-        StochasticNode(const std::string &n, TypedDistribution<valueType> *d);
-        StochasticNode(const StochasticNode<valueType> &n);                                                                             //!< Copy constructor
-        
-        virtual                                            ~StochasticNode(void);                                                       //!< Virtual destructor
-        
-        // Assignment operator
-        StochasticNode&                                     operator=(const StochasticNode& n);                                         //!< Assignment operator
-        
-        // Basic utility function
-        virtual StochasticNode<valueType>*                  clone(void) const;
-        
-        // methods
-        void                                                bootstrap(void);                                                            //!< Bootstrap the current value of the node (applies only to stochastic nodes)
-        void                                                clamp(valueType *val);                                                      //!< Clamp an observation to this random variable
-        void                                                executeMethod(const std::string &n, const std::vector<const DagNode*> &args, RbVector<double> &rv) const; //!< Map the member methods to internal function calls
-        virtual TypedDistribution<valueType>&               getDistribution(void);
-        virtual const TypedDistribution<valueType>&         getDistribution(void) const;
-        void                                                getIntegratedParents(RbOrderedSet<DagNode *>& ip) const;
-        virtual double                                      getLnProbability(void);
-        virtual double                                      getPrevLnProbability(void) const;
-        virtual double                                      getLnProbabilityRatio(void);
-        virtual std::vector<double>                         getMixtureLikelihoods(bool log=true) const;
-        virtual std::vector<double>                         getMixtureProbabilities(void) const;
-        virtual size_t                                      getNumberOfMixtureElements(void) const;                                                        //!< Get the number of elements for this value
-        valueType&                                          getValue(void);
-        const valueType&                                    getValue(void) const;
-        bool                                                isClamped(void) const;                                                      //!< Is this DAG node clamped?
-        bool                                                isIntegratedOut(void) const;
-        bool                                                isIgnoredData(void) const;
-        bool                                                isStochastic(void) const;                                                   //!< Is this DAG node stochastic?
-        virtual void                                        printStructureInfo(std::ostream &o, bool verbose=false) const;              //!< Print the structural information (e.g. name, value-type, distribution/function, children, parents, etc.)
-        void                                                redraw(SimulationCondition c = SimulationCondition::MCMC);                  //!< Redraw the current value of the node (applies only to stochastic nodes)
-        virtual void                                        reInitializeMe(void);                                                       //!< The DAG was re-initialized so maybe you want to reset some stuff (delegate to distribution)
-        void                                                setIgnoreRedraw(bool tf=true);
-        void                                                setIntegratedOut(bool tf=true);
-        virtual void                                        setIntegrationIndex( size_t i );
-        void                                                setMcmcMode(bool tf);                                                       //!< Set the modus of the DAG node to MCMC mode.
-        virtual void                                        setIgnoreData(bool tf);                                                 //!< Set whether we want to have the probability of the prior only.
-        virtual void                                        setValue(valueType *val, bool touch=true);                                  //!< Set the value of this node
-        void                                                setValueFromFile(const path &dir);                                          //!< Set value from string.
-        void                                                setValueFromString(const std::string &v);                                   //!< Set value from string.
-        
-        // Parent DAG nodes management functions
-        std::vector<const DagNode*>                         getParents(void) const;                                                     //!< Get the set of parents
-        void                                                swapParent(const DagNode *oldP, const DagNode *newP);                       //!< Exchange the parent (distribution parameter)
-        
-    protected:
-        
-        virtual double                                      computeRecursiveIntegratedLnProbability(RbOrderedSet<DagNode *>& ig, size_t idx);
-        virtual void                                        getAffected(RbOrderedSet<DagNode *>& affected, const DagNode* affecter);    //!< Mark and get affected nodes
-        virtual void                                        keepMe(const DagNode* affecter);                                            //!< Keep value of this and affected nodes
-        virtual void                                        restoreMe(const DagNode *restorer);                                         //!< Restore value of this nodes
-        virtual void                                        setActivePIDSpecialized(size_t i, size_t n);                                //!< Set the number of processes for this class.
-        virtual void                                        touchMe(const DagNode *toucher, bool touchAll);                             //!< Tell affected nodes value is reset
-        
-        // protected members
-        bool                                                ignore_data = false;                                                    //!< The PDF for this node is set to 1, removing the effects of the node.  Only for clamped nodes with no children.
-        bool                                                ignore_redraw = false;
-        mutable bool                                        integrated_out = false;
-        std::optional<double>                               lnProb;                                                                     //!< Current log probability, or empty if not computed.
-        std::optional<std::optional<double>>                stored_ln_prob;                                                             //!< Previous log probability if (a) there is a previous state and (b) the log probability for it is computed.
-        TypedDistribution<valueType>*                       distribution;
-        
-    };
-}
-
-
-#include "RbConstants.h"
-#include "RbOptions.h"
-#include "RbMathLogic.h"
+#include "RbVector.h"
+#include "Serializer.h"
+#include "StochasticNodeBase.h"
 #include "TypedDistribution.h"
 
+#include <cassert>
 
-#include <cmath>
+namespace RevBayesCore {
+
+    template <class valueType>
+    class StochasticNode : public DynamicNode<valueType>, public MemberObject<RbVector<double>>, public StochasticNodeBase {
+
+    public:
+        StochasticNode(const std::string &n, TypedDistribution<valueType> *d);
+        StochasticNode(const StochasticNode<valueType> &n);                                                                             //!< Copy constructor
+        virtual                                            ~StochasticNode(void);                                                       //!< Virtual destructor
+
+        // Assignment operator
+        StochasticNode&                                    operator=(const StochasticNode &n);                                          //!< Assignment operator
+
+        // Basic utility function
+        virtual StochasticNode<valueType>*                 clone(void) const;
+
+        // methods
+        void                                               bootstrap(void);                                                             //!< Bootstrap the current value of the node (applies only to stochastic nodes)
+        void                                               clamp(valueType *val);                                                       //!< Clamp an observation to this random variable
+        void                                               executeMethod(const std::string &n, const std::vector<const DagNode*> &args, RbVector<double> &rv) const; //!< Map the member methods to internal function calls
+        virtual TypedDistribution<valueType>&              getDistribution(void);
+        virtual const TypedDistribution<valueType>&        getDistribution(void) const;
+        void                                               getIntegratedParents(RbOrderedSet<DagNode*> &ip) const;
+        virtual double                                     getLnProbability(void);
+        virtual double                                     getPrevLnProbability(void) const;
+        virtual double                                     getLnProbabilityRatio(void);
+        virtual std::vector<double>                        getMixtureLikelihoods(bool log=true) const;
+        virtual std::vector<double>                        getMixtureProbabilities(void) const;
+        virtual size_t                                     getNumberOfMixtureElements(void) const;                                     //!< Get the number of elements for this value
+        valueType&                                         getValue(void);
+        const valueType&                                   getValue(void) const;
+        bool                                               isClamped(void) const;                                                       //!< Is this DAG node clamped?
+        bool                                               isIntegratedOut(void) const;
+        bool                                               isIgnoredData(void) const;
+        bool                                               isStochastic(void) const;                                                    //!< Is this DAG node stochastic?
+        virtual void                                       printStructureInfo(std::ostream &o, bool verbose=false) const;               //!< Print the structural information (e.g. name, value-type, distribution/function, children, parents, etc.)
+        void                                               redraw(SimulationCondition c = SimulationCondition::MCMC);                   //!< Redraw the current value of the node (applies only to stochastic nodes)
+        virtual void                                       reInitializeMe(void);                                                        //!< The DAG was re-initialized so maybe you want to reset some stuff (delegate to distribution)
+        void                                               setIgnoreRedraw(bool tf=true);
+        void                                               setIntegratedOut(bool tf=true);
+        virtual void                                       setIntegrationIndex(size_t i);
+        void                                               setMcmcMode(bool tf);                                                        //!< Set the modus of the DAG node to MCMC mode.
+        virtual void                                       setIgnoreData(bool tf);                                                      //!< Set whether we want to have the probability of the prior only.
+        virtual void                                       setValue(valueType *val, bool touch=true);                                   //!< Set the value of this node
+        void                                               setValueFromFile(const path &dir);                                           //!< Set value from string.
+        void                                               setValueFromString(const std::string &v);                                    //!< Set value from string.
+
+        // Parent DAG nodes management functions
+        std::vector<const DagNode*>                        getParents(void) const;                                                      //!< Get the set of parents
+        void                                               swapParent(const DagNode *oldParent, const DagNode *newParent);              //!< Exchange the parent (distribution parameter)
+
+    protected:
+        virtual double                                     computeRecursiveIntegratedLnProbability(RbOrderedSet<DagNode*> &integratedParents, size_t index);
+        virtual void                                       getAffected(RbOrderedSet<DagNode*> &affected, const DagNode *affecter);      //!< Mark and get affected nodes
+        virtual void                                       keepMe(const DagNode *affecter);                                             //!< Keep value of this and affected nodes
+        virtual void                                       restoreMe(const DagNode *restorer);                                          //!< Restore value of this nodes
+        virtual void                                       setActivePIDSpecialized(size_t activePid, size_t numProcesses);              //!< Set the number of processes for this class.
+        virtual void                                       touchMe(const DagNode *toucher, bool touchAll);                              //!< Tell affected nodes value is reset
+    };
+
+}
 
 
+/** Construct a typed stochastic node and attach it to its distribution parameters. */
 template<class valueType>
-RevBayesCore::StochasticNode<valueType>::StochasticNode( const std::string &n, TypedDistribution<valueType> *d )
+RevBayesCore::StochasticNode<valueType>::StochasticNode(const std::string &n, TypedDistribution<valueType> *d)
     : DynamicNode<valueType>( n ),
-      distribution( d )
+      StochasticNodeBase( d )
 {
     this->type = DagNode::STOCHASTIC;
-    
-    // Get the parameters from the distribution and add us as a child of them in the DAG
-    const std::vector<const DagNode*>& distParents = distribution->getParameters();
-    for (std::vector<const DagNode*>::const_iterator it = distParents.begin(); it != distParents.end(); ++it)
-    {
-        (*it)->addChild( this );
-        
-        // Increment the reference count
-        // We don't want this parent to get deleted while we are still alive
-        (*it)->incrementReferenceCount();
-    }
-    
+    this->attachToDistributionParameters( *this );
+
     // Set us as the DAG node of the distribution
-    distribution->setStochasticNode( this );
+    d->setStochasticNode( this );
 }
 
 
-
+/** Copy a stochastic node, attach its cloned distribution, and restore the typed back-pointer. */
 template<class valueType>
-RevBayesCore::StochasticNode<valueType>::StochasticNode( const StochasticNode<valueType> &n )
+RevBayesCore::StochasticNode<valueType>::StochasticNode(const StochasticNode<valueType> &n)
     : DynamicNode<valueType>( n ),
-      StochasticNodeBase( n ),
-      ignore_data( n.ignore_data ),
-      ignore_redraw( n.ignore_redraw ),
-      integrated_out( n.integrated_out ),
-      distribution( n.distribution->clone() )
+      StochasticNodeBase( n )
 {
     this->type = DagNode::STOCHASTIC;
-    
-    // Get the parameters from the distribution and add us as a child of them in the DAG
-    const std::vector<const DagNode*>& distParents = distribution->getParameters();
-    for (std::vector<const DagNode*>::const_iterator it = distParents.begin(); it != distParents.end(); ++it)
-    {
-        (*it)->addChild( this );
-        
-        // Increment the reference count
-        // We don't want this parent to get deleted while we are still alive
-        (*it)->incrementReferenceCount();
-    }
-    
+    this->attachToDistributionParameters( *this );
+
     // Set us as the DAG node of the distribution
-    distribution->setStochasticNode( this );
+    static_cast<TypedDistribution<valueType>*>( this->distribution )->setStochasticNode( this );
 }
 
 
+/** Detach the node before the implementation base destroys its distribution. */
 template<class valueType>
-RevBayesCore::StochasticNode<valueType>::~StochasticNode( void )
+RevBayesCore::StochasticNode<valueType>::~StochasticNode(void)
 {
-    
-    // Remove us as the child of the distribution parameters
-    std::vector<const DagNode*> distParents = distribution->getParameters();
-    for (std::vector<const DagNode*>::const_iterator it = distParents.begin(); it != distParents.end(); ++it)
-    {
-        (*it)->removeChild( this );
-        
-        // Decrement the reference count and check whether we need to delete the DAG node
-        if ( (*it)->decrementReferenceCount() == 0)
-        {
-            delete (*it);
-        }
-        
-    }
-    
-    delete distribution;
-    
+    this->detachFromDistributionParameters( *this );
 }
 
 
-/**
- * Assignment operator. Make sure we deal with parent nodes correctly here.
- */
+/** Assignment operator. Make sure we deal with parent nodes correctly here. */
 template<class valueType>
-RevBayesCore::StochasticNode<valueType>& RevBayesCore::StochasticNode<valueType>::operator=( const StochasticNode<valueType>& n )
+RevBayesCore::StochasticNode<valueType>& RevBayesCore::StochasticNode<valueType>::operator=(const StochasticNode<valueType> &n)
 {
-    
     if ( &n != this )
     {
         // Call base class assignment operators
         DynamicNode<valueType>::operator=( n );
-        StochasticNodeBase::operator=(n);
-        
-        // Remove us as the child of the distribution parameters
-        const std::vector<const DagNode*>& dist_parents = distribution->getParameters();
-        for (std::vector<const DagNode*>::const_iterator it = dist_parents.begin(); it != dist_parents.end(); ++it)
-        {
-            (*it)->removeChild( this );
-            
-            // Decrement the reference count and check whether we need to delete the DAG node
-            if ( (*it)->decrementReferenceCount() == 0)
-            {
-                delete (*it);
-            }
-            
-        }
-        
-        // Delete the distribution
-        delete distribution;
-        
-        // Recreate the distribution
-        distribution = n.distribution->clone();
-        
-        // Get the parameters from the new distribution and add us as child of them in the DAG
-        const std::vector<const DagNode*>& new_dist_parents = distribution->getParameters();
-        for (std::vector<const DagNode*>::const_iterator it = new_dist_parents.begin(); it != new_dist_parents.end(); ++it)
-        {
-            (*it)->addChild( this );
-            
-            // Increment the reference count
-            // We don't want this parent to get deleted while we are still alive
-            (*it)->incrementReferenceCount();
-        }
-        
+        StochasticNodeBase::assign( n, *this );
+
         // Set us as the DAG node of the new distribution
-        distribution->setStochasticNode( this );
-        
-        ignore_data                         = n.ignore_data;
-        ignore_redraw                       = n.ignore_redraw;
-        integrated_out                      = n.integrated_out;
-        lnProb                              = {};
+        static_cast<TypedDistribution<valueType>*>( this->distribution )->setStochasticNode( this );
     }
-    
+
     return *this;
 }
 
 
+/** Forward bootstrap redraw and invalidation to the implementation base. */
 template<class valueType>
-void RevBayesCore::StochasticNode<valueType>::bootstrap( void )
+void RevBayesCore::StochasticNode<valueType>::bootstrap(void)
 {
-    
-    distribution->bootstrap();
-    
-    // touch this node for probability recalculation
-    this->touch();
-    
+    StochasticNodeBase::bootstrap( *this );
 }
 
 
+/** Install an observed typed value and mark the node clamped. */
 template<class valueType>
 void RevBayesCore::StochasticNode<valueType>::clamp(valueType *val)
 {
     // clamp the node with the value
     // we call set value because some derived classes might have special implementations for setting values (e.g. mixtures)
     setValue( val );
-    
-    clamped = true;
-    
+    this->clamped = true;
 }
 
 
-
+/** Clone this typed stochastic node. */
 template<class valueType>
-RevBayesCore::StochasticNode<valueType>* RevBayesCore::StochasticNode<valueType>::clone( void ) const
+RevBayesCore::StochasticNode<valueType>* RevBayesCore::StochasticNode<valueType>::clone(void) const
 {
-    
     return new StochasticNode<valueType>( *this );
 }
 
 
+/** Preserve the virtual recursive integration hook while delegating its default behavior. */
 template<class valueType>
-double RevBayesCore::StochasticNode<valueType>::computeRecursiveIntegratedLnProbability(RbOrderedSet<DagNode *>& integrated_parents, size_t index)
+double RevBayesCore::StochasticNode<valueType>::computeRecursiveIntegratedLnProbability(RbOrderedSet<DagNode*> &integratedParents, size_t index)
 {
-
-    double ln_prob = 0;
-    
-    if ( integrated_parents.size() <= index )
-    {
-        ln_prob = distribution->computeLnProbability();
-    }
-    else
-    {
-        DagNode* this_parent = integrated_parents[index];
-        size_t num_mixture_elements = this_parent->getNumberOfMixtureElements();
-        std::vector<double> ln_probs = std::vector<double>(num_mixture_elements, 0.0);
-        double max_ln_probs = RbConstants::Double::neginf;
-        for (size_t i=0; i<num_mixture_elements; ++i)
-        {
-            this_parent->setIntegrationIndex( i );
-            ln_probs[i] = computeRecursiveIntegratedLnProbability( integrated_parents, index+1 );
-            if ( ln_probs[i] > max_ln_probs )
-            {
-                max_ln_probs = ln_probs[i];
-            }
-        }
-        std::vector<double> mixture_probs = this_parent->getMixtureProbabilities();
-        double prob = 0.0;
-        for (size_t i=0; i<num_mixture_elements; ++i)
-        {
-            prob += exp(ln_probs[i] - max_ln_probs) * mixture_probs[i];
-        }
-        ln_prob = log( prob ) + max_ln_probs;
-    }
-    
-    return ln_prob;
+    return StochasticNodeBase::computeRecursiveIntegratedLnProbability( integratedParents, index );
 }
 
 
+/** Dispatch the two stochastic-node mixture member methods. */
 template<class valueType>
-void RevBayesCore::StochasticNode<valueType>::executeMethod(const std::string &n, const std::vector<const DagNode*> &args, RbVector<double> &rv) const
+void RevBayesCore::StochasticNode<valueType>::executeMethod(const std::string &n, const std::vector<const DagNode*> & /*args*/, RbVector<double> &rv) const
 {
-
     if ( n == "lnMixtureLikelihoods" )
     {
         rv = this->getMixtureLikelihoods( true );
@@ -339,7 +180,6 @@ void RevBayesCore::StochasticNode<valueType>::executeMethod(const std::string &n
     {
         throw RbException() << "A DAG node does not have a member method called '" << n << "'.";
     }
-
 }
 
 
@@ -353,339 +193,189 @@ void RevBayesCore::StochasticNode<valueType>::executeMethod(const std::string &n
  * the implementation of getAffectedNodes(...).
  */
 template<class valueType>
-void RevBayesCore::StochasticNode<valueType>::getAffected( RbOrderedSet<DagNode*>& affected, const DagNode* affecter )
+void RevBayesCore::StochasticNode<valueType>::getAffected(RbOrderedSet<DagNode*> &affected, const DagNode *affecter)
 {
-    
-    if ( isIntegratedOut() == false )
-    {
-        // Insert this node as one of the affected
-        affected.insert( this );
-    
-        // Call the distribution for potential specialized handling (e.g. internal flags)
-        distribution->getAffected( affected, affecter );
-    }
-    else
-    {
-        // Dispatch the touch message to downstream nodes
-        this->getAffectedNodes( affected );
-    }
+    StochasticNodeBase::getAffected( *this, affected, affecter );
 }
 
 
+/** Return the owned distribution through its typed interface. */
 template<class valueType>
-RevBayesCore::TypedDistribution<valueType>& RevBayesCore::StochasticNode<valueType>::getDistribution( void )
+RevBayesCore::TypedDistribution<valueType>& RevBayesCore::StochasticNode<valueType>::getDistribution(void)
 {
-    
-    return *distribution;
+    return *static_cast<TypedDistribution<valueType>*>( this->distribution );
 }
 
 
+/** Return the owned distribution through its const typed interface. */
 template<class valueType>
-const RevBayesCore::TypedDistribution<valueType>& RevBayesCore::StochasticNode<valueType>::getDistribution( void ) const
+const RevBayesCore::TypedDistribution<valueType>& RevBayesCore::StochasticNode<valueType>::getDistribution(void) const
 {
-    
-    return *distribution;
+    return *static_cast<const TypedDistribution<valueType>*>( this->distribution );
 }
 
 
+/** Forward integrated-parent discovery to the non-template implementation. */
 template<class valueType>
-void RevBayesCore::StochasticNode<valueType>::getIntegratedParents(RbOrderedSet<DagNode *>& integrated_parents) const
+void RevBayesCore::StochasticNode<valueType>::getIntegratedParents(RbOrderedSet<DagNode*> &integratedParents) const
 {
-    
-    std::vector<const DagNode*> parents = this->getParents();
-
-    // delegate up the DAG
-    for (size_t i=0; i<parents.size(); ++i)
-    {
-        const DagNode *the_parent = parents[i];
-        if ( the_parent->isIntegratedOut() == true )
-        {
-            the_parent->getIntegratedParents( integrated_parents );
-            integrated_parents.insert( const_cast< DagNode* >(the_parent) );
-        }
-        
-    }
-    
+    StochasticNodeBase::getIntegratedParents( *this, integratedParents );
 }
 
 
+/** Forward per-mixture likelihood calculation to the non-template implementation. */
 template<class valueType>
-std::vector<double> RevBayesCore::StochasticNode<valueType>::getMixtureLikelihoods( bool use_log ) const
+std::vector<double> RevBayesCore::StochasticNode<valueType>::getMixtureLikelihoods(bool useLog) const
 {
-      
-    std::vector<double> ln_probs;
-    
-    if ( isIntegratedOut() == false )
-    {
-        // TODO: This is only for safety. We should actually never get in here!
-        ln_probs.push_back( distribution->computeLnProbability() );
-    }
-    else
-    {
-        // temporarily disable integration
-        integrated_out = false;
-        
-        size_t num_mixture_elements = this->getNumberOfMixtureElements();
-        ln_probs = std::vector<double>(num_mixture_elements, 0.0);
-        std::vector<double> probs = std::vector<double>(num_mixture_elements, 0.0);
-        double max_ln_probs = RbConstants::Double::neginf;
-        RbOrderedSet<DagNode *> affected;
-        this->getAffectedNodes( affected );
-        for (size_t i=0; i<num_mixture_elements; ++i)
-        {
-            const_cast< StochasticNode<valueType>* >(this)->setIntegrationIndex( i );
-            for ( size_t j=0; j<affected.size(); ++j )
-            {
-                ln_probs[i] += affected[j]->getLnProbability();
-            }
-            if ( RbMath::isNan(ln_probs[i]) == true )
-            {
-                ln_probs[i] = RbConstants::Double::neginf;
-            }
-            if ( ln_probs[i] > max_ln_probs )
-            {
-                max_ln_probs = ln_probs[i];
-            }
-        }
-        std::vector<double> mixture_probs = this->getMixtureProbabilities();
-        double prob = 0.0;
-        for (size_t i=0; i<num_mixture_elements; ++i)
-        {
-            prob += exp(ln_probs[i] - max_ln_probs) * mixture_probs[i];
-        }
-        
-        double ln_prob = log( prob ) + max_ln_probs;
-        for (size_t i=0; i<num_mixture_elements; ++i)
-        {
-            probs[i] = exp(ln_probs[i] - max_ln_probs) * mixture_probs[i] / prob;
-            ln_probs[i] += log(mixture_probs[i]) - ln_prob;
-        }
-        
-        if ( use_log == false )
-        {
-            ln_probs = probs;
-        }
-        
-        // switch back integration flag
-        integrated_out = true;
-    }
-    
-    return ln_probs;
+    return StochasticNodeBase::getMixtureLikelihoods( *this, useLog );
 }
 
 
-
+/** Compute or return the cached log probability. */
 template<class valueType>
-double RevBayesCore::StochasticNode<valueType>::getLnProbability( void )
+double RevBayesCore::StochasticNode<valueType>::getLnProbability(void)
 {
-    
-    if ( not lnProb )
-    {
-        // compute and store log-probability
-        if ( integrated_out or ignore_data )
-            lnProb = 0.0;
-        else
-        {
-            RbOrderedSet<DagNode *> integrated_parents;
-            getIntegratedParents(integrated_parents);
-            lnProb = computeRecursiveIntegratedLnProbability(integrated_parents,0);
-        }
-    }
-
-    return lnProb.value();
+    return StochasticNodeBase::getLnProbability( *this );
 }
 
 
+/** Return the current-to-previous log-probability difference for a touched node. */
 template<class valueType>
-double RevBayesCore::StochasticNode<valueType>::getLnProbabilityRatio( void )
+double RevBayesCore::StochasticNode<valueType>::getLnProbabilityRatio(void)
 {
     // 1. If the node is not affected/touched, then the probability is the same for the current and previous state.
-    if (not stored_ln_prob)
-        return 0;
-
+    if ( not this->stored_ln_prob )
+    {
+        return 0.0;
+    }
     // 2. If we touched the node when the log probability was not calculated, then we don't have a value for
     // the probability of the previous state.
-    if (not *stored_ln_prob)
-        throw RbException()<<"getLnProbabilityRatio: the log probability for the previous state was never calculated";
+    if ( not *this->stored_ln_prob )
+    {
+        throw RbException() << "getLnProbabilityRatio: the log probability for the previous state was never calculated";
+    }
 
     // 3. If (a) the node is touched/affected and (b) we know the previous probability, then use it.
-    return getLnProbability() - **stored_ln_prob;
+    return getLnProbability() - **this->stored_ln_prob;
 }
 
 
+/** Return the previous log probability from the implementation base. */
 template<class valueType>
-double RevBayesCore::StochasticNode<valueType>::getPrevLnProbability( void ) const
+double RevBayesCore::StochasticNode<valueType>::getPrevLnProbability(void) const
 {
-    /*
-     * NOTE: If there is no previous probability then we could do a few things:
-     *         (1) throw an exception (current done).
-     *         (2) return an optional<double> to indicate if there is a previous probability or not.
-     *         (3) return the current probability.  This would make the method non-const.
-     *       Right now we do (1).
-     */
-
-    // 1. If the node is not affected/touched, then throw an exception.
-    if (not stored_ln_prob)
-        throw RbException()<<"getPrevLnProbability: no previous probability!";
-
-    // 2. If we touched the node when the log probability was not calculated, then we don't have a value for
-    // the probability of the previous state.
-    if (not *stored_ln_prob)
-        throw RbException()<<"getLnProbabilityRatio: the log probability for the previous state was never calculated";
-
-    // 3. If (a) the node is touched/affected and (b) we know the previous probability, then use it.
-    return **stored_ln_prob;
+    return StochasticNodeBase::getPrevLnProbability();
 }
 
 
+/** Return the distribution's mixture probabilities. */
 template<class valueType>
 std::vector<double> RevBayesCore::StochasticNode<valueType>::getMixtureProbabilities(void) const
 {
-    return distribution->getMixtureProbabilities();
+    return StochasticNodeBase::getMixtureProbabilities();
 }
 
 
+/** Return the distribution's number of mixture elements. */
 template<class valueType>
 size_t RevBayesCore::StochasticNode<valueType>::getNumberOfMixtureElements(void) const
 {
-    return distribution->getNumberOfMixtureElements();
+    return StochasticNodeBase::getNumberOfMixtureElements();
 }
 
 
-/**
- * Get the parents of this node. Simply ask the distribution to provide its parameters,
- * no need to keep parents here.
- */
+/** Return the distribution parameters as the node's parents. */
 template<class valueType>
-std::vector<const RevBayesCore::DagNode*> RevBayesCore::StochasticNode<valueType>::getParents( void ) const
+std::vector<const RevBayesCore::DagNode*> RevBayesCore::StochasticNode<valueType>::getParents(void) const
 {
-    return distribution->getParameters();
+    return StochasticNodeBase::getParents();
 }
 
 
+/** Return the mutable typed value owned by the distribution. */
 template<class valueType>
-valueType& RevBayesCore::StochasticNode<valueType>::getValue( void )
+valueType& RevBayesCore::StochasticNode<valueType>::getValue(void)
 {
-    
-    return distribution->getValue();
+    return static_cast<TypedDistribution<valueType>*>( this->distribution )->getValue();
 }
 
 
+/** Return the const typed value owned by the distribution. */
 template<class valueType>
-const valueType& RevBayesCore::StochasticNode<valueType>::getValue( void ) const
+const valueType& RevBayesCore::StochasticNode<valueType>::getValue(void) const
 {
-    
-    return distribution->getValue();
+    return static_cast<const TypedDistribution<valueType>*>( this->distribution )->getValue();
 }
 
 
+/** Report whether this stochastic node is clamped. */
 template<class valueType>
-bool RevBayesCore::StochasticNode<valueType>::isClamped( void ) const
+bool RevBayesCore::StochasticNode<valueType>::isClamped(void) const
 {
-    
-    return clamped;
+    return StochasticNodeBase::isClamped();
 }
 
 
+/** Report whether this stochastic node is integrated out. */
 template<class valueType>
 bool RevBayesCore::StochasticNode<valueType>::isIntegratedOut(void) const
 {
-    
-    return integrated_out;
+    return StochasticNodeBase::isIntegratedOut();
 }
 
 
+/** Report whether this stochastic node's data likelihood is ignored. */
 template<class valueType>
 bool RevBayesCore::StochasticNode<valueType>::isIgnoredData(void) const
 {
-
-    return ignore_data;
+    return StochasticNodeBase::isIgnoredData();
 }
 
 
+/** Identify this node as stochastic. */
 template<class valueType>
-bool RevBayesCore::StochasticNode<valueType>::isStochastic( void ) const
+bool RevBayesCore::StochasticNode<valueType>::isStochastic(void) const
 {
-    
     return true;
 }
 
 
-/**
- * Keep the current value of the node.
- * At this point, we also need to make sure we update the stored ln probability.
- */
+/** Commit stochastic and dynamic state through the implementation bases. */
 template<class valueType>
-void RevBayesCore::StochasticNode<valueType>::keepMe( const DagNode* affecter )
+void RevBayesCore::StochasticNode<valueType>::keepMe(const DagNode *affecter)
 {
-    
-    if ( this->touched == true )
-    {
-        stored_ln_prob = {};
-
-        if ( not lnProb )
-        {
-            if (integrated_out or ignore_data)
-                lnProb = 0.0;
-            else
-            {
-                RbOrderedSet<DagNode *> integrated_parents;
-                getIntegratedParents(integrated_parents);
-                lnProb = computeRecursiveIntegratedLnProbability(integrated_parents,0);
-            }
-        }
-        
-        distribution->keep( affecter );
-        
-        // clear the list of touched element indices
-        this->touched_elements.clear();
-        
-        if ( isIntegratedOut() == true )
-        {
-            // Dispatch the touch message to downstream nodes
-            this->keepAffected();
-        }
-        
-    }
-
-    assert( lnProb );
-    
-    
-    // delegate call
-    DynamicNode<valueType>::keepMe( affecter );
-    
+    StochasticNodeBase::keepMe( *this, *this, affecter );
 }
 
 
+/** Print stochastic-node structure while retaining access to DagNode's protected formatting helpers. */
 template<class valueType>
-void RevBayesCore::StochasticNode<valueType>::printStructureInfo( std::ostream &o, bool verbose ) const
+void RevBayesCore::StochasticNode<valueType>::printStructureInfo(std::ostream &o, bool verbose) const
 {
-        
     o << "_dagType      = Stochastic node (distribution)" << std::endl;
-    o << "_distribution = " << "<" << distribution << ">" << std::endl;
+    o << "_distribution = <" << this->distribution << ">" << std::endl;
     o << "_clamped      = " << ( this->clamped ? "TRUE" : "FALSE" ) << std::endl;
-    o << "_lnProb       = " << const_cast< StochasticNode<valueType>* >( this )->getLnProbability() << std::endl;
-    
-    if ( verbose == true)
+    o << "_lnProb       = " << const_cast<StochasticNode<valueType>*>( this )->getLnProbability() << std::endl;
+
+    if ( verbose == true )
     {
         o << "_stored_ln_prob = ";
-        if (not stored_ln_prob)
-            o<< "EMPTY";
-        else if (not *stored_ln_prob)
-            o<< "UNCOMPUTED";
+        if ( not this->stored_ln_prob )
+            o << "EMPTY";
+        else if ( not *this->stored_ln_prob )
+            o << "UNCOMPUTED";
         else
-            o<<**stored_ln_prob;
-
-        o<< std::endl;
+            o << **this->stored_ln_prob;
+        o << std::endl;
     }
+
     o << "_parents      = ";
-    this->printParents(o, 16, 70, verbose);
+    this->printParents( o, 16, 70, verbose );
     o << std::endl;
-    
     o << "_children     = ";
-    this->printChildren(o, 16, 70, verbose);
+    this->printChildren( o, 16, 70, verbose );
     o << std::endl;
-    
+
     if ( verbose == true )
     {
         o << "_dagNode      = " << this->name << " <" << this << ">" << std::endl;
@@ -695,238 +385,136 @@ void RevBayesCore::StochasticNode<valueType>::printStructureInfo( std::ostream &
 }
 
 
+/** Forward redraw behavior to the non-template implementation. */
 template<class valueType>
-void RevBayesCore::StochasticNode<valueType>::redraw( SimulationCondition c )
+void RevBayesCore::StochasticNode<valueType>::redraw(SimulationCondition condition)
 {
-    
-    // draw the value
-    if ( ignore_redraw == false )
-    {
-        if (this->isClamped()) {
-            throw RbException("Cannot modify the value of a clamped node.");
-        }
-        distribution->redrawValue( c );
-    }
-    
-    // touch this node for probability recalculation
-    this->touch();
-    
+    StochasticNodeBase::redraw( *this, condition );
 }
 
 
+/** Forward model reinitialization to the owned distribution. */
 template<class valueType>
-void RevBayesCore::StochasticNode<valueType>::reInitializeMe( void )
+void RevBayesCore::StochasticNode<valueType>::reInitializeMe(void)
 {
-    
-    distribution->reInitialized();
-    
+    StochasticNodeBase::reInitializeMe();
 }
 
 
-/** Restore the old value of the node and tell affected */
+/** Restore stochastic and dynamic state through the implementation bases. */
 template<class valueType>
-void RevBayesCore::StochasticNode<valueType>::restoreMe( const DagNode *restorer )
+void RevBayesCore::StochasticNode<valueType>::restoreMe(const DagNode *restorer)
 {
-    
-    if ( this->touched == true )
-    {
-        lnProb              = stored_ln_prob.value();
-        stored_ln_prob      = {};    // An almost impossible value for the density
-
-        // reset flags that recalculation is not needed
-        assert(lnProb);
-
-        // call for potential specialized handling (e.g. internal flags)
-        distribution->restore(restorer);
-
-        // clear the list of touched element indices
-        this->touched_elements.clear();
-
-        if ( isIntegratedOut() == true )
-        {
-            // Dispatch the touch message to downstream nodes
-            this->restoreAffected();
-        }
-    }
-    
-    // delegate call
-    DynamicNode<valueType>::restoreMe( restorer );
-    
+    StochasticNodeBase::restoreMe( *this, *this, restorer );
 }
 
 
-/**
- * Set the active PID of this specific DAG node object.
- */
-template <class valueType>
-void RevBayesCore::StochasticNode<valueType>::setActivePIDSpecialized(size_t a, size_t n)
+/** Forward process partitioning to the owned distribution. */
+template<class valueType>
+void RevBayesCore::StochasticNode<valueType>::setActivePIDSpecialized(size_t activePid, size_t numProcesses)
 {
-    
-    if ( distribution != NULL )
-    {
-        distribution->setActivePID( a, n );
-    }
-    
+    StochasticNodeBase::setActivePIDSpecialized( activePid, numProcesses );
 }
 
 
-template <class valueType>
-void RevBayesCore::StochasticNode<valueType>::setIgnoreRedraw( bool tf )
+/** Set whether redraw requests should retain the current value. */
+template<class valueType>
+void RevBayesCore::StochasticNode<valueType>::setIgnoreRedraw(bool tf)
 {
-    
-    ignore_redraw = tf;
-
+    StochasticNodeBase::setIgnoreRedraw( tf );
 }
 
 
-template <class valueType>
-void RevBayesCore::StochasticNode<valueType>::setIntegratedOut( bool tf )
+/** Set whether downstream likelihoods marginalize over this node. */
+template<class valueType>
+void RevBayesCore::StochasticNode<valueType>::setIntegratedOut(bool tf)
 {
-    
-    integrated_out = tf;
-
+    StochasticNodeBase::setIntegratedOut( tf );
 }
 
 
-template <class valueType>
-void RevBayesCore::StochasticNode<valueType>::setIntegrationIndex( size_t i )
+/** Clone and install the selected mixture value. */
+template<class valueType>
+void RevBayesCore::StochasticNode<valueType>::setIntegrationIndex(size_t i)
 {
-    valueType *new_val = Cloner<valueType, IsDerivedFrom<valueType, Cloneable>::Is >::createClone( distribution->getParameterValues()[i] );
-    this->setValue( new_val );
-
+    TypedDistribution<valueType> *typedDistribution = static_cast<TypedDistribution<valueType>*>( this->distribution );
+    valueType *newValue = Cloner<valueType, IsDerivedFrom<valueType, Cloneable>::Is>::createClone( typedDistribution->getParameterValues()[i] );
+    this->setValue( newValue );
 }
 
 
-
+/** Propagate MCMC mode to the owned distribution. */
 template<class valueType>
 void RevBayesCore::StochasticNode<valueType>::setMcmcMode(bool tf)
 {
-    
-    distribution->setMcmcMode( tf );
-    
+    StochasticNodeBase::setMcmcMode( tf );
 }
 
+
+/** Set whether this clamped node's likelihood should be ignored. */
 template<class valueType>
 void RevBayesCore::StochasticNode<valueType>::setIgnoreData(bool tf)
 {
-    if (tf and not isClamped())
-        throw RbException()<<"Error: cannot ignore data at node '"<<this->getName()<<"' because it is not clamped (has no data)!";
-
-//    PROBLEM: Right now vectors are children of their elements, so this prohibits using vectors.
-//             We check for stochastic descendants?
-//    if (tf and not this->children.empty())
-//        throw RbException()<<"Error: cannot ignore data at node '"<<this->getName()<<"' because it has children! (e.g. "<<this->children[0]->getName()<<")";
-
-    ignore_data = tf;
-
-    assert(not stored_ln_prob);
-
-    lnProb = 0;
+    StochasticNodeBase::setIgnoreData( *this, tf );
 }
 
-/**
- * Set the value.
- */
+
+/** Set the value. */
 template<class valueType>
-void RevBayesCore::StochasticNode<valueType>::setValue(valueType *val, bool force_touch)
+void RevBayesCore::StochasticNode<valueType>::setValue(valueType *val, bool forceTouch)
 {
     // set the value
-    distribution->setValue( val, true );
-    
-    if ( force_touch == true )
+    static_cast<TypedDistribution<valueType>*>( this->distribution )->setValue( val, true );
+    if ( forceTouch == true )
     {
         // touch this node for probability recalculation
         this->touch();
     }
-    
 }
 
 
+/** Read a serialized typed value and install it through the normal value path. */
 template<class valueType>
 void RevBayesCore::StochasticNode<valueType>::setValueFromFile(const RevBayesCore::path &dir)
 {
-    
-    Serializer<valueType, IsDerivedFrom<valueType, RevBayesCore::Serializable>::Is >::ressurectFromFile( &getValue(), dir, this->getName() );
-    
+    Serializer<valueType, IsDerivedFrom<valueType, Serializable>::Is>::ressurectFromFile( &getValue(), dir, this->getName() );
+
     // delegate to the standard function of setting the value
     this->setValue( &this->getValue() );
-    
 }
 
 
+/** Parse a hidden state or a serialized typed value and invalidate the node. */
 template<class valueType>
 void RevBayesCore::StochasticNode<valueType>::setValueFromString(const std::string &v)
 {
     if ( v.size() >= 2 && v.front() == '\'' && v.back() == '\'' )
     {
         // quoted string — this is a hidden state (e.g. allocation index)
-        distribution->setHiddenStateFromString(v.substr(1, v.size() - 2));
+        this->distribution->setHiddenStateFromString( v.substr( 1, v.size() - 2 ) );
         this->touch();
     }
     else
     {
-        Serializer<valueType, IsDerivedFrom<valueType, RevBayesCore::Serializable>::Is >::ressurectFromString( &getValue(), v );
+        Serializer<valueType, IsDerivedFrom<valueType, Serializable>::Is>::ressurectFromString( &getValue(), v );
         this->setValue( &this->getValue() );
     }
 }
 
 
-/**
- * This function replaces the earlier swapParameter function. If we rely on the
- * internal RevBayesCore::Distribution to manage our parents, we simply need to ask
- * the distribution to swap its parameter, and then manage the connection of the
- * old and new parents (parameters) to this node.
- */
-template <class valueType>
-void RevBayesCore::StochasticNode<valueType>::swapParent( const RevBayesCore::DagNode *oldParent, const RevBayesCore::DagNode *newParent )
+/** Forward distribution-parameter replacement to the implementation base. */
+template<class valueType>
+void RevBayesCore::StochasticNode<valueType>::swapParent(const DagNode *oldParent, const DagNode *newParent)
 {
-    // We are sure to get into trouble if either one of these is NULL
-    if ( oldParent == NULL || newParent == NULL )
-    {
-        throw RbException( "Attempt to swap NULL distribution parameter of RevBayesCore::StochasticNode" );
-    }
-    
-    // This throws an error if the oldParent cannot be found
-    distribution->swapParameter( oldParent, newParent );
-    
-    oldParent->removeChild( this );
-    if ( oldParent->decrementReferenceCount() == 0 )
-    {
-        delete ( oldParent );
-    }
-    
-    newParent->addChild( this );
-    newParent->incrementReferenceCount();
-    
-    this->touch();
+    StochasticNodeBase::swapParent( *this, oldParent, newParent );
 }
 
 
-/** touch this node for recalculation */
+/** Forward stochastic invalidation to the implementation bases. */
 template<class valueType>
-void RevBayesCore::StochasticNode<valueType>::touchMe( const DagNode *toucher, bool touchAll )
+void RevBayesCore::StochasticNode<valueType>::touchMe(const DagNode *toucher, bool touchAll)
 {
-    
-    if ( this->touched == false )
-    {
-        assert(not stored_ln_prob);
-        stored_ln_prob = lnProb;
-    }
-    
-    lnProb = {};
-    
-    // call for potential specialized handling (e.g. internal flags), we might have been touched already by someone else, so we need to delegate regardless
-    distribution->touch( toucher, touchAll );
-    
-    // delegate call
-    DynamicNode<valueType>::touchMe( toucher, touchAll );
-    
-    if ( isIntegratedOut() == true )
-    {
-        // Dispatch the touch message to downstream nodes
-        this->touchAffected( touchAll );
-    }
-    
+    StochasticNodeBase::touchMe( *this, *this, toucher, touchAll );
 }
 
 #endif

--- a/src/core/dag/StochasticNodeBase.cpp
+++ b/src/core/dag/StochasticNodeBase.cpp
@@ -1,0 +1,549 @@
+#include "StochasticNodeBase.h"
+
+#include "DagNode.h"
+#include "Distribution.h"
+#include "DynamicNodeBase.h"
+#include "RbConstants.h"
+#include "RbException.h"
+#include "RbMathLogic.h"
+
+#include <cassert>
+#include <cmath>
+
+using namespace RevBayesCore;
+
+/** Take ownership of a distribution and initialize stochastic bookkeeping. */
+StochasticNodeBase::StochasticNodeBase(Distribution *d) :
+    clamped( false ),
+    ignore_data( false ),
+    ignore_redraw( false ),
+    integrated_out( false ),
+    lnProb(),
+    stored_ln_prob(),
+    distribution( d )
+{
+}
+
+
+/** Clone the distribution and flags without copying probability snapshots. */
+StochasticNodeBase::StochasticNodeBase(const StochasticNodeBase &n) :
+    clamped( n.clamped ),
+    ignore_data( n.ignore_data ),
+    ignore_redraw( n.ignore_redraw ),
+    integrated_out( n.integrated_out ),
+    lnProb(),
+    stored_ln_prob(),
+    distribution( n.distribution->clone() )
+{
+}
+
+
+/** Destroy the distribution owned by this implementation base. */
+StochasticNodeBase::~StochasticNodeBase(void)
+{
+    delete distribution;
+}
+
+
+/** Set whether the current value is treated as observed data. */
+void StochasticNodeBase::setClamped(bool tf)
+{
+    clamped = tf;
+}
+
+
+/** Retain the current value but stop treating it as observed data. */
+void StochasticNodeBase::unclamp(void)
+{
+    clamped = false;
+}
+
+
+/** Replace the distribution and copied flags while preserving the existing stored snapshot state. */
+void StochasticNodeBase::assign(const StochasticNodeBase &n, DagNode &owner)
+{
+    // Remove us as the child of the distribution parameters
+    detachFromDistributionParameters( owner );
+
+    // Delete the distribution
+    delete distribution;
+
+    // Recreate the distribution
+    distribution = n.distribution->clone();
+
+    // Get the parameters from the new distribution and add us as child of them in the DAG
+    attachToDistributionParameters( owner );
+
+    clamped = n.clamped;
+    ignore_data = n.ignore_data;
+    ignore_redraw = n.ignore_redraw;
+    integrated_out = n.integrated_out;
+    lnProb = {};
+}
+
+
+/** Register the stochastic node as a child of every distribution parameter. */
+void StochasticNodeBase::attachToDistributionParameters(DagNode &owner) const
+{
+    // Get the parameters from the distribution and add us as a child of them in the DAG
+    const std::vector<const DagNode*> &parents = distribution->getParameters();
+    for ( std::vector<const DagNode*>::const_iterator it = parents.begin(); it != parents.end(); ++it )
+    {
+        (*it)->addChild( &owner );
+
+        // Increment the reference count
+        // We don't want this parent to get deleted while we are still alive
+        (*it)->incrementReferenceCount();
+    }
+}
+
+
+/** Draw a new value from the distribution and invalidate the node. */
+void StochasticNodeBase::bootstrap(DagNode &owner)
+{
+    distribution->bootstrap();
+
+    // touch this node for probability recalculation
+    owner.touch();
+}
+
+
+/** Sum over integrated parent states recursively using a numerically stable log-sum-exp. */
+double StochasticNodeBase::computeRecursiveIntegratedLnProbability(RbOrderedSet<DagNode*> &integratedParents, size_t index)
+{
+    if ( integratedParents.size() <= index )
+    {
+        return distribution->computeLnProbability();
+    }
+
+    DagNode *parent = integratedParents[index];
+    size_t numElements = parent->getNumberOfMixtureElements();
+    std::vector<double> lnProbs( numElements, 0.0 );
+    double maxLnProb = RbConstants::Double::neginf;
+
+    for ( size_t i = 0; i < numElements; ++i )
+    {
+        parent->setIntegrationIndex( i );
+        lnProbs[i] = computeRecursiveIntegratedLnProbability( integratedParents, index + 1 );
+        if ( lnProbs[i] > maxLnProb )
+        {
+            maxLnProb = lnProbs[i];
+        }
+    }
+
+    std::vector<double> mixtureProbs = parent->getMixtureProbabilities();
+    double probability = 0.0;
+    for ( size_t i = 0; i < numElements; ++i )
+    {
+        probability += std::exp( lnProbs[i] - maxLnProb ) * mixtureProbs[i];
+    }
+
+    return std::log( probability ) + maxLnProb;
+}
+
+
+/** Remove the stochastic node's incoming edges and release its references to its parameters. */
+void StochasticNodeBase::detachFromDistributionParameters(DagNode &owner) const
+{
+    // Remove us as the child of the distribution parameters
+    // Copy the vector because releasing a parameter may delete it and invalidate related storage.
+    std::vector<const DagNode*> parents = distribution->getParameters();
+    for ( std::vector<const DagNode*>::const_iterator it = parents.begin(); it != parents.end(); ++it )
+    {
+        (*it)->removeChild( &owner );
+
+        // Decrement the reference count and check whether we need to delete the DAG node
+        if ( (*it)->decrementReferenceCount() == 0 )
+        {
+            delete *it;
+        }
+    }
+}
+
+
+/** Record this likelihood as affected, or pass discovery downstream when integrated out. */
+void StochasticNodeBase::getAffected(DagNode &owner, RbOrderedSet<DagNode*> &affected, const DagNode *affecter)
+{
+    if ( owner.isIntegratedOut() == false )
+    {
+        // Insert this node as one of the affected
+        affected.insert( &owner );
+
+        // Call the distribution for potential specialized handling (e.g. internal flags)
+        distribution->getAffected( affected, affecter );
+    }
+    else
+    {
+        // Dispatch the touch message to downstream nodes
+        owner.getAffectedNodes( affected );
+    }
+}
+
+
+/** Collect integrated stochastic parents, recursively including their integrated ancestors. */
+void StochasticNodeBase::getIntegratedParents(const DagNode &owner, RbOrderedSet<DagNode*> &integratedParents) const
+{
+    std::vector<const DagNode*> parents = owner.getParents();
+
+    // delegate up the DAG
+    for ( std::vector<const DagNode*>::const_iterator it = parents.begin(); it != parents.end(); ++it )
+    {
+        if ( (*it)->isIntegratedOut() == true )
+        {
+            (*it)->getIntegratedParents( integratedParents );
+            integratedParents.insert( const_cast<DagNode*>( *it ) );
+        }
+    }
+}
+
+
+/** Compute and cache this node's current log probability when needed. */
+double StochasticNodeBase::getLnProbability(DagNode &owner)
+{
+    if ( not lnProb )
+    {
+        // compute and store log-probability
+        if ( integrated_out || ignore_data )
+        {
+            lnProb = 0.0;
+        }
+        else
+        {
+            RbOrderedSet<DagNode*> integratedParents;
+            owner.getIntegratedParents( integratedParents );
+            lnProb = computeRecursiveIntegratedLnProbability( integratedParents, 0 );
+        }
+    }
+
+    return lnProb.value();
+}
+
+
+/** Compute likelihoods for every mixture state, optionally returning them on the log scale. */
+std::vector<double> StochasticNodeBase::getMixtureLikelihoods(const DagNode &owner, bool useLog) const
+{
+    std::vector<double> lnProbs;
+    if ( owner.isIntegratedOut() == false )
+    {
+        // TODO: This is only for safety. We should actually never get in here!
+        lnProbs.push_back( distribution->computeLnProbability() );
+        return lnProbs;
+    }
+
+    // temporarily disable integration
+    integrated_out = false;
+
+    size_t numElements = owner.getNumberOfMixtureElements();
+    lnProbs.assign( numElements, 0.0 );
+    std::vector<double> probabilities( numElements, 0.0 );
+    double maxLnProb = RbConstants::Double::neginf;
+    RbOrderedSet<DagNode*> affected;
+    owner.getAffectedNodes( affected );
+
+    for ( size_t i = 0; i < numElements; ++i )
+    {
+        const_cast<DagNode&>( owner ).setIntegrationIndex( i );
+        for ( size_t j = 0; j < affected.size(); ++j )
+        {
+            lnProbs[i] += affected[j]->getLnProbability();
+        }
+        if ( RbMath::isNan( lnProbs[i] ) == true )
+        {
+            lnProbs[i] = RbConstants::Double::neginf;
+        }
+        if ( lnProbs[i] > maxLnProb )
+        {
+            maxLnProb = lnProbs[i];
+        }
+    }
+
+    std::vector<double> mixtureProbs = owner.getMixtureProbabilities();
+    double probability = 0.0;
+    for ( size_t i = 0; i < numElements; ++i )
+    {
+        probability += std::exp( lnProbs[i] - maxLnProb ) * mixtureProbs[i];
+    }
+
+    double lnProbability = std::log( probability ) + maxLnProb;
+    for ( size_t i = 0; i < numElements; ++i )
+    {
+        probabilities[i] = std::exp( lnProbs[i] - maxLnProb ) * mixtureProbs[i] / probability;
+        lnProbs[i] += std::log( mixtureProbs[i] ) - lnProbability;
+    }
+
+    // switch back integration flag
+    integrated_out = true;
+    return useLog ? lnProbs : probabilities;
+}
+
+
+/** Return the mixture probabilities supplied by the distribution. */
+std::vector<double> StochasticNodeBase::getMixtureProbabilities(void) const
+{
+    return distribution->getMixtureProbabilities();
+}
+
+
+/** Return the number of mixture values supplied by the distribution. */
+size_t StochasticNodeBase::getNumberOfMixtureElements(void) const
+{
+    return distribution->getNumberOfMixtureElements();
+}
+
+
+/**
+ * Get the parents of this node. Simply ask the distribution to provide its parameters,
+ * no need to keep parents here.
+ */
+std::vector<const DagNode*> StochasticNodeBase::getParents(void) const
+{
+    return distribution->getParameters();
+}
+
+
+/** Return the stored log probability, distinguishing absent and never-computed snapshots. */
+double StochasticNodeBase::getPrevLnProbability(void) const
+{
+    /*
+     * NOTE: If there is no previous probability then we could do a few things:
+     *         (1) throw an exception (current done).
+     *         (2) return an optional<double> to indicate if there is a previous probability or not.
+     *         (3) return the current probability. This would make the method non-const.
+     *       Right now we do (1).
+     */
+
+    // 1. If the node is not affected/touched, then throw an exception.
+    if ( not stored_ln_prob )
+    {
+        throw RbException() << "getPrevLnProbability: no previous probability!";
+    }
+    // 2. If we touched the node when the log probability was not calculated, then we don't have a value for
+    // the probability of the previous state.
+    if ( not *stored_ln_prob )
+    {
+        throw RbException() << "getLnProbabilityRatio: the log probability for the previous state was never calculated";
+    }
+
+    // 3. If (a) the node is touched/affected and (b) we know the previous probability, then use it.
+    return **stored_ln_prob;
+}
+
+
+/** Report whether the node's current value is observed data. */
+bool StochasticNodeBase::isClamped(void) const
+{
+    return clamped;
+}
+
+
+/** Report whether the node's likelihood is currently ignored. */
+bool StochasticNodeBase::isIgnoredData(void) const
+{
+    return ignore_data;
+}
+
+
+/** Report whether the node is marginalized over its mixture values. */
+bool StochasticNodeBase::isIntegratedOut(void) const
+{
+    return integrated_out;
+}
+
+
+/**
+ * Keep the current value of the node.
+ * At this point, we also need to make sure we update the stored ln probability.
+ */
+void StochasticNodeBase::keepMe(DagNode &owner, DynamicNodeBase &dynamicState, const DagNode *affecter)
+{
+    if ( dynamicState.isTouched() == true )
+    {
+        stored_ln_prob = {};
+
+        if ( not lnProb )
+        {
+            if ( integrated_out || ignore_data )
+            {
+                lnProb = 0.0;
+            }
+            else
+            {
+                RbOrderedSet<DagNode*> integratedParents;
+                owner.getIntegratedParents( integratedParents );
+                lnProb = computeRecursiveIntegratedLnProbability( integratedParents, 0 );
+            }
+        }
+
+        distribution->keep( affecter );
+
+        // clear the list of touched element indices
+        owner.clearTouchedElementIndices();
+        if ( owner.isIntegratedOut() == true )
+        {
+            // Dispatch the touch message to downstream nodes
+            owner.keepAffected();
+        }
+    }
+
+    assert( lnProb );
+
+    // delegate call
+    dynamicState.keepMe();
+}
+
+
+/** Redraw an unclamped node unless redraws are suppressed, then invalidate its probability. */
+void StochasticNodeBase::redraw(DagNode &owner, SimulationCondition condition)
+{
+    // draw the value
+    if ( ignore_redraw == false )
+    {
+        if ( owner.isClamped() )
+        {
+            throw RbException( "Cannot modify the value of a clamped node." );
+        }
+        distribution->redrawValue( condition );
+    }
+
+    // touch this node for probability recalculation
+    owner.touch();
+}
+
+
+/** Notify the distribution that its model has been reinitialized. */
+void StochasticNodeBase::reInitializeMe(void)
+{
+    distribution->reInitialized();
+}
+
+
+/** Restore the old value of the node and tell affected. */
+void StochasticNodeBase::restoreMe(DagNode &owner, DynamicNodeBase &dynamicState, const DagNode *restorer)
+{
+    if ( dynamicState.isTouched() == true )
+    {
+        lnProb = stored_ln_prob.value();
+        stored_ln_prob = {};    // An almost impossible value for the density
+
+        // reset flags that recalculation is not needed
+        assert( lnProb );
+
+        // call for potential specialized handling (e.g. internal flags)
+        distribution->restore( restorer );
+
+        // clear the list of touched element indices
+        owner.clearTouchedElementIndices();
+        if ( owner.isIntegratedOut() == true )
+        {
+            // Dispatch the touch message to downstream nodes
+            owner.restoreAffected();
+        }
+    }
+
+    // delegate call
+    dynamicState.restoreMe();
+}
+
+
+/** Set the active PID of this specific DAG node object. */
+void StochasticNodeBase::setActivePIDSpecialized(size_t activePid, size_t numProcesses)
+{
+    if ( distribution != NULL )
+    {
+        distribution->setActivePID( activePid, numProcesses );
+    }
+}
+
+
+/** Ignore a clamped node's likelihood and reset its probability cache to zero. */
+void StochasticNodeBase::setIgnoreData(const DagNode &owner, bool tf)
+{
+    if ( tf && owner.isClamped() == false )
+    {
+        throw RbException() << "Error: cannot ignore data at node '" << owner.getName() << "' because it is not clamped (has no data)!";
+    }
+
+//    PROBLEM: Right now vectors are children of their elements, so this prohibits using vectors.
+//             We check for stochastic descendants?
+//    if (tf and not this->children.empty())
+//        throw RbException()<<"Error: cannot ignore data at node '"<<this->getName()<<"' because it has children! (e.g. "<<this->children[0]->getName()<<")";
+
+    ignore_data = tf;
+    assert( not stored_ln_prob );
+    lnProb = 0.0;
+}
+
+
+/** Set whether redraw requests should retain the current value. */
+void StochasticNodeBase::setIgnoreRedraw(bool tf)
+{
+    ignore_redraw = tf;
+}
+
+
+/** Set whether downstream likelihoods marginalize over this node. */
+void StochasticNodeBase::setIntegratedOut(bool tf)
+{
+    integrated_out = tf;
+}
+
+
+/** Propagate the requested MCMC mode to the distribution. */
+void StochasticNodeBase::setMcmcMode(bool tf)
+{
+    distribution->setMcmcMode( tf );
+}
+
+
+/**
+ * This function replaces the earlier swapParameter function. If we rely on the
+ * internal RevBayesCore::Distribution to manage our parents, we simply need to ask
+ * the distribution to swap its parameter, and then manage the connection of the
+ * old and new parents (parameters) to this node.
+ */
+void StochasticNodeBase::swapParent(DagNode &owner, const DagNode *oldParent, const DagNode *newParent)
+{
+    // We are sure to get into trouble if either one of these is NULL
+    if ( oldParent == NULL || newParent == NULL )
+    {
+        throw RbException( "Attempt to swap NULL distribution parameter of RevBayesCore::StochasticNode" );
+    }
+
+    // This throws an error if the oldParent cannot be found
+    distribution->swapParameter( oldParent, newParent );
+
+    oldParent->removeChild( &owner );
+    if ( oldParent->decrementReferenceCount() == 0 )
+    {
+        delete oldParent;
+    }
+
+    newParent->addChild( &owner );
+    newParent->incrementReferenceCount();
+    owner.touch();
+}
+
+
+/** Touch this node for recalculation. */
+void StochasticNodeBase::touchMe(DagNode &owner, DynamicNodeBase &dynamicState, const DagNode *toucher, bool touchAll)
+{
+    if ( dynamicState.isTouched() == false )
+    {
+        assert( not stored_ln_prob );
+        stored_ln_prob = lnProb;
+    }
+
+    lnProb = {};
+
+    // call for potential specialized handling (e.g. internal flags), we might have been touched already by someone else, so we need to delegate regardless
+    distribution->touch( toucher, touchAll );
+
+    // delegate call
+    dynamicState.touchMe();
+
+    if ( owner.isIntegratedOut() == true )
+    {
+        // Dispatch the touch message to downstream nodes
+        owner.touchAffected( touchAll );
+    }
+}

--- a/src/core/dag/StochasticNodeBase.h
+++ b/src/core/dag/StochasticNodeBase.h
@@ -1,0 +1,82 @@
+#ifndef StochasticNodeBase_H
+#define StochasticNodeBase_H
+
+#include "RbOrderedSet.h"
+#include "SimulationConditions.h"
+
+#include <cstddef>
+#include <optional>
+#include <vector>
+
+namespace RevBayesCore {
+
+    class DagNode;
+    class Distribution;
+    class DynamicNodeBase;
+
+    // Put StochasticNode-specific stuff that doesn't depend on valueType here.
+    class StochasticNodeBase {
+
+    public:
+        explicit StochasticNodeBase(Distribution *d);
+        StochasticNodeBase(const StochasticNodeBase &n);
+                                                           ~StochasticNodeBase(void);
+
+        /**
+         * Set directly the flag whether this node is clamped.
+         * The caller needs to be responsible enough to know that we will assume
+         * that the current value is the observed value.
+         * We could use instead as well a call: clamp( getValue() );
+         */
+        void                                               setClamped(bool tf);
+
+        /**
+         * Unclamp this node. If I understand this correctly, we
+         * can just set the clamped flag to false if we keep the
+         * current value. We do not need to tell anyone that we
+         * have changed value because we really haven't.
+         */
+        void                                               unclamp(void);
+
+    protected:
+        void                                               assign(const StochasticNodeBase &n, DagNode &owner);
+        void                                               attachToDistributionParameters(DagNode &owner) const;
+        void                                               bootstrap(DagNode &owner);
+        virtual double                                     computeRecursiveIntegratedLnProbability(RbOrderedSet<DagNode*> &integratedParents, size_t index);
+        void                                               detachFromDistributionParameters(DagNode &owner) const;
+        void                                               getAffected(DagNode &owner, RbOrderedSet<DagNode*> &affected, const DagNode *affecter);
+        void                                               getIntegratedParents(const DagNode &owner, RbOrderedSet<DagNode*> &integratedParents) const;
+        double                                             getLnProbability(DagNode &owner);
+        std::vector<double>                                getMixtureLikelihoods(const DagNode &owner, bool useLog) const;
+        std::vector<double>                                getMixtureProbabilities(void) const;
+        size_t                                             getNumberOfMixtureElements(void) const;
+        std::vector<const DagNode*>                        getParents(void) const;
+        double                                             getPrevLnProbability(void) const;
+        bool                                               isClamped(void) const;
+        bool                                               isIgnoredData(void) const;
+        bool                                               isIntegratedOut(void) const;
+        void                                               keepMe(DagNode &owner, DynamicNodeBase &dynamicState, const DagNode *affecter);
+        void                                               redraw(DagNode &owner, SimulationCondition condition);
+        void                                               reInitializeMe(void);
+        void                                               restoreMe(DagNode &owner, DynamicNodeBase &dynamicState, const DagNode *restorer);
+        void                                               setActivePIDSpecialized(size_t activePid, size_t numProcesses);
+        void                                               setIgnoreData(const DagNode &owner, bool tf);
+        void                                               setIgnoreRedraw(bool tf);
+        void                                               setIntegratedOut(bool tf);
+        void                                               setMcmcMode(bool tf);
+        void                                               swapParent(DagNode &owner, const DagNode *oldParent, const DagNode *newParent);
+        void                                               touchMe(DagNode &owner, DynamicNodeBase &dynamicState, const DagNode *toucher, bool touchAll);
+
+        // protected members
+        bool                                               clamped;
+        bool                                               ignore_data;                                                                //!< The PDF for this node is set to 1, removing the effects of the node. Only for clamped nodes with no children.
+        bool                                               ignore_redraw;
+        mutable bool                                       integrated_out;
+        std::optional<double>                              lnProb;                                                                     //!< Current log probability, or empty if not computed.
+        std::optional<std::optional<double>>               stored_ln_prob;                                                             //!< Previous log probability if (a) there is a previous state and (b) the log probability for it is computed.
+        Distribution                                      *distribution;
+    };
+
+}
+
+#endif

--- a/src/core/distributions/phylogenetics/matrix/FossilizedBirthDeathRangeProcess.cpp
+++ b/src/core/distributions/phylogenetics/matrix/FossilizedBirthDeathRangeProcess.cpp
@@ -13,6 +13,7 @@
 #include "MatrixReal.h"
 #include "RbMathCombinatorialFunctions.h"
 #include "RbMathFunctions.h"
+#include "RbMathLogic.h"
 #include "RandomNumberFactory.h"
 #include "RandomNumberGenerator.h"
 #include "StochasticNode.h"


### PR DESCRIPTION
## PR Type
- 💅 Refactor
- 🚦 Infrastructure

## Summary
Move member functions that do not depend on `valueType` from `DeterministicNode<valueType>` -> `DeterministicNodeBase`, from `StochasticNode<valueType>` to StochasticNodeBase, and from `DynamicNode<valueType>` to DynamicNodeBase.  A lot of these functions work on the graph, but are independent of `valueType`.  This has two immediate benefits:
* we can call these functions in places where we have no idea what `valueType` is.
* the body of these functions can be moved out of the header file and into a `*.cpp` file.  So, when we change them, it doesn't recompile all of RevBayes.

This change should make it faster to compile the branch that refactors and untangles invalidation (touch) and snapshotting (touch, keep,restore).
I also have a longer-term change in mind that further separates value-access from graph-walking.


## Context 
Currently the `DeterministicNode<valueType>` and `StochasticNode<valueType>`  depend on the value type `valueType` because they hold a pointer to a value.  This causes trouble because we need to know `valueType` in order to dynamic_cast from `DagNode*` to `StochasticNode<valueType>*` and call them.  So, in order to allow clamping and unclamping nodes, I had already added a StochasticNodeBase that does *not* depend on `valueType`.  


## Approach
For each `XNode<valueType>` class, add a XNodeBase class and inherit from that.  The XNodeBase class currently does NOT inherit from DagNode.  However, future changes could allow it to do so.

## Checklist
This is a basic infrastructure change, so I think compiling and passing the existing test suite is fine.  No new permanent tests are needed, because every existing test already exercises the DAG.

### AI/LLM Assistance
- [x] I used an AI/LLM tool to assist with this PR
  - *If checked, I affirm that:*
      - *I personally understand the submitted changes and take responsibility for their correctness, style, and maintainability.*
      - *I will answer reviewer questions in my own words without copy-pasting AI output.*
      - *I am the primary author of the PR cover letter (e.g. it wasn't AI/LLM generated).*
      - *I have cleaned up the AI-generated code (e.g. removing verbose comments.)*
