### PR TITLE
No special-casing of boost installation for CI on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -160,20 +160,6 @@ jobs:
       if: runner.os == 'macOS'
       run: |
           brew install boost ccache coreutils meson
-          
-          # Boost 1.90 has a bug causing a compilation error.
-          # We'll use a static boost until the version in homebrew is fixed.
-          ( cd
-            curl -O -L https://archives.boost.io/release/1.89.0/source/boost_1_89_0.tar.gz
-            tar -xzvf boost_1_89_0.tar.gz
-            cd boost_1_89_0
-            ./bootstrap.sh --with-libraries=atomic,chrono,system,regex,thread,date_time,math,serialization --prefix=../installed-boost-1.89.0
-            ./b2 link=static install
-            echo -e "\n    BOOST root is at $(cd ../installed-boost-1.89.0; pwd)\n"
-            echo BOOST_ROOT=$(cd ../installed-boost-1.89.0; pwd) >> $GITHUB_ENV
-            echo CMAKE_PREFIX_PATH=$(cd ../installed-boost-1.89.0; pwd) >> $GITHUB_ENV
-          )
-
 
     - name: Install meson
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,6 +159,7 @@ jobs:
     - name: Install (macOS)
       if: runner.os == 'macOS'
       run: |
+          brew update --auto-update
           brew install boost ccache coreutils meson
 
     - name: Install meson

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,7 @@ jobs:
     - name: Install (macOS)
       if: runner.os == 'macOS'
       run: |
+          brew update --auto-update
           brew install boost ccache coreutils meson
 
     - name: Install meson

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,6 @@ jobs:
     - name: Install (macOS)
       if: runner.os == 'macOS'
       run: |
-          brew update --auto-update
           brew install boost ccache coreutils meson
 
     - name: Install meson
@@ -169,16 +168,16 @@ jobs:
         # Don't use weird boost version installed by github actions.
         sudo rm -rf /usr/local/share/boost
 
-        # This is a hack.
+        # Compile static boost libs so that released executables don't depend on homebrew
         ( cd
-          curl -O -L https://archives.boost.io/release/1.88.0/source/boost_1_88_0.tar.gz
-          tar -xzvf boost_1_88_0.tar.gz
-          cd boost_1_88_0
-          ./bootstrap.sh --with-libraries=atomic,chrono,system,regex,thread,date_time,math,serialization --prefix=../installed-boost-1.88.0
+          curl -O -L https://archives.boost.io/release/1.92.0/source/boost_1_92_0.tar.gz
+          tar -xzvf boost_1_92_0.tar.gz
+          cd boost_1_92_0
+          ./bootstrap.sh --with-libraries=atomic,chrono,system,regex,thread,date_time,math,serialization --prefix=../installed-boost-1.92.0
           ./b2 link=static install
-          echo -e "\n    BOOST root is at $(cd ../installed-boost-1.88.0; pwd)\n"
-          echo BOOST_ROOT=$(cd ../installed-boost-1.88.0; pwd) >> $GITHUB_ENV
-          echo CMAKE_PREFIX_PATH=$(cd ../installed-boost-1.88.0; pwd) >> $GITHUB_ENV
+          echo -e "\n    BOOST root is at $(cd ../installed-boost-1.92.0; pwd)\n"
+          echo BOOST_ROOT=$(cd ../installed-boost-1.92.0; pwd) >> $GITHUB_ENV
+          echo CMAKE_PREFIX_PATH=$(cd ../installed-boost-1.92.0; pwd) >> $GITHUB_ENV
         )
 
     - name: Install BOOST and set up build (Windows meson cross compile)


### PR DESCRIPTION
## PR Type
- Infrastructure

Until recently, the latest version of the boost library available from the homebrew package manager was v1.90, which is known to be problematic (see #953). We therefore special-cased the [`build.yml`](https://github.com/revbayes/revbayes/blob/development/.github/workflows/build.yml) workflow script to install the older v1.89. However, since homebrew [now ships](https://github.com/Homebrew/homebrew-core/pull/298472) v1.92, we can just go for the latest version available. I also took the opportunity and changed the [`release.yml`](https://github.com/revbayes/revbayes/blob/development/.github/workflows/release.yml) script to be more in line with the build script: in particular, it no longer contains a hardcoded requirement for one specific version of boost (v1.88).

This PR effectively undoes PR #924.